### PR TITLE
make it possible to suppress solver output when running CBC and GLPK

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -4,6 +4,11 @@ Release Notes
 .. Upcoming Release
 .. ----------------
 
+Version 0.3.4
+-------------
+
+* Solver output of CBC and GLPK is sent to logging with level INFO instead of stdout
+
 Version 0.3.3
 -------------
 

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -181,8 +181,10 @@ def run_cbc(
 
     if log_fn is None:
         p = sub.Popen(command.split(" "), stdout=sub.PIPE, stderr=sub.PIPE)
+        output = ""
         for line in iter(p.stdout.readline, b""):
-            print(line.decode(), end="")
+            output += line.decode()
+        logger.info(output)
         p.stdout.close()
         p.wait()
     else:
@@ -284,8 +286,10 @@ def run_glpk(
 
     p = sub.Popen(command.split(" "), stdout=sub.PIPE, stderr=sub.PIPE)
     if log_fn is None:
+        output = ""
         for line in iter(p.stdout.readline, b""):
-            print(line.decode(), end="")
+            output += line.decode()
+        logger.info(output)
         p.stdout.close()
         p.wait()
     else:


### PR DESCRIPTION
Currently, the solver output is printed all the time to stdout using `print` when using CBC or GLPK.
This should be fixed, by also using the logging module.

I did set this to INFO, so that users relying on this output can still use it without going to debug logs.

It would be very cool to have release with this change afterwards