### PR TITLE
add COPT solver

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Fri    0          4
 * [Gurobi](https://www.gurobi.com/)
 * [Xpress](https://www.fico.com/en/products/fico-xpress-solver)
 * [Cplex](https://www.ibm.com/de-de/analytics/cplex-optimizer)
+* [COPT](https://www.shanshu.ai/copt)
 
 Note that these do have to be installed by the user separately.
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -133,6 +133,7 @@ Solvers
     solvers.run_cplex
     solvers.run_gurobi
     solvers.run_xpress
+    solvers.run_copt
 
 Solving
 =======

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -45,6 +45,7 @@ flexible data-handling features:
    - `Gurobi <https://www.gurobi.com/>`__
    - `Xpress <https://www.fico.com/en/products/fico-xpress-solver>`__
    - `Cplex <https://www.ibm.com/de-de/analytics/cplex-optimizer>`__
+   - `COPT <https://www.shanshu.ai/copt>`__
 
 
 

--- a/doc/prerequisites.rst
+++ b/doc/prerequisites.rst
@@ -36,6 +36,7 @@ Linopy won't work without a solver. Currently, the following solvers are support
 -  `Gurobi <https://www.gurobi.com/>`__  - closed source, commercial, very fast
 -  `Xpress <https://www.fico.com/en/products/fico-xpress-solver>`__ - closed source, commercial, very fast
 -  `Cplex <https://www.ibm.com/de-de/analytics/cplex-optimizer>`__ - closed source, commercial, very fast
+-  `COPT <https://www.shanshu.ai/copt>`__ - closed source, commercial, very fast
 
 For a subset of the solvers, Linopy provides a wrapper.
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -1,8 +1,10 @@
 Release Notes
 =============
 
-.. Upcoming Release
-.. ----------------
+Upcoming Release
+----------------
+
+* Added solver interface for COPT by Cardinal Optimizer.
 
 Version 0.3.0
 -------------

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -768,15 +768,15 @@ def run_copt(
         except Exception as err:
             logger.info("No model basis stored. Raised error: ", err)
 
-    condition = m.LpStatus if model.type == 'LP' else m.MipStatus
+    condition = m.LpStatus if model.type == "LP" else m.MipStatus
     termination_condition = CONDITION_MAP.get(condition, condition)
     status = Status.from_termination_condition(termination_condition)
     status.legacy_status = condition
 
     def get_solver_solution() -> Solution:
-        objective = m.LpObjval if model.type == 'LP' else m.BestObj
+        objective = m.LpObjval if model.type == "LP" else m.BestObj
 
-        m.getValues() # potential alternative
+        m.getValues()  # potential alternative
         sol = m.getVars()
         sol = pd.Series({v.index: v.x for v in sol}, dtype=float)
         sol = set_int_index(sol)
@@ -795,7 +795,6 @@ def run_copt(
     maybe_adjust_objective_sign(solution, model.objective.sense, io_api, "copt")
 
     return Result(status, solution, m)
-
 
 
 def run_pips(

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -24,7 +24,7 @@ from linopy.constants import (
     TerminationCondition,
 )
 
-quadratic_solvers = ["gurobi", "xpress", "cplex", "highs"]
+quadratic_solvers = ["gurobi", "xpress", "cplex", "highs", "copt"]
 
 available_solvers = []
 
@@ -54,6 +54,10 @@ with contextlib.suppress(ImportError):
     import xpress
 
     available_solvers.append("xpress")
+with contextlib.suppress(ImportError):
+    import coptpy
+
+    available_solvers.append("copt")
 logger = logging.getLogger(__name__)
 
 
@@ -703,6 +707,95 @@ def run_xpress(
     maybe_adjust_objective_sign(solution, model.objective.sense, io_api, "xpress")
 
     return Result(status, solution, m)
+
+
+def run_copt(
+    model,
+    io_api=None,
+    problem_fn=None,
+    solution_fn=None,
+    log_fn=None,
+    warmstart_fn=None,
+    basis_fn=None,
+    keep_files=False,
+    env=None,
+    **solver_options,
+):
+    """
+    Solve a linear problem using the COPT solver.
+
+    https://guide.coap.online/copt/en-doc/index.html
+
+    For more information on solver options, see
+    https://guide.coap.online/copt/en-doc/parameter.html
+    """
+    # conditions: https://guide.coap.online/copt/en-doc/constant.html#chapconst-solstatus
+    CONDITION_MAP = {}
+
+    if io_api is not None and io_api not in ["lp", "mps"]:
+        logger.warning(
+            f"IO setting '{io_api}' not available for COPT solver. "
+            "Falling back to `lp`."
+        )
+
+    problem_fn = model.to_file(problem_fn)
+
+    problem_fn = maybe_convert_path(problem_fn)
+    log_fn = maybe_convert_path(log_fn)
+    warmstart_fn = maybe_convert_path(warmstart_fn)
+    basis_fn = maybe_convert_path(basis_fn)
+
+    env = coptpy.Envr()
+
+    m = env.createModel()
+
+    m.read(problem_fn)
+
+    if log_fn:
+        m.setLogFile(log_fn)
+
+    for k, v in solver_options.items():
+        m.setParam(k, v)
+
+    if warmstart_fn:
+        m.readBasis(warmstart_fn)
+
+    m.solve()
+
+    if basis_fn and m.HasBasis:
+        try:
+            m.write(basis_fn)
+        except Exception as err:
+            logger.info("No model basis stored. Raised error: ", err)
+
+    condition = m.LpStatus if model.type == 'LP' else m.MipStatus
+    termination_condition = CONDITION_MAP.get(condition, condition)
+    status = Status.from_termination_condition(termination_condition)
+    status.legacy_status = condition
+
+    def get_solver_solution() -> Solution:
+        objective = m.LpObjval if model.type == 'LP' else m.BestObj
+
+        m.getValues() # potential alternative
+        sol = m.getVars()
+        sol = pd.Series({v.index: v.x for v in sol}, dtype=float)
+        sol = set_int_index(sol)
+
+        try:
+            dual = m.getDuals()
+            dual = pd.Series(dtype=float)
+            dual = set_int_index(dual)
+        except coptpy.CoptError:
+            logger.warning("Dual values of MILP couldn't be parsed")
+            dual = pd.Series(dtype=float)
+
+        return Solution(sol, dual, objective)
+
+    solution = safe_get_solution(status, get_solver_solution)
+    maybe_adjust_objective_sign(solution, model.objective.sense, io_api, "copt")
+
+    return Result(status, solution, m)
+
 
 
 def run_pips(

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
             "highspy",
             "cplex",
             "xpress",
+            "coptpy",
         ],
     },
     classifiers=[

--- a/test/test_optimization.py
+++ b/test/test_optimization.py
@@ -345,6 +345,7 @@ def test_solver_options(model, solver, io_api):
         "scip": {"time_limit": 1},
         "xpress": {"maxtime": 1},
         "highs": {"time_limit": 1},
+        "copt": {"TimeLimit": 1},
     }
     status, condition = model.solve(solver, io_api=io_api, **time_limit_option[solver])
     assert status == "ok"


### PR DESCRIPTION
closes #186 

https://shanshu.ai/copt

Documentation: https://guide.coap.online/copt/en-doc/index.html

Install with `pip install coptpy`

Commercial, free academic license.

Tested locally and passed all tests. However, quadratic problems are not supported yet (LP file format issues?).

Small problem instances do not require a license. Hence, this solver can be tested in CI.

COPT could also calculate IIS (for later).

```py
import pypsa

n = pypsa.examples.ac_dc_meshed()
n.optimize(solver_name='highs')
n.buses_t.marginal_price["London"]
n.generators_t.p
n.optimize(solver_name='copt', solver_options=dict(LpMethod=2))
n.generators_t.p
n.buses_t.marginal_price["London"]
```
