### PR TITLE
`.cumsum` for Variables and LinearExpression

### DIFF
--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -628,7 +628,7 @@ class LinearExpression:
         if not dim:
             # If user did not specify a dimension to sum over, use all relevant
             # dimensions
-            dim = [d for d in self.data.dims.keys() if d != "_term"]
+            dim = self.coord_dims
         if isinstance(dim, str):
             # Make sure, single mentioned dimensions is handled correctly.
             dim = [dim]

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -11,7 +11,7 @@ import logging
 import warnings
 from dataclasses import dataclass, field
 from itertools import product, zip_longest
-from typing import Any, Mapping, Union
+from typing import Any, Mapping, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -591,8 +591,8 @@ class LinearExpression:
         self,
         dim: Dims = None,
         *,
-        skipna: bool | None = None,
-        keep_attrs: bool | None = None,
+        skipna: Optional[bool] = None,
+        keep_attrs: Optional[bool] = None,
         **kwargs: Any,
     ) -> "LinearExpression":
         """

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -587,7 +587,6 @@ class LinearExpression:
 
         return res
 
-    
     def cumsum(
         self,
         dim: Dims = None,
@@ -633,10 +632,7 @@ class LinearExpression:
         if isinstance(dim, str):
             # Make sure, single mentioned dimensions is handled correctly.
             dim = [dim]
-        dim_dict = {
-            dim_name: self.data.dims[dim_name]
-            for dim_name in dim
-        }
+        dim_dict = {dim_name: self.data.dims[dim_name] for dim_name in dim}
         return self.rolling(dim=dim_dict).sum(keep_attrs=keep_attrs, skipna=skipna)
 
     @classmethod

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -9,7 +9,7 @@ import functools
 import logging
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Any, Dict, Mapping, Sequence, Union
+from typing import Any, Dict, Mapping, Optional, Sequence, Union
 from warnings import warn
 
 import dask
@@ -420,8 +420,8 @@ class Variable:
         self,
         dim: Dims = None,
         *,
-        skipna: bool | None = None,
-        keep_attrs: bool | None = None,
+        skipna: Optional[bool] = None,
+        keep_attrs: Optional[bool] = None,
         **kwargs: Any,
     ) -> "expressions.LinearExpression":
         """

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -17,7 +17,8 @@ import numpy as np
 import pandas as pd
 from deprecation import deprecated
 from numpy import floating, inf, issubdtype
-from xarray import DataArray, Dataset, align, broadcast, zeros_like
+from xarray import DataArray, Dataset, align, broadcast, zeros_like 
+from xarray.core.types import Dims
 
 import linopy.expressions as expressions
 from linopy.common import (
@@ -413,6 +414,46 @@ class Variable:
         """
         return self.to_linexpr().rolling(
             dim=dim, min_periods=min_periods, center=center, **window_kwargs
+        )
+
+    def cumsum(
+        self,
+        dim: Dims = None,
+        *,
+        skipna: bool | None = None,
+        keep_attrs: bool | None = None,
+        **kwargs: Any,
+    ) -> "expressions.LinearExpression":
+        """
+        Cumulated sum along a given axis.
+
+        Docstring and arguments are borrowed from `xarray.Dataset.cumsum`
+
+        Parameters
+        ----------
+        dim : str, Iterable of Hashable, "..." or None, default: None
+            Name of dimension[s] along which to apply ``cumsum``. For e.g. ``dim="x"``
+            or ``dim=["x", "y"]``. If "..." or None, will reduce over all dimensions.
+        skipna : bool or None, optional
+            If True, skip missing values (as marked by NaN). By default, only
+            skips missing values for float dtypes; other dtypes either do not
+            have a sentinel missing value (int) or ``skipna=True`` has not been
+            implemented (object, datetime64 or timedelta64).
+        keep_attrs : bool or None, optional
+            If True, ``attrs`` will be copied from the original
+            object to the new one.  If False, the new object will be
+            returned without attributes.
+        **kwargs : Any
+            Additional keyword arguments passed on to the appropriate array
+            function for calculating ``cumsum`` on this object's data.
+            These could include dask-specific kwargs like ``split_every``.
+
+        Returns
+        -------
+        linopy.expression.LinearExpression
+        """
+        return self.to_linexpr().cumsum(
+            dim=dim, skipna=skipna, keep_attrs=keep_attrs, **kwargs
         )
 
     @property

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -17,7 +17,7 @@ import numpy as np
 import pandas as pd
 from deprecation import deprecated
 from numpy import floating, inf, issubdtype
-from xarray import DataArray, Dataset, align, broadcast, zeros_like 
+from xarray import DataArray, Dataset, align, broadcast, zeros_like
 from xarray.core.types import Dims
 
 import linopy.expressions as expressions

--- a/test/test_linear_expression.py
+++ b/test/test_linear_expression.py
@@ -603,3 +603,19 @@ def test_rename(x, y, z):
     renamed = expr.rename({"dim_0": "dim_1", "dim_1": "dim_2"})
     assert set(renamed.dims) == {"dim_1", "dim_2", TERM_DIM}
     assert renamed.nterm == 3
+
+
+@pytest.mark.parametrize("multiple", [1.0, 0.5, 2.0, 0.0])
+def test_cumsum(m, multiple):
+    # Test cumsum on variable x
+    var = m.variables["x"]
+    cumsum = (multiple * var).cumsum()
+    assert_linequal(cumsum.loc[0], multiple * var.loc[0])
+    assert_linequal(cumsum.loc[0], multiple * (var.loc[0] + var.loc[1]))
+
+    # Test cumsum on sum of variables
+    var = m.variables["x"] + var = m.variables["y"]
+    cumsum = (multiple * var).cumsum()
+    assert_linequal(cumsum.loc[0], multiple * var.loc[0])
+    assert_linequal(cumsum.loc[0], multiple * (var.loc[0] + var.loc[1]))
+

--- a/test/test_linear_expression.py
+++ b/test/test_linear_expression.py
@@ -610,11 +610,9 @@ def test_cumsum(m, multiple):
     # Test cumsum on variable x
     var = m.variables["x"]
     cumsum = (multiple * var).cumsum()
-    assert_linequal(cumsum.loc[0], multiple * var.loc[0])
-    assert_linequal(cumsum.loc[0], multiple * (var.loc[0] + var.loc[1]))
+    cumsum.nterm == 2
 
     # Test cumsum on sum of variables
     var = m.variables["x"] + m.variables["y"]
     cumsum = (multiple * var).cumsum()
-    assert_linequal(cumsum.loc[0], multiple * var.loc[0])
-    assert_linequal(cumsum.loc[0], multiple * (var.loc[0] + var.loc[1]))
+    cumsum.nterm == 2

--- a/test/test_linear_expression.py
+++ b/test/test_linear_expression.py
@@ -618,4 +618,3 @@ def test_cumsum(m, multiple):
     cumsum = (multiple * var).cumsum()
     assert_linequal(cumsum.loc[0], multiple * var.loc[0])
     assert_linequal(cumsum.loc[0], multiple * (var.loc[0] + var.loc[1]))
-

--- a/test/test_linear_expression.py
+++ b/test/test_linear_expression.py
@@ -614,7 +614,7 @@ def test_cumsum(m, multiple):
     assert_linequal(cumsum.loc[0], multiple * (var.loc[0] + var.loc[1]))
 
     # Test cumsum on sum of variables
-    var = m.variables["x"] + var = m.variables["y"]
+    var = m.variables["x"] + m.variables["y"]
     cumsum = (multiple * var).cumsum()
     assert_linequal(cumsum.loc[0], multiple * var.loc[0])
     assert_linequal(cumsum.loc[0], multiple * (var.loc[0] + var.loc[1]))


### PR DESCRIPTION
Addresses #145 

Implements (to the best of my knowledge) `.cumsum` methods for `Variable` and `LinearExpression` objects. No implementation is provided yet for e.g. `LinearExpressionGroupBy` objects.