### PR TITLE
Float representation in lp files

### DIFF
--- a/linopy/io.py
+++ b/linopy/io.py
@@ -40,9 +40,9 @@ def float_to_str(arr, ensure_sign=True):
     Convert numpy array to str typed array.
     """
     if ensure_sign:
-        convert = np.frompyfunc(lambda f: "%+f" % f, 1, 1)
+        convert = np.frompyfunc(lambda f: "%+.12g" % f, 1, 1)
     else:
-        convert = np.frompyfunc(lambda f: "%f" % f, 1, 1)
+        convert = np.frompyfunc(lambda f: "%.12g" % f, 1, 1)
     return convert(arr)
 
 


### PR DESCRIPTION
This PR changes the float to string conversion for #111 and #112 . The new format is `.12g` (or `+.12g`), which increases the precision of the float and removes tailing zeros of numbers, e.g.

`array([1.       , 1.2      , 1.2334567]) -> array(['+1', '+1.2', '+1.2334567'], dtype=object)`
