### PR TITLE
Use matrices accessor for directly exporting to gurobipy

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -11,6 +11,7 @@ Upcoming Release
 * Terms with zero coefficient are now filtered out before writing to file to avoid unnecessary overhead.
 * The function `sanitize_zeros` was added to `Constraints`. Use this to filter out zero coefficient terms.
 * A new module was created to export basic mathematical quantities such as `lb`, `ub`, `c` vectors and the `A` matrix. Use it with the `matrices` accessor in `linopy.Model`.
+* Solving with `gurobi` and `io_api="direct"` lead to wrong objective assignment if the objective contained non-unique variables. This is fixed in this version.
 
 Version 0.0.11
 --------------

--- a/linopy/matrices.py
+++ b/linopy/matrices.py
@@ -165,7 +165,7 @@ def get_constraint_labels(m, filter_missings=True):
 
 def is_documented_by(original):
     def wrapper(target):
-        target.__doc__ = original.__doc__.splitlines()[0]
+        target.__doc__ = original.__doc__.splitlines()
         return target
 
     return wrapper
@@ -199,8 +199,8 @@ class MatrixAccessor:
     def clabels(self):
         return get_constraint_labels(self._parent)
 
-    @property
     @is_documented_by(get_constraint_matrix)
+    @property
     def A(self):
         return get_constraint_matrix(self._parent)
 

--- a/linopy/matrices.py
+++ b/linopy/matrices.py
@@ -160,15 +160,8 @@ def get_constraint_labels(m, filter_missings=True):
     labels
         One-dimensional numpy array containing labels of all constraints.
     """
+    m.constraints.sanitize_missings()
     return m.constraints.ravel("labels", filter_missings=filter_missings)
-
-
-def is_documented_by(original):
-    def wrapper(target):
-        target.__doc__ = original.__doc__.splitlines()
-        return target
-
-    return wrapper
 
 
 class MatrixAccessor:
@@ -180,41 +173,41 @@ class MatrixAccessor:
         self._parent = model
 
     @property
-    @is_documented_by(get_variable_labels)
     def vlabels(self):
+        "Vector of labels of all non-missing variables."
         return get_variable_labels(self._parent)
 
     @property
-    @is_documented_by(get_lower_bounds)
     def lb(self):
+        "Vector of lower bounds of all non-missing variables."
         return get_lower_bounds(self._parent)
 
     @property
-    @is_documented_by(get_upper_bounds)
     def ub(self):
+        "Vector of upper bounds of all non-missing variables."
         return get_upper_bounds(self._parent)
 
     @property
-    @is_documented_by(get_constraint_labels)
     def clabels(self):
+        "Vector of labels of all non-missing constraints."
         return get_constraint_labels(self._parent)
 
-    @is_documented_by(get_constraint_matrix)
     @property
     def A(self):
+        "Constraint matrix of all non-missing constraints and variables."
         return get_constraint_matrix(self._parent)
 
     @property
-    @is_documented_by(get_sense)
     def sense(self):
+        "Vector of senses of all non-missing constraints."
         return get_sense(self._parent)
 
     @property
-    @is_documented_by(get_rhs)
     def b(self):
+        "Vector of right-hand-sides of all non-missing constraints."
         return get_rhs(self._parent)
 
     @property
-    @is_documented_by(get_objective_coefficients)
     def c(self):
+        "Vector of objective coefficients of all non-missing variables."
         return get_objective_coefficients(self._parent)

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -26,7 +26,7 @@ from linopy.constraints import (
 )
 from linopy.eval import Expr
 from linopy.expressions import LinearExpression, ScalarLinearExpression
-from linopy.io import to_block_files, to_file, to_netcdf
+from linopy.io import to_block_files, to_file, to_gurobipy, to_netcdf
 from linopy.matrices import MatrixAccessor
 from linopy.solvers import available_solvers
 from linopy.variables import ScalarVariable, Variable, Variables
@@ -1208,5 +1208,7 @@ class Model:
     to_netcdf = to_netcdf
 
     to_file = to_file
+
+    to_gurobipy = to_gurobipy
 
     to_block_files = to_block_files

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -506,37 +506,7 @@ def run_gurobi(
 
     else:
         problem_fn = None
-        m = gurobipy.Model()
-
-        lower = Model.variables.ravel("lower", filter_missings=True)
-        upper = Model.variables.ravel("upper", filter_missings=True)
-        xlabels = Model.variables.ravel("labels", filter_missings=True)
-        names = "x" + xlabels.astype(str).astype(object)
-        kwargs = {}
-        if len(Model.binaries.labels):
-            specs = {
-                name: "B" if name in Model.binaries else "C" for name in Model.variables
-            }
-            specs = Dataset({k: DataArray(v) for k, v in specs.items()})
-            kwargs["vtype"] = Model.variables.ravel(specs, filter_missings=True)
-
-        x = m.addMVar(xlabels.shape, lower, upper, name=list(names), **kwargs)
-
-        coeffs = np.zeros(Model._xCounter)
-        coeffs[np.asarray(Model.objective.vars)] = np.asarray(Model.objective.coeffs)
-        m.setObjective(coeffs[xlabels] @ x)
-
-        A = Model.constraints.to_matrix(filter_missings=True)
-        sense = Model.constraints.ravel("sign", filter_missings=True).astype(
-            np.dtype("<U1")
-        )
-        b = Model.constraints.ravel("rhs", filter_missings=True)
-        clabels = Model.constraints.ravel("labels", filter_missings=True)
-        names = "c" + clabels.astype(str).astype(object)
-        c = m.addMConstr(A, x, sense, b)
-        c.setAttr("ConstrName", list(names))
-
-        m.update()
+        m = Model.to_gurobipy()
 
     if solver_options is not None:
         for key, value in solver_options.items():

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -85,6 +85,20 @@ def test_to_file(tmp_path):
     gurobipy.read(str(fn))
 
 
+@pytest.mark.skipif("gurobi" not in available_solvers, reason="Gurobipy not installed")
+def test_to_gurobipy(tmp_path):
+    m = Model()
+
+    x = m.add_variables(4, pd.Series([8, 10]))
+    y = m.add_variables(0, pd.DataFrame([[1, 2], [3, 4], [5, 6]]))
+
+    m.add_constraints(x + y, "<=", 10)
+
+    m.add_objective(2 * x + 3 * y)
+
+    m.to_gurobipy()
+
+
 def test_to_blocks(tmp_path):
     m = Model()
 

--- a/test/test_matrices.py
+++ b/test/test_matrices.py
@@ -7,6 +7,7 @@ Created on Mon Oct 10 14:21:23 2022.
 """
 
 import numpy as np
+import pandas as pd
 import xarray as xr
 
 from linopy import Model
@@ -24,6 +25,26 @@ def test_basic_matrices():
 
     obj = (10 * x + 5 * y).sum()
     m.add_objective(obj)
+
+    assert m.matrices.A.shape == (*m.matrices.clabels.shape, *m.matrices.vlabels.shape)
+    assert m.matrices.clabels.shape == m.matrices.sense.shape
+    assert m.matrices.vlabels.shape == m.matrices.ub.shape
+    assert m.matrices.vlabels.shape == m.matrices.lb.shape
+
+
+def test_basic_matrices_masked():
+    m = Model()
+
+    lower = pd.Series(0, range(10))
+    x = m.add_variables(lower, name="x")
+    mask = pd.Series([True] * 8 + [False, False])
+    y = m.add_variables(lower, name="y", mask=mask)
+
+    m.add_constraints(x + y, ">=", 10)
+
+    m.add_constraints(y, ">=", 0)
+
+    m.add_objective(2 * x + y)
 
     assert m.matrices.A.shape == (*m.matrices.clabels.shape, *m.matrices.vlabels.shape)
     assert m.matrices.clabels.shape == m.matrices.sense.shape


### PR DESCRIPTION
Solving with `gurobi` and `io_api="direct"` lead to wrong objective assignment if the objective contained non-unique variables. This is through this PR.