### PR TITLE
MOSEK ensure any license tokens are checked in after initialisation

### DIFF
--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -58,8 +58,10 @@ with contextlib.suppress(ImportError):
     import mosek
 
     with contextlib.suppress(mosek.Error):
-        with mosek.Task() as m:
-            m.optimize()
+        with mosek.Env() as m:
+            t = m.Task()
+            t.optimize()
+            m.checkinall()
 
         available_solvers.append("mosek")
 with contextlib.suppress(ImportError):


### PR DESCRIPTION
Proposed to fix issue #197 
Tested with Python 3.10.11 Mosek 10.1.16 and Linopy 0.31 in a Linux Ubuntu machine.