### PR TITLE
repr: use consistent dims order to determine order of display

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -1,6 +1,12 @@
 Release Notes
 =============
 
+Upcoming Version
+----------------
+
+* The return type of ``coord_dims`` for expressions and constraints was changed from set to tuple to align with the xarray convention.
+* The printout of transposed expressions and constraints was fixed.
+
 
 Version 0.3.4
 -------------

--- a/linopy/constraints.py
+++ b/linopy/constraints.py
@@ -153,7 +153,11 @@ class Constraint:
 
     @property
     def coord_dims(self):
-        return {k for k in self.dims if k not in HELPER_DIMS}
+        return tuple(k for k in self.dims if k not in HELPER_DIMS)
+
+    @property
+    def coord_sizes(self):
+        return {k: v for k, v in self.sizes.items() if k not in HELPER_DIMS}
 
     @property
     def is_assigned(self):
@@ -164,9 +168,9 @@ class Constraint:
         Print the constraint arrays.
         """
         max_lines = options["display_max_rows"]
-        dims = list(self.dims)
-        ndim = len(self.coord_dims)
-        dim_sizes = list(self.sizes.values())[:-1]
+        dims = list(self.coord_sizes.keys())
+        ndim = len(dims)
+        dim_sizes = list(self.coord_sizes.values())
         size = np.prod(dim_sizes)  # that the number of theoretical printouts
         masked_entries = self.mask.sum().values if self.mask is not None else 0
         lines = []

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -333,7 +333,7 @@ class LinearExpression:
         Print the expression arrays.
         """
         max_lines = options["display_max_rows"]
-        dims = list(self.coord_dims)
+        dims = list(self.coord_sizes.keys())
         ndim = len(dims)
         dim_sizes = list(self.coord_sizes.values())
         size = np.prod(dim_sizes)  # that the number of theoretical printouts
@@ -515,7 +515,7 @@ class LinearExpression:
 
     @property
     def coord_dims(self):
-        return {k for k in self.dims if k not in HELPER_DIMS}
+        return tuple(k for k in self.dims if k not in HELPER_DIMS)
 
     @property
     def coord_sizes(self):

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -121,14 +121,14 @@ class Model:
         self.matrices = MatrixAccessor(self)
 
     @property
-    def variables(self):
+    def variables(self) -> Variables:
         """
         Variables assigned to the model.
         """
         return self._variables
 
     @property
-    def constraints(self):
+    def constraints(self) -> Constraints:
         """
         Constraints assigned to the model.
         """

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -65,6 +65,7 @@ def _var_unwrap(var):
         "attrs",
         "coords",
         "indexes",
+        "sizes",
     ],
     labels=[
         "shape",
@@ -219,8 +220,8 @@ class Variable:
         Print the variable arrays.
         """
         max_lines = options["display_max_rows"]
-        dims = list(self.dims)
-        dim_sizes = list(self.data.sizes.values())
+        dims = list(self.sizes.keys())
+        dim_sizes = list(self.sizes.values())
         masked_entries = (~self.mask).sum().values
         lines = []
 


### PR DESCRIPTION
expression & constraints: return tuple for coord_dims
variables: add sizes attribute