### PR TITLE
add option to pass existing gurobipy.Env to run_gurobipy()

### DIFF
--- a/linopy/model.py
+++ b/linopy/model.py
@@ -921,6 +921,7 @@ class Model:
         basis_fn=None,
         warmstart_fn=None,
         keep_files=False,
+        env=None,
         sanitize_zeros=True,
         remote=None,
         **solver_options,
@@ -964,6 +965,9 @@ class Model:
             Whether to keep all temporary files like lp file, solution file.
             This argument is ignored for the logger file `log_fn`. The default
             is False.
+        env : gurobi.Env, optional
+            Existing environment passed to the solver (e.g. `gurobipy.Env`).
+            Currently only in use for Gurobi. The default is None.
         sanitize_zeros : bool, optional
             Whether to set terms with zero coeffficient as missing.
             This will remove unneeded overhead in the lp file writing.
@@ -1048,6 +1052,7 @@ class Model:
                 warmstart_fn,
                 basis_fn,
                 keep_files,
+                env,
                 **solver_options,
             )
         finally:

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -4,6 +4,7 @@
 Linopy module for solving lp files with different solvers.
 """
 
+import contextlib
 import io
 import logging
 import os
@@ -111,6 +112,7 @@ def run_cbc(
     warmstart_fn=None,
     basis_fn=None,
     keep_files=False,
+    env=None,
     **solver_options,
 ):
     """
@@ -206,6 +208,7 @@ def run_glpk(
     warmstart_fn=None,
     basis_fn=None,
     keep_files=False,
+    env=None,
     **solver_options,
 ):
     """
@@ -316,6 +319,7 @@ def run_highs(
     warmstart_fn=None,
     basis_fn=None,
     keep_files=False,
+    env=None,
     **solver_options,
 ):
     """
@@ -406,6 +410,7 @@ def run_cplex(
     warmstart_fn=None,
     basis_fn=None,
     keep_files=False,
+    env=None,
     **solver_options,
 ):
     """
@@ -510,6 +515,7 @@ def run_gurobi(
     warmstart_fn=None,
     basis_fn=None,
     keep_files=False,
+    env=None,
     **solver_options,
 ):
     """
@@ -545,7 +551,10 @@ def run_gurobi(
     warmstart_fn = maybe_convert_path(warmstart_fn)
     basis_fn = maybe_convert_path(basis_fn)
 
-    with gurobipy.Env() as env:
+    with contextlib.ExitStack() as stack:
+        if env is None:
+            env = stack.enter_context(gurobipy.Env())
+
         if io_api is None or io_api in ["lp", "mps"]:
             problem_fn = model.to_file(problem_fn)
             problem_fn = maybe_convert_path(problem_fn)
@@ -609,6 +618,7 @@ def run_xpress(
     warmstart_fn=None,
     basis_fn=None,
     keep_files=False,
+    env=None,
     **solver_options,
 ):
     """
@@ -701,6 +711,7 @@ def run_pips(
     warmstart_fn=None,
     basis_fn=None,
     keep_files=False,
+    env=None,
     **solver_options,
 ):
     """


### PR DESCRIPTION
Quick successions of gurobi environment instantiation may cause clogging on Gurobi token server since tokens are not released quickly enough.

Gurobi recommends that in this case, one should do multiple solving calls inside the same environment.

https://support.gurobi.com/hc/en-us/articles/4424054948881

```py
import gurobipy as gp

with gp.Env() as env:
    with gp.Model(env=env) as model1:
        # formulate and solve model1
    with gp.Model(env=env) as model2:
        # formulate and solve model2
```

E.g. in PyPSA the primary use case would be rolling horizon optimisation.

```py
with gurobipy.Env() as env:
    n.optimize.optimize_with_rolling_horizon(
        ...,
        env=env,
    )
