### PR TITLE
Allow removing objective expression from the model

### DIFF
--- a/linopy/model.py
+++ b/linopy/model.py
@@ -666,6 +666,16 @@ class Model:
         """
         self.constraints.remove(name)
 
+    def remove_objective(self):
+        """
+        Remove the objective's linear expression from the model.
+
+        Returns
+        -------
+        None.
+        """
+        self.objective = Objective(LinearExpression(None, self), self)
+
     @property
     def continuous(self):
         """

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -114,6 +114,19 @@ def test_remove_constraint():
     assert not len(m.constraints.labels)
 
 
+def test_remove_objective():
+    m = Model()
+
+    lower = xr.DataArray(np.zeros((2, 2)), coords=[range(2), range(2)])
+    upper = xr.DataArray(np.ones((2, 2)), coords=[range(2), range(2)])
+    x = m.add_variables(lower, upper, name="x")
+    y = m.add_variables(lower, upper, name="y")
+    obj = (10 * x + 5 * y).sum()
+    m.add_objective(obj)
+    m.remove_objective()
+    assert not len(m.objective.vars)
+
+
 def test_assert_model_equal():
     m = Model()
 


### PR DESCRIPTION
Add functionality to remove a linear expression of the objective from the model.
complements already existing functionality, such as `remove_variables()` and `remove_constraints()`
Useful for tutorials, and more generally, for any type of programming exercises when one wants to keep variables and parameters from `n.optimize.create_model()` but use own objective.

example use:

`n.optimize.create_model()`
`n.model.objective`

> LinearExpression: +70 Generator-p[now, gas]
> Sense: min
> Value: None

`n.model.remove_objective()`

> LinearExpression: +0
> Sense: min
> Value: None

closes https://github.com/PyPSA/linopy/issues/209