### PR TITLE
add MOSEK solver

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -75,6 +75,8 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
     - name: Test with pytest
+      env:
+        MOSEKLM_LICENSE_FILE: ${{ secrets.MSK_LICENSE }}
       run: |
         pytest --cov=./ --cov-report=xml linopy --doctest-modules test
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Fri    0          4
 * [Gurobi](https://www.gurobi.com/)
 * [Xpress](https://www.fico.com/en/products/fico-xpress-solver)
 * [Cplex](https://www.ibm.com/de-de/analytics/cplex-optimizer)
+* [MOSEK](https://www.mosek.com/)
 
 Note that these do have to be installed by the user separately.
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -133,6 +133,7 @@ Solvers
     solvers.run_cplex
     solvers.run_gurobi
     solvers.run_xpress
+    solvers.run_mosek
 
 Solving
 =======

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -45,6 +45,7 @@ flexible data-handling features:
    - `Gurobi <https://www.gurobi.com/>`__
    - `Xpress <https://www.fico.com/en/products/fico-xpress-solver>`__
    - `Cplex <https://www.ibm.com/de-de/analytics/cplex-optimizer>`__
+   - `MOSEK <https://www.mosek.com/>`__
 
 
 

--- a/doc/prerequisites.rst
+++ b/doc/prerequisites.rst
@@ -36,6 +36,7 @@ Linopy won't work without a solver. Currently, the following solvers are support
 -  `Gurobi <https://www.gurobi.com/>`__  - closed source, commercial, very fast
 -  `Xpress <https://www.fico.com/en/products/fico-xpress-solver>`__ - closed source, commercial, very fast
 -  `Cplex <https://www.ibm.com/de-de/analytics/cplex-optimizer>`__ - closed source, commercial, very fast
+-  `MOSEK <https://www.mosek.com/>`__
 
 For a subset of the solvers, Linopy provides a wrapper.
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -1,8 +1,12 @@
 Release Notes
 =============
 
-.. Upcoming Release
-.. ----------------
+Upcoming Release
+----------------
+
+**New Features**
+
+* Added solver interface for MOSEK.
 
 Version 0.3.0
 -------------

--- a/linopy/io.py
+++ b/linopy/io.py
@@ -277,7 +277,7 @@ def integers_to_file(m, f, log=False, batch_size=1000, integer_label="general"):
         f.writelines(batch)
 
 
-def to_file(m, fn, integer_label='general'):
+def to_file(m, fn, integer_label="general"):
     """
     Write out a model to a lp or mps file.
     """
@@ -297,7 +297,9 @@ def to_file(m, fn, integer_label='general'):
             constraints_to_file(m, f, log=log, batch_size=batch_size)
             bounds_to_file(m, f, log=log, batch_size=batch_size)
             binaries_to_file(m, f, log=log, batch_size=batch_size)
-            integers_to_file(m, f, log=log, batch_size=batch_size, integer_label=integer_label)
+            integers_to_file(
+                m, f, log=log, batch_size=batch_size, integer_label=integer_label
+            )
             f.write("end\n")
 
             logger.info(f" Writing time: {round(time.time()-start, 2)}s")

--- a/linopy/io.py
+++ b/linopy/io.py
@@ -249,7 +249,7 @@ def binaries_to_file(m, f, log=False, batch_size=1000):
         f.writelines(batch)
 
 
-def integers_to_file(m, f, log=False, batch_size=1000):
+def integers_to_file(m, f, log=False, batch_size=1000, integer_label="general"):
     """
     Write out integers of a model to a lp file.
     """
@@ -257,7 +257,7 @@ def integers_to_file(m, f, log=False, batch_size=1000):
     if not len(list(names)):
         return
 
-    f.write("\n\ninteger\n\n")
+    f.write(f"\n\n{integer_label}\n\n")
     if log:
         names = tqdm(
             list(names),
@@ -277,7 +277,7 @@ def integers_to_file(m, f, log=False, batch_size=1000):
         f.writelines(batch)
 
 
-def to_file(m, fn):
+def to_file(m, fn, integer_label='general'):
     """
     Write out a model to a lp or mps file.
     """
@@ -297,7 +297,7 @@ def to_file(m, fn):
             constraints_to_file(m, f, log=log, batch_size=batch_size)
             bounds_to_file(m, f, log=log, batch_size=batch_size)
             binaries_to_file(m, f, log=log, batch_size=batch_size)
-            integers_to_file(m, f, log=log, batch_size=batch_size)
+            integers_to_file(m, f, log=log, batch_size=batch_size, integer_label=integer_label)
             f.write("end\n")
 
             logger.info(f" Writing time: {round(time.time()-start, 2)}s")

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -57,6 +57,9 @@ with contextlib.suppress(ImportError):
 with contextlib.suppress(ImportError):
     import mosek
 
+    with mosek.Task() as m:
+        m.optimize()
+
     available_solvers.append("mosek")
 logger = logging.getLogger(__name__)
 

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -747,7 +747,16 @@ def run_mosek(
 
     if io_api is not None and io_api not in ["lp", "mps"]:
         logger.warning(
-            f"IO setting '{io_api}' not available for xpress solver. "
+            f"IO setting '{io_api}' not available for mosek solver. "
+            "Falling back to `lp`."
+        )
+
+    problem_fn = model.to_file(problem_fn)
+
+    problem_fn = maybe_convert_path(problem_fn)
+    log_fn = maybe_convert_path(log_fn)
+    warmstart_fn = maybe_convert_path(warmstart_fn)
+    basis_fn = maybe_convert_path(basis_fn)
 
     with contextlib.ExitStack() as stack:
         if env is None:

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -24,7 +24,7 @@ from linopy.constants import (
     TerminationCondition,
 )
 
-quadratic_solvers = ["gurobi", "xpress", "cplex", "highs"]
+quadratic_solvers = ["gurobi", "xpress", "cplex", "highs", "mosek"]
 
 available_solvers = []
 
@@ -54,11 +54,15 @@ with contextlib.suppress(ImportError):
     import xpress
 
     available_solvers.append("xpress")
+with contextlib.suppress(ImportError):
+    import mosek
+
+    available_solvers.append("mosek")
 logger = logging.getLogger(__name__)
 
 
 io_structure = dict(
-    lp_file={"gurobi", "xpress", "cbc", "glpk", "cplex"}, blocks={"pips"}
+    lp_file={"gurobi", "xpress", "cbc", "glpk", "cplex", "mosek"}, blocks={"pips"}
 )
 
 
@@ -703,6 +707,113 @@ def run_xpress(
     maybe_adjust_objective_sign(solution, model.objective.sense, io_api, "xpress")
 
     return Result(status, solution, m)
+
+
+def run_mosek(
+    model,
+    io_api=None,
+    problem_fn=None,
+    solution_fn=None,
+    log_fn=None,
+    warmstart_fn=None,
+    basis_fn=None,
+    keep_files=False,
+    env=None,
+    **solver_options,
+):
+    """
+    Solve a linear problem using the MOSEK solver.
+
+    https://www.mosek.com/
+
+    For more information on solver options, see
+    https://docs.mosek.com/latest/pythonapi/parameters.html#doc-all-parameter-list
+    """
+    CONDITION_MAP = {
+        "solsta.unknown": "unknown",
+        "solsta.optimal": "optimal",
+        "solsta.integer_optimal": "optimal",
+        "solsta.prim_infeas_cer": "infeasible",
+        "solsta.dual_infeas_cer": "infeasible",
+    }
+
+    if io_api is not None and io_api not in ["lp", "mps"]:
+        logger.warning(
+            f"IO setting '{io_api}' not available for xpress solver. "
+            "Falling back to `lp`."
+        )
+
+    problem_fn = model.to_file(problem_fn)
+
+    problem_fn = maybe_convert_path(problem_fn)
+    log_fn = maybe_convert_path(log_fn)
+    warmstart_fn = maybe_convert_path(warmstart_fn)
+    basis_fn = maybe_convert_path(basis_fn)
+
+    with contextlib.ExitStack() as stack:
+        if env is None:
+            env = stack.enter_context(mosek.Env())
+
+        with env.Task() as m:
+
+            m.readdata(problem_fn)
+
+            for k, v in solver_options.items():
+                m.putparam(k, str(v))
+
+            if log_fn is not None:
+                m.linkfiletostream(mosek.streamtype.log, log_fn, 0)
+
+            if warmstart_fn:
+                m.readdata(warmstart_fn)
+
+            m.optimize()
+
+            m.solutionsummary(mosek.streamtype.log)
+
+            if basis_fn:
+                try:
+                    m.writedata(basis_fn)
+                except mosek.Error as err:
+                    logger.info("No model basis stored. Raised error:", err)
+
+            soltype = None
+            possible_soltypes = [mosek.soltype.bas, mosek.soltype.itr, mosek.soltype.itg]
+            for possible_soltype in possible_soltypes:
+                try:
+                    if m.solutiondef(possible_soltype):
+                        soltype = possible_soltype
+                except mosek.Error:
+                    pass
+
+            condition = str(m.getsolsta(soltype))
+            termination_condition = CONDITION_MAP.get(condition, condition)
+            status = Status.from_termination_condition(termination_condition)
+            status.legacy_status = condition
+
+            def get_solver_solution() -> Solution:
+                objective = m.getprimalobj(soltype)
+
+                sol = m.getxx(soltype)
+                sol = {m.getvarname(i): sol[i] for i in range(m.getnumvar())}
+                sol = pd.Series(sol, dtype=float)
+                sol = set_int_index(sol)
+
+                try:
+                    dual = m.gety(soltype)
+                    dual = {m.getconname(i): dual[i] for i in range(m.getnumcon())}
+                    dual = pd.Series(dual, dtype=float)
+                    dual = set_int_index(dual)
+                except mosek.Error:
+                    logger.warning("Dual values of MILP couldn't be parsed")
+                    dual = pd.Series(dtype=float)
+
+                return Solution(sol, dual, objective)
+
+            solution = safe_get_solution(status, get_solver_solution)
+            maybe_adjust_objective_sign(solution, model.objective.sense, io_api, "mosek")
+
+    return Result(status, solution)
 
 
 def run_pips(

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -74,7 +74,8 @@ logger = logging.getLogger(__name__)
 
 
 io_structure = dict(
-    lp_file={"gurobi", "xpress", "cbc", "glpk", "cplex", "mosek", "mindopt"}, blocks={"pips"}
+    lp_file={"gurobi", "xpress", "cbc", "glpk", "cplex", "mosek", "mindopt"},
+    blocks={"pips"},
 )
 
 

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -24,7 +24,7 @@ from linopy.constants import (
     TerminationCondition,
 )
 
-quadratic_solvers = ["gurobi", "xpress", "cplex", "highs", "mosek"]
+quadratic_solvers = ["gurobi", "xpress", "cplex", "highs"]
 
 available_solvers = []
 

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -65,7 +65,7 @@ with contextlib.suppress(ImportError):
     import coptpy
 
     available_solvers.append("copt")
-    
+
 logger = logging.getLogger(__name__)
 
 
@@ -819,7 +819,7 @@ def run_mosek(
 
     return Result(status, solution)
 
-  
+
 def run_copt(
     model,
     io_api=None,

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -755,7 +755,6 @@ def run_mosek(
             env = stack.enter_context(mosek.Env())
 
         with env.Task() as m:
-
             m.readdata(problem_fn)
 
             for k, v in solver_options.items():
@@ -778,7 +777,11 @@ def run_mosek(
                     logger.info("No model basis stored. Raised error:", err)
 
             soltype = None
-            possible_soltypes = [mosek.soltype.bas, mosek.soltype.itr, mosek.soltype.itg]
+            possible_soltypes = [
+                mosek.soltype.bas,
+                mosek.soltype.itr,
+                mosek.soltype.itg,
+            ]
             for possible_soltype in possible_soltypes:
                 try:
                     if m.solutiondef(possible_soltype):
@@ -811,7 +814,9 @@ def run_mosek(
                 return Solution(sol, dual, objective)
 
             solution = safe_get_solution(status, get_solver_solution)
-            maybe_adjust_objective_sign(solution, model.objective.sense, io_api, "mosek")
+            maybe_adjust_objective_sign(
+                solution, model.objective.sense, io_api, "mosek"
+            )
 
     return Result(status, solution)
 

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
             "highspy",
             "cplex",
             "xpress",
+            "mosek",
         ],
     },
     classifiers=[

--- a/test/test_optimization.py
+++ b/test/test_optimization.py
@@ -345,6 +345,7 @@ def test_solver_options(model, solver, io_api):
         "scip": {"time_limit": 1},
         "xpress": {"maxtime": 1},
         "highs": {"time_limit": 1},
+        "mosek": {"MSK_DPAR_OPTIMIZER_MAX_TIME": 1},
     }
     status, condition = model.solve(solver, io_api=io_api, **time_limit_option[solver])
     assert status == "ok"


### PR DESCRIPTION
Solve a linear problem using the MOSEK solver.

category: commercial

https://www.mosek.com/

For more information on solver options, see
https://docs.mosek.com/latest/pythonapi/parameters.html#doc-all-parameter-list
    
https://docs.mosek.com/latest/pythonapi/index.html#
    
Install with `pip install mosek`

Needs license setup (free academic): https://www.mosek.com/products/academic-licenses/

Tested locally and passed all tests. However, quadratic problems are not supported yet.

MOSEK does not understand "integer" as a label in the LP-file. It understands "general" however, and all other solvers also seem to. Not sure if you want to change the label completely, or have this as function argument.

MOSEK can also compute IIS (for later).

```py
import pypsa

n = pypsa.examples.ac_dc_meshed()
n.optimize(solver_name='highs')
n.buses_t.marginal_price["London"]
n.generators_t.p
n.optimize(solver_name='mosek')
n.generators_t.p
n.buses_t.marginal_price["London"]
```
