### PR TITLE
refine treatment of missing values

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -5,7 +5,9 @@ Upcoming Release
 ----------------
 
 * It is now possible to set the sense of the objective function to `minimize` or `maximize`. Therefore, a new class `Objective` was introduced which is used in `Model.objective`. It supports the same arithmetic operations as `LinearExpression` and `QuadraticExpression` and contains a `sense` attribute which can be set to `minimize` or `maximize`.
-
+* The `fill_value` of default of constants in the LinearExpression and QuadraticExpression classes was changed to ``NaN``.
+* The `fillna` function for variables was made more secure by raising a warning if the fill value is not of  variable-like type.
+* The `where` and `fillna` functions for expressions were made more flexible: When passing a scalar value or a DataArray, the values are added as constants to the expression, where there were missing values before. If another expression is passed, the values are added to the expression, where there were missing values before.
 
 Version 0.2.5
 -------------

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -5,7 +5,7 @@ Upcoming Release
 ----------------
 
 * It is now possible to set the sense of the objective function to `minimize` or `maximize`. Therefore, a new class `Objective` was introduced which is used in `Model.objective`. It supports the same arithmetic operations as `LinearExpression` and `QuadraticExpression` and contains a `sense` attribute which can be set to `minimize` or `maximize`.
-* The `fill_value` of default of constants in the LinearExpression and QuadraticExpression classes was changed to ``NaN``.
+* The `_fill_value` for LinearExpression and QuadraticExpression classes was changed to ``NaN`` for the constant array ("const"). This allows to use the `where` function for expressions with constant values in the argument `other`.
 * The `fillna` function for variables was made more secure by raising a warning if the fill value is not of  variable-like type.
 * The `where` and `fillna` functions for expressions were made more flexible: When passing a scalar value or a DataArray, the values are added as constants to the expression, where there were missing values before. If another expression is passed, the values are added to the expression, where there were missing values before.
 

--- a/linopy/common.py
+++ b/linopy/common.py
@@ -317,7 +317,7 @@ def print_single_expression(c, v, const, model):
 
             res.append(f"{coeff_string}{var_string}")
 
-        if const != 0:
+        if not np.isnan(const):
             const_string = f"{const:+.4g}"
             if len(res):
                 res.append(f"{const_string[0]} {const_string[1:]}")

--- a/test/test_linear_expression.py
+++ b/test/test_linear_expression.py
@@ -374,31 +374,79 @@ def test_linear_expression_loc(x, y):
     assert expr.loc[0].size < expr.loc[:5].size
 
 
+def test_linear_expression_isnull(v):
+    expr = np.arange(20) * v
+    filter = (expr.coeffs >= 10).any(TERM_DIM)
+    expr = expr.where(filter)
+    assert expr.isnull().sum() == 10
+
+
 def test_linear_expression_where(v):
     expr = np.arange(20) * v
-    expr = expr.where(expr.coeffs >= 10)
+    filter = (expr.coeffs >= 10).any(TERM_DIM)
+    expr = expr.where(filter)
     assert isinstance(expr, LinearExpression)
     assert expr.nterm == 1
 
     expr = np.arange(20) * v
-    expr = expr.where(expr.coeffs >= 10, drop=True).sum()
+    expr = expr.where(filter, drop=True).sum()
     assert isinstance(expr, LinearExpression)
     assert expr.nterm == 10
 
 
 def test_linear_expression_where_with_const(v):
     expr = np.arange(20) * v + 10
-    expr = expr.where(expr.coeffs >= 10)
+    filter = (expr.coeffs >= 10).any(TERM_DIM)
+    expr = expr.where(filter)
     assert isinstance(expr, LinearExpression)
     assert expr.nterm == 1
-    assert (expr.const[:10] == 0).all()
+    assert expr.const[:10].isnull().all()
     assert (expr.const[10:] == 10).all()
 
     expr = np.arange(20) * v + 10
-    expr = expr.where(expr.coeffs >= 10, drop=True).sum()
+    expr = expr.where(filter, drop=True).sum()
     assert isinstance(expr, LinearExpression)
     assert expr.nterm == 10
     assert expr.const == 100
+
+
+def test_linear_expression_where_scalar_fill_value(v):
+    expr = np.arange(20) * v + 10
+    filter = (expr.coeffs >= 10).any(TERM_DIM)
+    expr = expr.where(filter, 200)
+    assert isinstance(expr, LinearExpression)
+    assert expr.nterm == 1
+    assert (expr.const[:10] == 200).all()
+    assert (expr.const[10:] == 10).all()
+
+
+def test_linear_expression_where_array_fill_value(v):
+    expr = np.arange(20) * v + 10
+    filter = (expr.coeffs >= 10).any(TERM_DIM)
+    other = expr.coeffs
+    expr = expr.where(filter, other)
+    assert isinstance(expr, LinearExpression)
+    assert expr.nterm == 1
+    assert (expr.const[:10] == other[:10]).all()
+    assert (expr.const[10:] == 10).all()
+
+
+def test_linear_expression_where_expr_fill_value(v):
+    expr = np.arange(20) * v + 10
+    expr2 = np.arange(20) * v + 5
+    filter = (expr.coeffs >= 10).any(TERM_DIM)
+    res = expr.where(filter, expr2)
+    assert isinstance(res, LinearExpression)
+    assert res.nterm == 1
+    assert (res.const[:10] == expr2.const[:10]).all()
+    assert (res.const[10:] == 10).all()
+
+
+def test_where_with_helper_dim_false(v):
+    expr = np.arange(20) * v
+    with pytest.raises(ValueError):
+        filter = expr.coeffs >= 10
+        expr.where(filter)
 
 
 def test_linear_expression_shift(v):
@@ -406,6 +454,21 @@ def test_linear_expression_shift(v):
     assert shifted.nterm == 1
     assert shifted.coeffs.loc[:1].isnull().all()
     assert (shifted.vars.loc[:1] == -1).all()
+
+
+def test_linear_expression_fillna(v):
+    expr = np.arange(20) * v + 10
+    assert expr.const.sum() == 200
+
+    filter = (expr.coeffs >= 10).any(TERM_DIM)
+    filtered = expr.where(filter)
+    assert isinstance(filtered, LinearExpression)
+    assert filtered.const.sum() == 100
+
+    filled = filtered.fillna(10)
+    assert isinstance(filled, LinearExpression)
+    assert filled.const.sum() == 200
+    assert filled.coeffs.isnull().sum() == 10
 
 
 def test_linear_expression_diff(v):

--- a/test/test_quadratic_expression.py
+++ b/test/test_quadratic_expression.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from scipy.sparse import csc_matrix
+from xarray import DataArray
 
 from linopy import Model, merge
 from linopy.constants import FACTOR_DIM, TERM_DIM
@@ -122,6 +123,15 @@ def test_merge_linear_expression_and_quadratic_expression(x, y):
 def test_quadratic_expression_loc(x):
     expr = x * x
     assert expr.loc[0].size < expr.loc[:5].size
+
+
+def test_quadratic_expression_isnull(x):
+    expr = np.arange(2) * x * x
+    filter = (expr.coeffs > 0).any(TERM_DIM)
+    expr = expr.where(filter)
+    isnull = expr.isnull()
+    assert isinstance(isnull, DataArray)
+    assert isnull.sum() == 1
 
 
 def test_quadratic_expression_flat(x, y):

--- a/test/test_variable.py
+++ b/test/test_variable.py
@@ -157,6 +157,11 @@ def test_variable_where(x):
     assert x.labels[9] == x[0].label
 
 
+def test_variable_where_deprecation_warning(x):
+    with pytest.warns(FutureWarning):
+        x.where([True] * 4 + [False] * 6, 1)
+
+
 def test_variable_shift(x):
     x = x.shift(first=3)
     assert isinstance(x, linopy.variables.Variable)

--- a/test/test_variable.py
+++ b/test/test_variable.py
@@ -163,6 +163,21 @@ def test_variable_shift(x):
     assert x.labels[0] == -1
 
 
+def test_isnull(x):
+    x = x.where([True] * 4 + [False] * 6)
+    assert isinstance(x.isnull(), xr.DataArray)
+    assert (x.isnull() == [False] * 4 + [True] * 6).all()
+
+
+def test_variable_fillna(x):
+    x = x.where([True] * 4 + [False] * 6)
+
+    with pytest.warns(FutureWarning):
+        x.fillna(0)
+
+    isinstance(x.fillna(x[0]), linopy.variables.Variable)
+
+
 def test_variable_bfill(x):
     x = x.where([False] * 4 + [True] * 6)
     x = x.bfill("first")
@@ -185,13 +200,14 @@ def test_variable_ffill(x):
 
 
 def test_variable_fillna(x):
-    result = x.fillna(-1)
+    result = x.fillna(x[0])
     assert isinstance(result, linopy.variables.Variable)
 
 
 def test_variable_sanitize(x):
     # convert intentionally to float with nans
-    x = x.where([True] * 4 + [False] * 6, np.nan)
+    fill_value = {"labels": np.nan, "lower": np.nan, "upper": np.nan}
+    x = x.where([True] * 4 + [False] * 6, fill_value)
     x = x.sanitize()
     assert isinstance(x, linopy.variables.Variable)
     assert x.labels[9] == -1


### PR DESCRIPTION
closes #144 

From release notes:

* The `_fill_value` for LinearExpression and QuadraticExpression classes was changed to ``NaN`` for the constant array ("const"). This allows to use the `where` function for expressions with constant values in the argument `other`.
* The `fillna` function for variables was made more secure by raising a warning if the fill value is not of  variable-like type.
* The `where` and `fillna` functions for expressions were made more flexible: When passing a scalar value or a DataArray, the values are added as constants to the expression, where there were missing values before. If another expression is passed, the values are added to the expression, where there were missing values before.
