### PR TITLE
allow removing multiple constraints at once

### DIFF
--- a/linopy/model.py
+++ b/linopy/model.py
@@ -665,15 +665,13 @@ class Model:
         -------
         None.
         """
-
         if isinstance(name, list):
             for n in name:
-                logger.info(f"Removed constraint: {name}")
-                self.remove_constraints(n)
-            return
-
-        logger.info(f"Removed constraint: {name}")
-        self.constraints.remove(name)
+                logger.info(f"Removed constraint: {n}")
+                self.constraints.remove(n)
+        else:
+            logger.info(f"Removed constraint: {name}")
+            self.constraints.remove(name)
 
     @property
     def continuous(self):

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -651,19 +651,28 @@ class Model:
 
     def remove_constraints(self, name):
         """
-        Remove all constraints stored under reference name `name` from the
+        Remove all constraints stored under reference name 'name' from the
         model.
 
         Parameters
         ----------
-        name : str
-            Reference name of the constraints which to remove, same as used in
-            `model.add_constraints`.
+        name : str or list of str
+            Reference name(s) of the constraints to remove. If a single name is
+            provided, only that constraint will be removed. If a list of names
+            is provided, all constraints with those names will be removed.
 
         Returns
         -------
         None.
         """
+
+        if isinstance(name, list):
+            for n in name:
+                logger.info(f"Removed constraint: {name}")
+                self.remove_constraints(n)
+            return
+
+        logger.info(f"Removed constraint: {name}")
         self.constraints.remove(name)
 
     @property

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -667,7 +667,7 @@ class Model:
         """
         if isinstance(name, list):
             for n in name:
-                logger.info(f"Removed constraint: {n}")
+                logger.debug(f"Removed constraint: {n}")
                 self.constraints.remove(n)
         else:
             logger.info(f"Removed constraint: {name}")

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -670,7 +670,7 @@ class Model:
                 logger.debug(f"Removed constraint: {n}")
                 self.constraints.remove(n)
         else:
-            logger.info(f"Removed constraint: {name}")
+            logger.debug(f"Removed constraint: {name}")
             self.constraints.remove(name)
 
     def remove_objective(self):

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -114,6 +114,19 @@ def test_remove_constraint():
     assert not len(m.constraints.labels)
 
 
+def test_remove_constraints_with_list():
+    m = Model()
+
+    x = m.add_variables()
+    y = m.add_variables()
+    m.add_constraints(x, EQUAL, 0, name="constraint_x")
+    m.add_constraints(y, EQUAL, 0, name="constraint_y")
+    m.remove_constraints(["constraint_x", "constraint_y"])
+    assert "constraint_x" not in m.constraints.labels
+    assert "constraint_y" not in m.constraints.labels
+    assert not len(m.constraints.labels)
+
+
 def test_assert_model_equal():
     m = Model()
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -126,6 +126,7 @@ def test_remove_constraints_with_list():
     assert "constraint_y" not in m.constraints.labels
     assert not len(m.constraints.labels)
 
+
 def test_remove_objective():
     m = Model()
 
@@ -137,6 +138,7 @@ def test_remove_objective():
     m.add_objective(obj)
     m.remove_objective()
     assert not len(m.objective.vars)
+
 
 def test_assert_model_equal():
     m = Model()


### PR DESCRIPTION
Make possible to pass a list into remove_constraints() to remove multiple constraints at once.
Keeps old functionality, i.e. it is still possible to pass constraint name as a string.
Adds logging, so user can see what constraints are removed.

to remove all constraints:
`n.model.remove_constraints(list(n.model.constraints))`

to remove a single constraint:
`n.model.remove_constraints(['Bus-nodal_balance'])`
or
`n.model.remove_constraints('Bus-nodal_balance')`

closes https://github.com/PyPSA/linopy/issues/210
