### PR TITLE
Enclose env usage in with keyword for gurobi

### DIFF
--- a/linopy/io.py
+++ b/linopy/io.py
@@ -319,7 +319,7 @@ def to_file(m, fn):
     return fn
 
 
-def to_gurobipy(m):
+def to_gurobipy(m, env=None):
     """
     Export the model to gurobipy.
 
@@ -330,6 +330,7 @@ def to_gurobipy(m):
     Parameters
     ----------
     m : linopy.Model
+    env : gurobipy.Env
 
     Returns
     -------
@@ -338,7 +339,7 @@ def to_gurobipy(m):
     import gurobipy
 
     m.constraints.sanitize_missings()
-    model = gurobipy.Model()
+    model = gurobipy.Model(env=env)
 
     M = m.matrices
 


### PR DESCRIPTION
**Description of the PR**
When using a commercial WLS (Web License Service) license from Gurobi, we want to avoid any unwanted use of a token. This is especially the case when we are using the WLS license with single-use token (one token allowed at the time). 

License usage is managed through the `gurobipy.Env` object. Therefore, we need to use `gurobipy.Env` wisely and allow the garbage collector to clean the object when appropriate (which is releasing the license). This PR suggest to use a `with` context to easily track/clean the usage of the object. This is espacially a must when using a Jupyter notebook to run the code.

**Gurobi documentation**
https://www.gurobi.com/documentation/current/refman/py_env.html
