### PR TITLE
A PyPSA-based problem is not necessary linear.

### DIFF
--- a/linopy/model.py
+++ b/linopy/model.py
@@ -1011,7 +1011,7 @@ class Model:
         if solver_name is None:
             solver_name = available_solvers[0]
 
-        logger.info(f" Solve linear problem using {solver_name.title()} solver")
+        logger.info(f" Solve problem using {solver_name.title()} solver")
         assert solver_name in available_solvers, f"Solver {solver_name} not installed"
 
         # reset result


### PR DESCRIPTION
Just changed the log message to be general (before stating "linear model" even if a MILP f. inst.).