### PR TITLE
supress disturbing output when cbc/glpk are no available_solvers

### DIFF
--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -27,10 +27,10 @@ if os.name == "nt":
 else:
     which = "which"
 
-if sub.run([which, "glpsol"], stdout=sub.DEVNULL).returncode == 0:
+if sub.run([which, "glpsol"], stdout=sub.DEVNULL, stderr=sub.STDOUT).returncode == 0:
     available_solvers.append("glpk")
 
-if sub.run([which, "cbc"], stdout=sub.DEVNULL).returncode == 0:
+if sub.run([which, "cbc"], stdout=sub.DEVNULL, stderr=sub.STDOUT).returncode == 0:
     available_solvers.append("cbc")
 
 try:


### PR DESCRIPTION
avoid disturbing output (INFORMATION: Es konnten keine Dateien mit dem angegebenen Muster gefunden werden.) see: https://github.com/PyPSA/linopy/issues/85

works on windows. i don't know if this changes the behaviour on linux though