### PR TITLE
Allow addition and subtraction by 0 on lin. exprs. and variables

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -1,8 +1,10 @@
 Release Notes
 =============
 
-.. Upcoming Release
-.. ----------------
+Upcoming Release
+----------------
+
+* Allow addition of 0 to `Variables` and `LinearExpressions`.
 
 Version 0.1.5
 -------------

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -256,6 +256,8 @@ class LinearExpression:
         """
         Add an expression to others.
         """
+        if other == 0:
+            return self
         if not isinstance(other, (LinearExpression, variables.Variable)):
             raise TypeError(
                 "unsupported operand type(s) for +: " f"{type(self)} and {type(other)}"
@@ -275,6 +277,8 @@ class LinearExpression:
         """
         Subtract others from expression.
         """
+        if other == 0:
+            return self
         if not isinstance(other, (LinearExpression, variables.Variable)):
             raise TypeError(
                 "unsupported operand type(s) for +: " f"{type(self)} and {type(other)}"

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -317,6 +317,8 @@ class Variable:
         """
         Add variables to linear expressions or other variables.
         """
+        if other == 0:
+            return self
         if isinstance(other, Variable):
             return expressions.LinearExpression.from_tuples((1, self), (1, other))
         elif isinstance(other, expressions.LinearExpression):


### PR DESCRIPTION
This is just a convenience feature, but I think it would be nice.

I was summing up a bunch of different expressions, but some of them only sometimes depending on some configuration settings. These might be `None`. To sum them, I did something like
````python
S = sum(e for e in [a, b, c] if e is not None)
````
With this pull request, I can set each of the summands to `0` instead of `None` as needed, and the above line is just
````python
S = sum([a, b, c])  # or: S = a + b + c
````