### PR TITLE
Better doc by explicitly using __qualname__ instead of __repr__()

### DIFF
--- a/linopy/constraints.py
+++ b/linopy/constraints.py
@@ -56,7 +56,9 @@ def conwrap(method, *default_args, **new_default_kwargs):
             method(con.data, *default_args, *args, **kwargs), con.model, con.name
         )
 
-    _conwrap.__doc__ = f"Wrapper for the xarray {method} function for linopy.Constraint"
+    _conwrap.__doc__ = (
+        f"Wrapper for the xarray {method.__qualname__} function for linopy.Constraint"
+    )
     if new_default_kwargs:
         _conwrap.__doc__ += f" with default arguments: {new_default_kwargs}"
 

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -58,7 +58,9 @@ def exprwrap(method, *default_args, **new_default_kwargs):
             method(_expr_unwrap(expr), *default_args, *args, **kwargs), expr.model
         )
 
-    _exprwrap.__doc__ = f"Wrapper for the xarray {method} function for linopy.Variable"
+    _exprwrap.__doc__ = (
+        f"Wrapper for the xarray {method.__qualname__} function for linopy.Variable"
+    )
     if new_default_kwargs:
         _exprwrap.__doc__ += f" with default arguments: {new_default_kwargs}"
 

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -49,7 +49,9 @@ def varwrap(method, *default_args, **new_default_kwargs):
             method(var.data, *default_args, *args, **kwargs), var.model, var.name
         )
 
-    _varwrap.__doc__ = f"Wrapper for the xarray {method} function for linopy.Variable"
+    _varwrap.__doc__ = (
+        f"Wrapper for the xarray {method.__qualname__} function for linopy.Variable"
+    )
     if new_default_kwargs:
         _varwrap.__doc__ += f" with default arguments: {new_default_kwargs}"
 


### PR DESCRIPTION
# Description
By explicitly using the `__qualname__` string of an object (introduced in PEP 3155), the documentation does not include the `<...>` brackets with the memory address. 

# Screenshots
Here`Variable.assign_attrs` as an example, but more methods are affected.

## Screenshot documentation BEFORE changes
<img width="771" alt="Bildschirmfoto 2024-02-27 um 22 48 29" src="https://github.com/PyPSA/linopy/assets/59877932/2b8cafd3-5013-4b64-b071-38002ee0f464">

## Screenshot documentation AFTER changes
<img width="751" alt="Bildschirmfoto 2024-02-27 um 22 48 14" src="https://github.com/PyPSA/linopy/assets/59877932/e95f0adc-a954-42ea-a547-e37cb678be9b">
