### PR TITLE
Update JuMP and linopy benchmark scripts

### DIFF
--- a/benchmark/scripts/benchmark_linopy.py
+++ b/benchmark/scripts/benchmark_linopy.py
@@ -24,7 +24,7 @@ def basic_model(n, solver):
     y = m.add_variables(coords=[N, M])
     m.add_constraints(x - y >= N)
     m.add_constraints(x + y >= 0)
-    m.add_objective((2 * x).sum() + y.sum())
+    m.add_objective(2 * x.sum() + y.sum())
     # m.to_file(f"linopy-model.lp")
     m.solve(solver)
     return m.objective_value


### PR DESCRIPTION
Hey! I've been meaning to check this project out. People keep mentioning it to me. 

Your docs are very nice, and I quite like this style of modeling. I couldn't get the benchmarks to run (told me it couldn't find `ortools-python` and it took ages to try and find a feasible install?), but here are a couple of minor changes. (Feel free to close this PR if you would prefer to keep them as-is.)

I thought it might be helpful to explain why JuMP's memory usage is so high: we actually store three copies of the problem data.

 * One is in JuMP, that's all of the `x` and `y` variables
 * One is in a MathOptInterface cache, so that we can swap out solvers etc
 * One is the solver's in-memory representation.

Here's a demonstration:
```julia
using JuMP, Gurobi

function basic_model(n, solver)
    m = Model(solver)
    set_silent(m)
    N = 1:n
    M = 1:n
    @variable(m, x[N, M])
    @variable(m, y[N, M])
    @constraint(m, [i=N, j=M], x[i, j] - y[i, j] >= i-1)
    @constraint(m, [i=N, j=M], x[i, j] + y[i, j] >= 0)
    @objective(m, Min, sum(2 * x[i, j] + y[i, j] for i in N, j in M))
    optimize!(m)
    return objective_value(m)
end

function basic_model_1(n, solver)
    m = Model(solver) 
    set_silent(m)
    @variable(m, x[1:n, 1:n])
    @variable(m, y[1:n, 1:n])
    @constraint(m, x - y .>= 0:(n-1))
    @constraint(m, x + y .>= 0)
    @objective(m, Min, 2 * sum(x) + sum(y))
    optimize!(m)
    return objective_value(m)
end

function basic_model_2(n, solver)
    m = direct_model(solver())
    set_silent(m)
    @variable(m, x[1:n, 1:n])
    @variable(m, y[1:n, 1:n])
    @constraint(m, x - y .>= 0:(n-1))
    @constraint(m, x + y .>= 0)
    @objective(m, Min, 2 * sum(x) + sum(y))
    optimize!(m)
    return objective_value(m)
end

julia> GC.gc(); @time basic_model(700, Gurobi.Optimizer)
  7.008127 seconds (32.83 M allocations: 2.411 GiB, 20.01% gc time)
8.56275e7

julia> GC.gc(); @time basic_model_1(700, Gurobi.Optimizer)
  7.231301 seconds (32.83 M allocations: 2.482 GiB, 22.91% gc time)
8.56275e7

julia> GC.gc(); @time basic_model_2(700, Gurobi.Optimizer)
  5.856433 seconds (28.91 M allocations: 1.932 GiB, 19.70% gc time)
8.56275e7
```

Biggest change with `direct_model` is that memory usage drops by 20% (not the expected 1/3 because there's some other overhead, etc).

If we turn off passing variable names to Gurobi, we get more improvement:
```julia
julia> function basic_model_3(n, solver)
           m = direct_model(solver())
           set_string_names_on_creation(m, false)
           set_silent(m)
           @variable(m, x[1:n, 1:n])
           @variable(m, y[1:n, 1:n])
           @constraint(m, x - y .>= 0:(n-1))
           @constraint(m, x + y .>= 0)
           @objective(m, Min, 2 * sum(x) + sum(y))
           optimize!(m)
           return objective_value(m)
       end
basic_model_3 (generic function with 1 method)

julia> GC.gc(); @time basic_model_3(700, Gurobi.Optimizer)
  5.596101 seconds (23.03 M allocations: 1.728 GiB, 22.79% gc time)
8.56275e7
```
But I wouldn't expect most users to care about this.