### PR TITLE
Use os.makedirs to create parent dirs for solution_fn

### DIFF
--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -171,8 +171,7 @@ def run_cbc(
     if basis_fn:
         command += f"-basisO {basis_fn} "
 
-    if not os.path.exists(solution_fn):
-        os.mknod(solution_fn)
+    os.makedirs(os.path.dirname(solution_fn), exist_ok=True)
 
     command = command.strip()
 
@@ -262,6 +261,8 @@ def run_glpk(
 
     problem_fn = model.to_file(problem_fn)
     suffix = problem_fn.suffix[1:]
+
+    os.makedirs(os.path.dirname(solution_fn), exist_ok=True)
 
     # TODO use --nopresol argument for non-optimal solution output
     command = f"glpsol --{suffix} {problem_fn} --output {solution_fn} "

--- a/test/test_optimization.py
+++ b/test/test_optimization.py
@@ -555,6 +555,13 @@ def test_basis_and_warmstart(tmp_path, model, solver, io_api):
     model.solve(solver, warmstart_fn=basis_fn)
 
 
+@pytest.mark.parametrize("solver,io_api", params)
+def test_solution_fn_parent_dir_doesnt_exist(model, solver, io_api, tmp_path):
+    solution_fn = tmp_path / "non_existent_dir" / "non_existent_file"
+    status, condition = model.solve(solver, io_api=io_api, solution_fn=solution_fn)
+    assert status == "ok"
+
+
 # def init_model_large():
 #     m = Model()
 #     time = pd.Index(range(10), name="time")


### PR DESCRIPTION
Before this fix the tests fail cbc does not work on OSx. 

On OSx mknod requires privledged access (need to run as sudo)
https://stackoverflow.com/questions/32115715/os-mknod-fails-on-macos, but even when running as sudo, the test still fails with an invalid argument error.  

I assume the mknod is there incase the parent dir of the solution_fn is not present, so I created a test for this case and found that glpk also fails if the solution_fn's parent dir does not exist so I added a fix for this. 