### PR TITLE
QP support for MOSEK, COPT, MindOpt

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -1,8 +1,10 @@
 Release Notes
 =============
 
-.. Upcoming Release
-.. ----------------
+Upcoming Release
+----------------
+
+- Added support for QP problems with MOSEK and COPT.
 
 Version 0.3.3
 -------------

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -383,6 +383,12 @@ def run_highs(
     if warmstart_fn:
         logger.warning("Warmstart not available with HiGHS solver. Ignore argument.")
 
+    if solver_options.get("solver") in ["simplex", "ipm"] and model.type == "QP":
+        logger.warning(
+            "The HiGHS solver ignores quadratic terms if the solver is set to 'simplex' or 'ipm'. "
+            "Drop the solver option or use 'choose' to enable quadratic terms."
+        )
+
     if io_api is None or io_api in ["lp", "mps"]:
         model.to_file(problem_fn)
         h = highspy.Highs()

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -24,7 +24,16 @@ from linopy.constants import (
     TerminationCondition,
 )
 
-QUADRATIC_SOLVERS = ["gurobi", "xpress", "cplex", "highs", "scip", "mosek", "copt"]
+QUADRATIC_SOLVERS = [
+    "gurobi",
+    "xpress",
+    "cplex",
+    "highs",
+    "scip",
+    "mosek",
+    "copt",
+    "mindopt",
+]
 
 available_solvers = []
 
@@ -1074,6 +1083,10 @@ def run_mindopt(
         raise ValueError(
             "Keyword argument `io_api` has to be one of `lp`, `mps` or None"
         )
+    if (io_api == "lp" or str(problem_fn).endswith(".lp")) and model.type == "QP":
+        raise ValueError(
+            "MindOpt does not support QP problems in LP format. Use `io_api='mps'` instead."
+        )
 
     problem_fn = model.to_file(problem_fn)
 
@@ -1119,7 +1132,7 @@ def run_mindopt(
         try:
             dual = pd.Series({c.constrname: c.DualSoln for c in m.getConstrs()})
             dual = set_int_index(dual)
-        except mindoptpy.MindoptError:
+        except (mindoptpy.MindoptError, AttributeError):
             logger.warning("Dual values of MILP couldn't be parsed")
             dual = pd.Series(dtype=float)
 

--- a/setup.py
+++ b/setup.py
@@ -24,10 +24,9 @@ SOLVERS = [
     "mindoptpy",
     "coptpy",
     "pyscipopt",
-    "xpress",
 ]
 
-if sys.version_info <= (3, 10):
+if not (sys.version_info == (3, 11) and sys.platform == "darwin"):
     SOLVERS.append("xpress")
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ SOLVERS = [
     "mindoptpy",
     "coptpy",
     "pyscipopt",
+    "xpress",
 ]
 
 if sys.version_info <= (3, 10):

--- a/setup.py
+++ b/setup.py
@@ -23,11 +23,15 @@ SOLVERS = [
     "mosek",
     "mindoptpy",
     "coptpy",
-    "pyscipopt",
+    # "pyscipopt",
+    # "xpress",
 ]
 
 if not (sys.version_info == (3, 11) and sys.platform == "darwin"):
     SOLVERS.append("xpress")
+
+if not sys.platform == "darwin":
+    SOLVERS.append("pyscipopt")
 
 setup(
     name="linopy",

--- a/test/test_optimization.py
+++ b/test/test_optimization.py
@@ -203,6 +203,7 @@ def quadratic_model():
     m.add_objective(x * x)
     return m
 
+
 @pytest.fixture
 def quadratic_model_unbounded():
     m = Model()
@@ -213,8 +214,9 @@ def quadratic_model_unbounded():
 
     m.add_constraints(x + y, GREATER_EQUAL, 10)
 
-    m.add_objective(- x - y + x * x)
+    m.add_objective(-x - y + x * x)
     return m
+
 
 @pytest.fixture
 def quadratic_model_cross_terms():

--- a/test/test_optimization.py
+++ b/test/test_optimization.py
@@ -497,7 +497,7 @@ def test_milp_model_r(milp_model_r, solver, io_api):
         assert ((milp_model_r.solution.x == 11) | (milp_model_r.solution.y == 0)).all()
 
 
-@pytest.mark.parametrize("solver,io_api", params)
+@pytest.mark.parametrize("solver,io_api", [p for p in params if p != ("mindopt", "lp")])
 def test_quadratic_model(quadratic_model, solver, io_api):
     if solver in feasible_quadratic_solvers:
         status, condition = quadratic_model.solve(solver, io_api=io_api)
@@ -510,7 +510,7 @@ def test_quadratic_model(quadratic_model, solver, io_api):
             quadratic_model.solve(solver, io_api=io_api)
 
 
-@pytest.mark.parametrize("solver,io_api", params)
+@pytest.mark.parametrize("solver,io_api", [p for p in params if p != ("mindopt", "lp")])
 def test_quadratic_model_cross_terms(quadratic_model_cross_terms, solver, io_api):
     if solver in feasible_quadratic_solvers:
         status, condition = quadratic_model_cross_terms.solve(solver, io_api=io_api)
@@ -523,7 +523,7 @@ def test_quadratic_model_cross_terms(quadratic_model_cross_terms, solver, io_api
             quadratic_model_cross_terms.solve(solver, io_api=io_api)
 
 
-@pytest.mark.parametrize("solver,io_api", params)
+@pytest.mark.parametrize("solver,io_api", [p for p in params if p != ("mindopt", "lp")])
 def test_quadratic_model_wo_constraint(quadratic_model, solver, io_api):
     quadratic_model.constraints.remove("con0")
     if solver in feasible_quadratic_solvers:
@@ -536,7 +536,7 @@ def test_quadratic_model_wo_constraint(quadratic_model, solver, io_api):
             quadratic_model.solve(solver, io_api=io_api)
 
 
-@pytest.mark.parametrize("solver,io_api", params)
+@pytest.mark.parametrize("solver,io_api", [p for p in params if p != ("mindopt", "lp")])
 def test_quadratic_model_unbounded(quadratic_model_unbounded, solver, io_api):
     if solver in feasible_quadratic_solvers:
         status, condition = quadratic_model_unbounded.solve(solver, io_api=io_api)


### PR DESCRIPTION
MOSEK:
- The `solsta.dual_infeas_cer` should be interpreted as "infeasible_or_unbounded"
- An empty constraint list can lead to an `AttributeError` when reading out duals. This is handled like in the Gurobi interface.

COPT
- For reading out the solver status, need to handle the case where `model.type == "QP"`
- An empty constraint list can lead to an `AttributeError` when reading out duals. This is handled like in the Gurobi interface.
- The check in the test `test_quadratic_model` for the `y` variable was too restrictive. 10 is the lowest value `y` has to take in the cost-optimum, but increasing this value (which was what COPT did) yields the same objective value. Degeneracy.

MindOpt:
- According to the developers, MindOpt does not yet support reading in QPs via LP file, only via MPS file.
- An empty constraint list can lead to an `AttributeError` when reading out duals. This is handled like in the Gurobi interface.

HiGHS:
- Added warning regarding #171 

Tests:
- The QP test for unbounded problems was flawed. By reversing the sign of the objective function with quadratic terms, the problem became non-convex. This caused MOSEK to complain (matrix was not positive semidefinite) and was also the cause why "SCIP" needed special handling. I exchanged that with a new test case that is unbounded yet convex.

Environment:
- Was there a reason to not add `xpress` to the solvers in `setup.py`?