### PR TITLE
Support constant values in LinearExpresssion

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -9,7 +9,7 @@ Upcoming Release
 * The classes `Variable`, `LinearExpression` and `Constraint` now have a `loc` method.
 * The classes `Variable`, `LinearExpression`, `Constraint`, `Variables` and `Constraints` now have a `flat` method, which returns a flattened `pandas.DataFrame` of the object in long-table format.
 * It is now possible to access variables and constraints by a dot notation. For example, `model.variables.x` returns the variable `x` of the model.
-
+* Variable assignment without explicit coordinates is now supported. In an internal step, integer coordinates are assigned to the dimensions without explicit coordinates.
 
 **Deprecations**
 * The class `AnonymousConstraint` is now deprecated in the favor of `Constraint`. The latter can now be assigned to a model or not.

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -6,10 +6,13 @@ Upcoming Release
 
 
 **New Features**
+* `LinearExpression`'s now support constant values. This allows defining linear expressions with numeric constant values, like `x + 5`.
+* When defining constraints, it is not needed to separate variables from constants anymore. Thus, expressions  like `x <= y` or `5 * x + 10 >= y` are supported.
 * The classes `Variable`, `LinearExpression` and `Constraint` now have a `loc` method.
 * The classes `Variable`, `LinearExpression`, `Constraint`, `Variables` and `Constraints` now have a `flat` method, which returns a flattened `pandas.DataFrame` of the object in long-table format.
 * It is now possible to access variables and constraints by a dot notation. For example, `model.variables.x` returns the variable `x` of the model.
 * Variable assignment without explicit coordinates is now supported. In an internal step, integer coordinates are assigned to the dimensions without explicit coordinates.
+
 
 **Deprecations**
 * The class `AnonymousConstraint` is now deprecated in the favor of `Constraint`. The latter can now be assigned to a model or not.

--- a/linopy/common.py
+++ b/linopy/common.py
@@ -7,10 +7,11 @@ This module contains commonly used functions.
 """
 
 from functools import partialmethod, update_wrapper, wraps
-from typing import Union
+from typing import Any, Dict, List, Optional, Union
 from warnings import warn
 
 import numpy as np
+import pandas as pd
 from numpy import arange, hstack
 from xarray import DataArray, Dataset, align, apply_ufunc, merge
 from xarray.core import indexing, utils
@@ -33,12 +34,49 @@ def maybe_replace_signs(sign):
     return apply_ufunc(func, sign, dask="parallelized", output_dtypes=[sign.dtype])
 
 
-def as_dataarray(arr, coords=None, **kwargs):
-    """
-    Convert an object to a DataArray if it is not already a DataArray.
-    """
-    if not isinstance(arr, DataArray):
-        return DataArray(arr, coords=coords, **kwargs)
+def as_dataarray(
+    arr,
+    coords: Optional[Union[dict, list]] = None,
+    dims: Optional[list] = None,
+    **kwargs,
+) -> DataArray:
+    if isinstance(arr, (pd.Series, pd.DataFrame)):
+        if dims is not None:
+            dims = [axis.name or list(dims)[i] for i, axis in enumerate(arr.axes)]
+        if coords is not None and not isinstance(coords, list):
+            coords = {dim: coords[dim] for dim in dims}
+        arr = DataArray(arr, coords=coords, dims=dims, **kwargs)
+
+    elif isinstance(arr, np.ndarray):
+        dims = list(dims)[: arr.ndim] if dims else []
+
+        if isinstance(coords, list):
+            coords = {dim: coord for dim, coord in zip(dims, coords)}
+
+        if len(dims) < arr.ndim:
+            dims = list(dims) + [f"dim_{i}" for i in range(len(dims), arr.ndim)]
+        arr = DataArray(arr, coords=coords, dims=dims, **kwargs)
+
+    elif isinstance(arr, (np.number, int, float, str, bool, list)):
+        arr = DataArray(arr, coords=coords, dims=dims, **kwargs)
+
+    elif not isinstance(arr, DataArray):
+        supported_types = [
+            np.number,
+            str,
+            bool,
+            list,
+            pd.Series,
+            pd.DataFrame,
+            np.ndarray,
+            DataArray,
+        ]
+        supported_types_str = ", ".join([t.__name__ for t in supported_types])
+        raise TypeError(
+            f"Unsupported type of arr: {type(arr)}. Supported types are: {supported_types_str}"
+        )
+
+    arr = fill_missing_coords(arr)
     return arr
 
 
@@ -72,7 +110,7 @@ def fill_missing_coords(ds):
 
     # Fill in missing integer coordinates
     for dim in ds.dims:
-        if dim not in ds.coords:
+        if dim not in ds.coords and not dim.endswith("_term"):
             ds.coords[dim] = arange(ds.sizes[dim])
 
     return ds
@@ -169,7 +207,7 @@ def print_single_variable(model, label):
     return f"{name}{print_coord(coord)}{bounds}"
 
 
-def print_single_expression(c, v, model):
+def print_single_expression(c, v, const, model):
     """
     Print a single linear expression based on the coefficients and variables.
     """
@@ -177,16 +215,23 @@ def print_single_expression(c, v, model):
     c, v = np.atleast_1d(c), np.atleast_1d(v)
 
     # catch case that to many terms would be printed
-    def print_line(expr):
+    def print_line(expr, const):
         res = []
         for i, (coeff, (name, coord)) in enumerate(expr):
             coord_string = print_coord(coord)
             if i:
+                coeff_string = f"{coeff:+.4g}"
                 # split sign and coefficient
-                coeff_string = f"{float(coeff):+.4g}"
                 res.append(f"{coeff_string[0]} {coeff_string[1:]} {name}{coord_string}")
             else:
-                res.append(f"{float(coeff):+.4g} {name}{coord_string}")
+                coeff_string = f"{coeff:+.4g} " if coeff != 1 else ""
+                res.append(f"{coeff_string}{name}{coord_string}")
+        if const != 0:
+            const_string = f"{const:+.4g}"
+            if len(res):
+                res.append(f"{const_string[0]} {const_string[1:]}")
+            else:
+                res.append(const_string)
         return " ".join(res) if len(res) else "None"
 
     if isinstance(c, np.ndarray):
@@ -197,17 +242,17 @@ def print_single_expression(c, v, model):
     if len(c) > max_terms:
         truncate = max_terms // 2
         expr = list(zip(c[:truncate], model.variables.get_label_position(v[:truncate])))
-        res = print_line(expr)
+        res = print_line(expr, const)
         res += " ... "
         expr = list(
             zip(c[-truncate:], model.variables.get_label_position(v[-truncate:]))
         )
-        residual = print_line(expr)
+        residual = print_line(expr, const)
         if residual != " None":
             res += residual
         return res
     expr = list(zip(c, model.variables.get_label_position(v)))
-    return print_line(expr)
+    return print_line(expr, const)
 
 
 def has_optimized_model(func):
@@ -229,10 +274,16 @@ def has_optimized_model(func):
 def is_constant(func):
     from linopy import expressions, variables
 
-    #
     @wraps(func)
     def wrapper(self, arg):
-        if isinstance(arg, (variables.Variable, expressions.LinearExpression)):
+        if isinstance(
+            arg,
+            (
+                variables.Variable,
+                variables.ScalarVariable,
+                expressions.LinearExpression,
+            ),
+        ):
             raise TypeError(f"Assigned rhs must be a constant, got {type()}).")
         return func(self, arg)
 
@@ -255,6 +306,26 @@ def forward_as_properties(**routes):
         return cls
 
     return deco
+
+
+def check_common_keys_values(list_of_dicts: List[Dict[str, Any]]) -> bool:
+    """
+    Check if all common keys among a list of dictionaries have the same value.
+
+    Parameters
+    ----------
+    list_of_dicts : list of dict
+        A list of dictionaries.
+
+    Returns
+    -------
+    bool
+        True if all common keys have the same value across all dictionaries, False otherwise.
+    """
+    common_keys = set.intersection(*(set(d.keys()) for d in list_of_dicts))
+    return all(
+        len(set(d[k] for d in list_of_dicts if k in d)) == 1 for k in common_keys
+    )
 
 
 class LocIndexer:

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -22,7 +22,6 @@ from linopy import solvers
 from linopy.common import (
     as_dataarray,
     best_int,
-    fill_missing_coords,
     maybe_replace_signs,
     replace_by_map,
     save_join,
@@ -436,11 +435,10 @@ class Model:
         )
 
         if mask is not None:
-            mask = as_dataarray(mask, **kwargs).astype(bool)
-
-        data = fill_missing_coords(data)
+            mask = as_dataarray(mask, coords=data.coords, dims=data.dims).astype(bool)
 
         labels = DataArray(-2, coords=data.coords)
+
         self.check_force_dim_names(labels)
 
         start = self._xCounter
@@ -559,6 +557,7 @@ class Model:
             ), "Dimensions of mask not a subset of resulting labels dimensions."
 
         labels = DataArray(-1, coords=data.indexes)
+
         self.check_force_dim_names(labels)
 
         start = self._cCounter

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -22,6 +22,7 @@ from linopy import solvers
 from linopy.common import (
     as_dataarray,
     best_int,
+    fill_missing_coords,
     maybe_replace_signs,
     replace_by_map,
     save_join,
@@ -428,14 +429,18 @@ class Model:
                 lower, upper = 0, 1
 
         data = Dataset(
-            {"lower": as_dataarray(lower, coords), "upper": as_dataarray(upper, coords)}
+            {
+                "lower": as_dataarray(lower, coords, **kwargs),
+                "upper": as_dataarray(upper, coords, **kwargs),
+            }
         )
 
         if mask is not None:
-            mask = as_dataarray(mask).astype(bool)
+            mask = as_dataarray(mask, **kwargs).astype(bool)
+
+        data = fill_missing_coords(data)
 
         labels = DataArray(-2, coords=data.coords)
-
         self.check_force_dim_names(labels)
 
         start = self._xCounter
@@ -554,7 +559,6 @@ class Model:
             ), "Dimensions of mask not a subset of resulting labels dimensions."
 
         labels = DataArray(-1, coords=data.indexes)
-
         self.check_force_dim_names(labels)
 
         start = self._cCounter

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Mon Jun 19 12:11:03 2023
+
+@author: fabian
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+from xarray import DataArray
+
+from linopy.common import as_dataarray
+
+
+def test_as_dataarray_with_series():
+    s = pd.Series([1, 2, 3], index=["a", "b", "c"])
+    da = as_dataarray(s, dims=["dim1"])
+    assert isinstance(da, DataArray)
+    assert da.dims == ("dim1",)
+    assert list(da.coords["dim1"].values) == ["a", "b", "c"]
+
+
+def test_as_dataarray_with_series_override_coords():
+    s = pd.Series([1, 2, 3], index=["a", "b", "c"])
+    da = as_dataarray(s, dims=["dim1"], coords=[[1, 2, 3]])
+    assert isinstance(da, DataArray)
+    assert da.dims == ("dim1",)
+    assert list(da.coords["dim1"].values) == [1, 2, 3]
+
+
+def test_as_dataarray_with_series_default_dims_coords():
+    s = pd.Series([1, 2, 3])
+    da = as_dataarray(s)
+    assert isinstance(da, DataArray)
+    assert da.dims == ("dim_0",)
+    assert list(da.coords["dim_0"].values) == list(s.index)
+
+
+def test_as_dataarray_with_dataframe():
+    df = pd.DataFrame({"A": [1, 2], "B": [3, 4]}, index=["a", "b"])
+    da = as_dataarray(df, dims=["dim1", "dim2"])
+    assert isinstance(da, DataArray)
+    assert da.dims == ("dim1", "dim2")
+    assert list(da.coords["dim1"].values) == ["a", "b"]
+    assert list(da.coords["dim2"].values) == ["A", "B"]
+
+
+def test_as_dataarray_with_dataframe_override_coords():
+    df = pd.DataFrame({"A": [1, 2], "B": [3, 4]}, index=["a", "b"])
+    da = as_dataarray(df, dims=["dim1", "dim2"], coords=[[1, 2], [2, 3]])
+    assert isinstance(da, DataArray)
+    assert da.dims == ("dim1", "dim2")
+    assert list(da.coords["dim1"].values) == [1, 2]
+    assert list(da.coords["dim2"].values) == [2, 3]
+
+
+def test_as_dataarray_with_dataframe_default_dims_coords():
+    df = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
+    da = as_dataarray(df)
+    assert isinstance(da, DataArray)
+    assert da.dims == ("dim_0", "dim_1")
+    assert list(da.coords["dim_0"].values) == [0, 1]
+    assert list(da.coords["dim_1"].values) == ["A", "B"]
+
+
+def test_as_dataarray_with_ndarray():
+    arr = np.array([[1, 2], [3, 4]])
+    da = as_dataarray(arr, dims=["dim1", "dim2"], coords=[["a", "b"], ["A", "B"]])
+    assert isinstance(da, DataArray)
+    assert da.dims == ("dim1", "dim2")
+    assert list(da.coords["dim1"].values) == ["a", "b"]
+    assert list(da.coords["dim2"].values) == ["A", "B"]
+
+
+def test_as_dataarray_with_ndarray_more_dims_than_given():
+    arr = np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])
+    da = as_dataarray(arr, dims=["dim0"], coords=[["a", "b"]])
+    assert isinstance(da, DataArray)
+    assert da.dims == ("dim0", "dim_1", "dim_2")
+    assert list(da.coords["dim0"].values) == ["a", "b"]
+    assert list(da.coords["dim_1"].values) == list(range(arr.shape[1]))
+    assert list(da.coords["dim_2"].values) == list(range(arr.shape[2]))
+
+
+def test_as_dataarray_with_ndarray_default_dims_coords():
+    arr = np.array([[1, 2], [3, 4]])
+    da = as_dataarray(arr)
+    assert isinstance(da, DataArray)
+    assert da.dims == ("dim_0", "dim_1")
+    assert list(da.coords["dim_0"].values) == list(range(arr.shape[0]))
+    assert list(da.coords["dim_1"].values) == list(range(arr.shape[1]))
+
+
+def test_as_dataarray_with_number():
+    num = 1
+    da = as_dataarray(num, dims=["dim1"], coords=[["a"]])
+    assert isinstance(da, DataArray)
+    assert da.dims == ("dim1",)
+    assert list(da.coords["dim1"].values) == ["a"]
+
+
+def test_as_dataarray_with_number_default_dims_coords():
+    num = 1
+    da = as_dataarray(num)
+    assert isinstance(da, DataArray)
+    assert da.dims == ()
+    assert da.coords == {}
+
+
+def test_as_dataarray_with_number_and_coords():
+    num = 1
+    da = as_dataarray(num, coords=[pd.RangeIndex(10, name="a")])
+    assert isinstance(da, DataArray)
+    assert da.dims == ("a",)
+    assert list(da.coords["a"].values) == list(range(10))
+
+
+def test_as_dataarray_with_dataarray():
+    da_in = DataArray(
+        data=[[1, 2], [3, 4]],
+        dims=["dim1", "dim2"],
+        coords={"dim1": ["a", "b"], "dim2": ["A", "B"]},
+    )
+    da_out = as_dataarray(da_in, dims=["dim1", "dim2"], coords=[["a", "b"], ["A", "B"]])
+    assert isinstance(da_out, DataArray)
+    assert da_out.dims == da_in.dims
+    assert list(da_out.coords["dim1"].values) == list(da_in.coords["dim1"].values)
+    assert list(da_out.coords["dim2"].values) == list(da_in.coords["dim2"].values)
+
+
+def test_as_dataarray_with_dataarray_default_dims_coords():
+    da_in = DataArray(
+        data=[[1, 2], [3, 4]],
+        dims=["dim1", "dim2"],
+        coords={"dim1": ["a", "b"], "dim2": ["A", "B"]},
+    )
+    da_out = as_dataarray(da_in)
+    assert isinstance(da_out, DataArray)
+    assert da_out.dims == da_in.dims
+    assert list(da_out.coords["dim1"].values) == list(da_in.coords["dim1"].values)
+    assert list(da_out.coords["dim2"].values) == list(da_in.coords["dim2"].values)
+
+
+def test_as_dataarray_with_unsupported_type():
+    with pytest.raises(TypeError):
+        as_dataarray(lambda x: 1, dims=["dim1"], coords=[["a"]])

--- a/test/test_matrices.py
+++ b/test/test_matrices.py
@@ -62,4 +62,4 @@ def test_matrices_duplicated_variables():
 
     A = m.matrices.A.todense()
     assert A[0, 0] == 2
-    assert np.isin(np.unique(A), [0, 2]).all()
+    assert np.isin(np.unique(np.array(A)), [0.0, 2.0]).all()

--- a/test/test_repr.py
+++ b/test/test_repr.py
@@ -43,6 +43,7 @@ lb = 1 * b
 lc = 1 * c
 ld = 1 * d
 lav = 1 * a + 1 * v
+luc = 1 * v + 10
 
 
 # create anonymous constraint for linear expression
@@ -56,6 +57,7 @@ cb_ = lb >= 0
 cc_ = lc >= 0
 cd_ = ld >= 0
 cav_ = lav >= 0
+cuc_ = luc >= 0
 
 # add constraint for each variable
 cu = m.add_constraints(cu_, name="cu")
@@ -68,6 +70,7 @@ cb = m.add_constraints(cb_, name="cb")
 cc = m.add_constraints(cc_, name="cc")
 cd = m.add_constraints(cd_, name="cd")
 cav = m.add_constraints(cav_, name="cav")
+cuc = m.add_constraints(cuc_, name="cuc")
 cu_masked = m.add_constraints(cu_, name="cu_masked", mask=xr.full_like(u.labels, False))
 
 
@@ -89,7 +92,7 @@ def test_single_variable_repr():
 
 
 def test_linear_expression_repr():
-    for expr in [lu, lv, lx, ly, lz, la, lb, lc, ld, lav]:
+    for expr in [lu, lv, lx, ly, lz, la, lb, lc, ld, lav, luc]:
         repr(expr)
 
 
@@ -110,7 +113,7 @@ def test_single_linear_repr():
 
 
 def test_anonymous_constraint_repr():
-    for con in [cu_, cv_, cx_, cy_, cz_, ca_, cb_, cc_, cd_, cav_]:
+    for con in [cu_, cv_, cx_, cy_, cz_, ca_, cb_, cc_, cd_, cav_, cuc_]:
         repr(con)
 
 
@@ -126,7 +129,7 @@ def test_single_constraint_repr():
 
 
 def test_constraint_repr():
-    for con in [cu, cv, cx, cy, cz, ca, cb, cc, cd, cav, cu_masked]:
+    for con in [cu, cv, cx, cy, cz, ca, cb, cc, cd, cav, cuc, cu_masked]:
         repr(con)
 
 

--- a/test/test_variable_assignment.py
+++ b/test/test_variable_assignment.py
@@ -35,8 +35,8 @@ def test_variable_assignment():
 
     lower = xr.DataArray(np.zeros((10, 10)), coords=[range(10), range(10)])
     upper = xr.DataArray(np.ones((10, 10)), coords=[range(10), range(10)])
-    m.add_variables(lower, upper, name="x")
-    assert m.variables.labels.x.shape == target_shape
+    x = m.add_variables(lower, upper, name="x")
+    assert x.shape == target_shape
 
 
 def test_variable_assignment_broadcasted():
@@ -44,8 +44,8 @@ def test_variable_assignment_broadcasted():
     # setting only one dimension, the other has to be broadcasted
     lower = xr.DataArray(np.zeros((10)), coords=[range(10)])
     upper = xr.DataArray(np.ones((10, 10)), coords=[range(10), range(10)])
-    m.add_variables(lower, upper, name="x")
-    assert m.variables.labels.x.shape == target_shape
+    x = m.add_variables(lower, upper, name="x")
+    assert x.shape == target_shape
 
 
 def test_variable_assignment_no_coords():
@@ -53,8 +53,8 @@ def test_variable_assignment_no_coords():
     m = Model()
     lower = xr.DataArray(np.zeros((10)))
     upper = xr.DataArray(np.ones((10, 10)), coords=[range(10), range(10)])
-    m.add_variables(lower, upper, name="x")
-    assert m.variables.labels.x.shape == target_shape
+    x = m.add_variables(lower, upper, name="x")
+    assert x.shape == target_shape
 
 
 def test_variable_assignment_pd_index():
@@ -62,8 +62,8 @@ def test_variable_assignment_pd_index():
     m = Model()
     lower = xr.DataArray(np.zeros((10)), coords=[pd.Index(range(10))])
     upper = xr.DataArray(np.ones((10, 10)), coords=[range(10), range(10)])
-    m.add_variables(lower, upper, name="x")
-    assert m.variables.labels.x.shape == target_shape
+    x = m.add_variables(lower, upper, name="x")
+    assert x.shape == target_shape
 
 
 def test_variable_assignment_by_coords():
@@ -72,8 +72,8 @@ def test_variable_assignment_by_coords():
     lower = 0
     upper = 1
     coords = [pd.Index(range(10)), pd.Index(range(10))]
-    m.add_variables(lower, upper, coords=coords, name="x")
-    assert m.variables.labels.x.shape == target_shape
+    x = m.add_variables(lower, upper, coords=coords, name="x")
+    assert x.shape == target_shape
 
 
 def test_variable_assignment_with_dataframes():
@@ -81,8 +81,8 @@ def test_variable_assignment_with_dataframes():
     m = Model()
     lower = pd.DataFrame(np.zeros((10, 10)))
     upper = pd.DataFrame(np.ones((10, 10)))
-    m.add_variables(lower, upper, name="x")
-    assert m.variables.labels.x.shape == target_shape
+    x = m.add_variables(lower, upper, name="x")
+    assert x.shape == target_shape
 
 
 def test_variable_assignment_with_dataframe_and_series():
@@ -90,8 +90,8 @@ def test_variable_assignment_with_dataframe_and_series():
     m = Model()
     lower = pd.DataFrame(np.zeros((10, 10)))
     upper = pd.Series(np.ones((10)))
-    m.add_variables(lower, upper, name="x")
-    assert m.variables.labels.x.shape == target_shape
+    x = m.add_variables(lower, upper, name="x")
+    assert x.shape == target_shape
 
 
 def test_variable_assignment_chunked():
@@ -99,9 +99,73 @@ def test_variable_assignment_chunked():
     m = Model(chunk=5)
     lower = pd.DataFrame(np.zeros((10, 10)))
     upper = pd.Series(np.ones((10)))
-    m.add_variables(lower, upper, name="x")
-    assert m.variables.labels.x.shape == target_shape
+    x = m.add_variables(lower, upper, name="x")
+    assert x.shape == target_shape
     assert isinstance(m.variables.labels.x.data, dask.array.core.Array)
+
+
+def test_variable_assignment_different_shapes():
+    # setting bounds with different shapes
+    m = Model()
+    lower = pd.DataFrame(np.zeros((10, 10)))
+    upper = pd.Series(np.ones((10)))
+    x = m.add_variables(lower, upper, name="x")
+    assert x.shape == target_shape
+
+
+def test_variable_assignment_without_coords():
+    # setting bounds without explicit coords
+    m = Model()
+    lower = np.zeros((10, 10))
+    upper = np.ones((10))
+    x = m.add_variables(lower, upper, name="x")
+    assert x.shape == target_shape
+
+
+def test_variable_assignment_without_coords_and_dims_names():
+    # setting bounds without explicit coords
+    m = Model()
+    lower = np.zeros((10, 10))
+    upper = np.ones((10, 10))
+    x = m.add_variables(lower, upper, name="x", dims=["i", "j"])
+    assert x.shape == target_shape
+    assert x.dims == ("i", "j")
+
+
+def test_variable_assignment_without_coords_in_bounds():
+    # setting bounds without explicit coords
+    m = Model()
+    lower = xr.DataArray(np.zeros((10, 10)), dims=["i", "j"])
+    upper = xr.DataArray(np.ones((10, 10)), dims=["i", "j"])
+    x = m.add_variables(lower, upper, name="x")
+    assert x.shape == target_shape
+    assert x.dims == ("i", "j")
+
+
+def test_variable_assignment_without_coords_pandas_types():
+    # setting bounds without explicit coords
+    m = Model()
+    lower = pd.DataFrame(np.zeros((10, 10)))
+    upper = pd.DataFrame(np.ones((10, 10)))
+    x = m.add_variables(lower, upper, name="x", dims=["i", "j"])
+    assert x.shape == target_shape
+    assert x.dims == ("i", "j")
+
+
+def test_variable_assignment_without_coords_mixed_types():
+    # setting bounds without explicit coords
+    m = Model()
+    lower = pd.DataFrame(np.zeros((10, 10)))
+    upper = 1
+    x = m.add_variables(lower, upper, name="x")
+    assert x.shape == target_shape
+
+    m = Model()
+    lower = xr.DataArray(np.zeros((10, 10)), dims=["i", "j"])
+    upper = 1
+    x = m.add_variables(lower, upper, name="x")
+    assert x.shape == target_shape
+    assert x.dims == ("i", "j")
 
 
 def test_variable_assignment_different_coords():
@@ -123,11 +187,13 @@ def test_variable_assignment_different_coords():
         assert (m.variables.labels.x != -1).sum() == 100
 
 
-def test_variable_assignment_non_broadcastable():
+def test_variable_assignment_with_broadcast():
     # setting with scalar and list
     m = Model()
+    m.add_variables(lower=0, upper=[1, 2])
+
     with pytest.raises(ValueError):
-        m.add_variables(0, [1, 2])
+        m.add_variables(lower=0, upper=[1, 2], dims=["i"])
 
 
 def test_variable_assignment_repeated():


### PR DESCRIPTION
closes #96 
closes #101 

* `LinearExpression`'s now support constant values. This allows defining linear expressions with numeric constant values, like `x + 5`.
* When defining constraints, it is not needed to separate variables from constants anymore. Thus, expressions  like `x <= y` or `5 * x + 10 >= y` are supported.
