### PR TITLE
Improved pandas object alignment

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -4,7 +4,9 @@ Release Notes
 Upcoming Version
 ----------------
 
-* The handling of `pandas` objects was improved. As `pandas` objects are fully aware of coordinates, their index and columns are now strictly taken into account. For example, when multiplying a `pandas.DataFrame` with variables, linopy will now check the alignment of indexes and re-index accordingly. Before, if the shapes of the axes were the same, the indexes of the Variable were forced in and the `pandas` indexes were effectively ignored. A warning was added for cases where users should expect changes of results with this version.
+* The handling of `pandas` objects was improved. As `pandas` objects are fully aware of coordinates, their index and columns are now strictly taken into account. For example, when multiplying a `pandas.DataFrame` with a variable, linopy now checks the alignment of indexes and reindexes accordingly. Previously, if the axis shapes were the same, the indexes of the variable were inserted and the `pandas` indexes were effectively ignored. A warning has been added for cases where users should expect changes to the results with this version. **Important**: This does not apply to overwriting the coordinates when one expression is added to another, e.g. "x + df" still overwrites the index of "df" when the dimensional shapes are aligned.
+
+
 
 
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -1,8 +1,13 @@
 Release Notes
 =============
 
-.. Upcoming Version
-.. ----------------
+Upcoming Version
+----------------
+
+* The handling of `pandas` objects was improved. As `pandas` objects are fully aware of coordinates, their index and columns are now strictly taken into account. For example, when multiplying a `pandas.DataFrame` with variables, linopy will now check the alignment of indexes and re-index accordingly. Before, if the shapes of the axes were the same, the indexes of the Variable were forced in and the `pandas` indexes were effectively ignored. A warning was added for cases where users should expect changes of results with this version.
+
+
+
 
 Version 0.3.5
 -------------

--- a/examples/creating-variables.ipynb
+++ b/examples/creating-variables.ipynb
@@ -466,7 +466,11 @@
    "id": "77e264e2",
    "metadata": {},
    "source": [
-    "The `coords` and `dims` argument is applied to `lower` and `upper` individually. Hence, when mixing array's of different shapes, setting `coords` or `dims` will raised an error:"
+    ".. important::\n",
+    "\n",
+    "    **New in version 0.3.6**\n",
+    "\n",
+    "    As pandas objects always have indexes, the `coords` argument is not required and is ignored is passed. Before, it was used to overwrite the indexes of the pandas objects. A warning is raised if `coords` is passed and if these are not aligned with the pandas object. "
    ]
   },
   {
@@ -476,11 +480,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "coords = pd.Index([1,2]), pd.Index([3,4,5])\n",
-    "try:\n",
-    "    m.add_variables(lower, upper, coords=coords)\n",
-    "except TypeError as e:\n",
-    "    print(\"This raises an error:\", e)"
+    "unaligned_coords = pd.Index([1,2]), pd.Index([2,3,4])\n",
+    "m.add_variables(lower, upper, coords=unaligned_coords)"
    ]
   },
   {

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -397,10 +397,14 @@ class LinearExpression:
     def __add__(self, other):
         """
         Add an expression to others.
+
+        Note: If other is a numpy array or pandas object without axes names,
+        dimension names of self will be filled in other
         """
-        other = as_expression(
-            other, model=self.model, coords=self.coords, dims=self.coord_dims
-        )
+        if np.isscalar(other):
+            return self.assign(const=self.const + other)
+
+        other = as_expression(other, model=self.model, dims=self.coord_dims)
         return merge(self, other, cls=self.__class__)
 
     def __radd__(self, other):
@@ -410,10 +414,14 @@ class LinearExpression:
     def __sub__(self, other):
         """
         Subtract others from expression.
+
+        Note: If other is a numpy array or pandas object without axes names,
+        dimension names of self will be filled in other
         """
-        other = as_expression(
-            other, model=self.model, coords=self.coords, dims=self.coord_dims
-        )
+        if np.isscalar(other):
+            return self.assign(const=self.const - other)
+
+        other = as_expression(other, model=self.model, dims=self.coord_dims)
         return merge(self, -other, cls=self.__class__)
 
     def __neg__(self):
@@ -1225,10 +1233,14 @@ class QuadraticExpression(LinearExpression):
     def __add__(self, other):
         """
         Add an expression to others.
+
+        Note: If other is a numpy array or pandas object without axes names,
+        dimension names of self will be filled in other
         """
-        other = as_expression(
-            other, model=self.model, coords=self.coords, dims=self.coord_dims
-        )
+        if np.isscalar(other):
+            return self.assign(const=self.const + other)
+
+        other = as_expression(other, model=self.model, dims=self.coord_dims)
         if type(other) is LinearExpression:
             other = other.to_quadexpr()
         return merge(self, other, cls=self.__class__)
@@ -1248,10 +1260,14 @@ class QuadraticExpression(LinearExpression):
     def __sub__(self, other):
         """
         Subtract others from expression.
+
+        Note: If other is a numpy array or pandas object without axes names,
+        dimension names of self will be filled in other
         """
-        other = as_expression(
-            other, model=self.model, coords=self.coords, dims=self.coord_dims
-        )
+        if np.isscalar(other):
+            return self.assign(const=self.const - other)
+
+        other = as_expression(other, model=self.model, dims=self.coord_dims)
         if type(other) is LinearExpression:
             other = other.to_quadexpr()
         return merge(self, -other, cls=self.__class__)

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -11,86 +11,343 @@ import pandas as pd
 import pytest
 from xarray import DataArray
 
-from linopy.common import as_dataarray
+from linopy.common import as_dataarray, pandas_to_dataarray
 
 
-def test_as_dataarray_with_series():
-    s = pd.Series([1, 2, 3], index=["a", "b", "c"])
-    da = as_dataarray(s, dims=["dim1"])
-    assert isinstance(da, DataArray)
-    assert da.dims == ("dim1",)
-    assert list(da.coords["dim1"].values) == ["a", "b", "c"]
-
-
-def test_as_dataarray_with_series_override_coords():
-    s = pd.Series([1, 2, 3], index=["a", "b", "c"])
-    da = as_dataarray(s, dims=["dim1"], coords=[[1, 2, 3]])
-    assert isinstance(da, DataArray)
-    assert da.dims == ("dim1",)
-    assert list(da.coords["dim1"].values) == [1, 2, 3]
-
-
-def test_as_dataarray_with_series_default_dims_coords():
+def test_as_dataarray_with_series_dims_default():
+    target_dim = "dim_0"
+    target_index = [0, 1, 2]
     s = pd.Series([1, 2, 3])
     da = as_dataarray(s)
     assert isinstance(da, DataArray)
-    assert da.dims == ("dim_0",)
-    assert list(da.coords["dim_0"].values) == list(s.index)
+    assert da.dims == (target_dim,)
+    assert list(da.coords[target_dim].values) == target_index
 
 
-def test_as_dataarray_with_dataframe():
-    df = pd.DataFrame({"A": [1, 2], "B": [3, 4]}, index=["a", "b"])
-    da = as_dataarray(df, dims=["dim1", "dim2"])
+def test_as_dataarray_with_series_dims_set():
+    target_dim = "dim1"
+    target_index = ["a", "b", "c"]
+    s = pd.Series([1, 2, 3], index=target_index)
+    dims = [target_dim]
+    da = as_dataarray(s, dims=dims)
     assert isinstance(da, DataArray)
-    assert da.dims == ("dim1", "dim2")
-    assert list(da.coords["dim1"].values) == ["a", "b"]
-    assert list(da.coords["dim2"].values) == ["A", "B"]
+    assert da.dims == (target_dim,)
+    assert list(da.coords[target_dim].values) == target_index
 
 
-def test_as_dataarray_with_dataframe_override_coords():
-    df = pd.DataFrame({"A": [1, 2], "B": [3, 4]}, index=["a", "b"])
-    da = as_dataarray(df, dims=["dim1", "dim2"], coords=[[1, 2], [2, 3]])
+def test_as_dataarray_with_series_dims_given():
+    target_dim = "dim1"
+    target_index = ["a", "b", "c"]
+    index = pd.Index(target_index, name=target_dim)
+    s = pd.Series([1, 2, 3], index=index)
+    dims = []
+    da = as_dataarray(s, dims=dims)
     assert isinstance(da, DataArray)
-    assert da.dims == ("dim1", "dim2")
-    assert list(da.coords["dim1"].values) == [1, 2]
-    assert list(da.coords["dim2"].values) == [2, 3]
+    assert da.dims == (target_dim,)
+    assert list(da.coords[target_dim].values) == target_index
 
 
-def test_as_dataarray_with_dataframe_default_dims_coords():
-    df = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
+def test_as_dataarray_with_series_dims_priority():
+    "The dimension name from the pandas object should have priority."
+    target_dim = "dim1"
+    target_index = ["a", "b", "c"]
+    index = pd.Index(target_index, name=target_dim)
+    s = pd.Series([1, 2, 3], index=index)
+    dims = ["other"]
+    da = as_dataarray(s, dims=dims)
+    assert isinstance(da, DataArray)
+    assert da.dims == (target_dim,)
+    assert list(da.coords[target_dim].values) == target_index
+
+
+def test_as_dataarray_with_series_dims_subset():
+    target_dim = "dim_0"
+    target_index = ["a", "b", "c"]
+    s = pd.Series([1, 2, 3], index=target_index)
+    dims = []
+    da = as_dataarray(s, dims=dims)
+    assert isinstance(da, DataArray)
+    assert da.dims == (target_dim,)
+    assert list(da.coords[target_dim].values) == target_index
+
+
+def test_as_dataarray_with_series_dims_superset():
+    target_dim = "dim_a"
+    target_index = ["a", "b", "c"]
+    s = pd.Series([1, 2, 3], index=target_index)
+    dims = [target_dim, "other"]
+    da = as_dataarray(s, dims=dims)
+    assert isinstance(da, DataArray)
+    assert da.dims == (target_dim,)
+    assert list(da.coords[target_dim].values) == target_index
+
+
+def test_as_dataarray_with_series_override_coords():
+    target_dim = "dim_0"
+    target_index = ["a", "b", "c"]
+    s = pd.Series([1, 2, 3], index=target_index)
+    with pytest.warns(UserWarning):
+        da = as_dataarray(s, coords=[[1, 2, 3]])
+    assert isinstance(da, DataArray)
+    assert da.dims == (target_dim,)
+    assert list(da.coords[target_dim].values) == target_index
+
+
+def test_as_dataarray_with_series_aligned_coords():
+    "This should not give out a warning even though coords are given."
+    target_dim = "dim_0"
+    target_index = ["a", "b", "c"]
+    s = pd.Series([1, 2, 3], index=target_index)
+    da = as_dataarray(s, coords=[target_index])
+    assert isinstance(da, DataArray)
+    assert da.dims == (target_dim,)
+    assert list(da.coords[target_dim].values) == target_index
+
+    da = as_dataarray(s, coords={target_dim: target_index})
+    assert isinstance(da, DataArray)
+    assert da.dims == (target_dim,)
+    assert list(da.coords[target_dim].values) == target_index
+
+
+def test_as_dataarray_dataframe_dims_default():
+    target_dims = ("dim_0", "dim_1")
+    target_index = [0, 1]
+    target_columns = ["A", "B"]
+    df = pd.DataFrame([[1, 2], [3, 4]], index=target_index, columns=target_columns)
     da = as_dataarray(df)
     assert isinstance(da, DataArray)
-    assert da.dims == ("dim_0", "dim_1")
-    assert list(da.coords["dim_0"].values) == [0, 1]
-    assert list(da.coords["dim_1"].values) == ["A", "B"]
+    assert da.dims == target_dims
+    assert list(da.coords[target_dims[0]].values) == target_index
+    assert list(da.coords[target_dims[1]].values) == target_columns
 
 
-def test_as_dataarray_with_ndarray():
-    arr = np.array([[1, 2], [3, 4]])
-    da = as_dataarray(arr, dims=["dim1", "dim2"], coords=[["a", "b"], ["A", "B"]])
+def test_as_dataarray_dataframe_dims_set():
+    target_dims = ("dim1", "dim2")
+    target_index = ["a", "b"]
+    target_columns = ["A", "B"]
+    df = pd.DataFrame([[1, 2], [3, 4]], index=target_index, columns=target_columns)
+    da = as_dataarray(df, dims=target_dims)
     assert isinstance(da, DataArray)
-    assert da.dims == ("dim1", "dim2")
-    assert list(da.coords["dim1"].values) == ["a", "b"]
-    assert list(da.coords["dim2"].values) == ["A", "B"]
+    assert da.dims == target_dims
+    assert list(da.coords[target_dims[0]].values) == target_index
+    assert list(da.coords[target_dims[1]].values) == target_columns
 
 
-def test_as_dataarray_with_ndarray_more_dims_than_given():
-    arr = np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])
-    da = as_dataarray(arr, dims=["dim0"], coords=[["a", "b"]])
+def test_as_dataarray_dataframe_dims_given():
+    target_dims = ("dim1", "dim2")
+    target_index = ["a", "b"]
+    target_columns = ["A", "B"]
+    index = pd.Index(target_index, name=target_dims[0])
+    columns = pd.Index(target_columns, name=target_dims[1])
+    df = pd.DataFrame([[1, 2], [3, 4]], index=index, columns=columns)
+    dims = []
+    da = as_dataarray(df, dims=dims)
     assert isinstance(da, DataArray)
-    assert da.dims == ("dim0", "dim_1", "dim_2")
-    assert list(da.coords["dim0"].values) == ["a", "b"]
-    assert list(da.coords["dim_1"].values) == list(range(arr.shape[1]))
-    assert list(da.coords["dim_2"].values) == list(range(arr.shape[2]))
+    assert da.dims == target_dims
+    assert list(da.coords[target_dims[0]].values) == target_index
+    assert list(da.coords[target_dims[1]].values) == target_columns
 
 
-def test_as_dataarray_with_ndarray_default_dims_coords():
+def test_as_dataarray_dataframe_dims_priority():
+    "The dimension name from the pandas object should have priority."
+    target_dims = ("dim1", "dim2")
+    target_index = ["a", "b"]
+    target_columns = ["A", "B"]
+    index = pd.Index(target_index, name=target_dims[0])
+    columns = pd.Index(target_columns, name=target_dims[1])
+    df = pd.DataFrame([[1, 2], [3, 4]], index=index, columns=columns)
+    dims = ["other"]
+    da = as_dataarray(df, dims=dims)
+    assert isinstance(da, DataArray)
+    assert da.dims == target_dims
+    assert list(da.coords[target_dims[0]].values) == target_index
+    assert list(da.coords[target_dims[1]].values) == target_columns
+
+
+def test_as_dataarray_dataframe_dims_subset():
+    target_dims = ("dim_0", "dim_1")
+    target_index = ["a", "b"]
+    target_columns = ["A", "B"]
+    df = pd.DataFrame([[1, 2], [3, 4]], index=target_index, columns=target_columns)
+    dims = []
+    da = as_dataarray(df, dims=dims)
+    assert isinstance(da, DataArray)
+    assert da.dims == target_dims
+    assert list(da.coords[target_dims[0]].values) == target_index
+    assert list(da.coords[target_dims[1]].values) == target_columns
+
+
+def test_as_dataarray_dataframe_dims_superset():
+    target_dims = ("dim_a", "dim_b")
+    target_index = ["a", "b"]
+    target_columns = ["A", "B"]
+    df = pd.DataFrame([[1, 2], [3, 4]], index=target_index, columns=target_columns)
+    dims = [*target_dims, "other"]
+    da = as_dataarray(df, dims=dims)
+    assert isinstance(da, DataArray)
+    assert da.dims == target_dims
+    assert list(da.coords[target_dims[0]].values) == target_index
+    assert list(da.coords[target_dims[1]].values) == target_columns
+
+
+def test_as_dataarray_dataframe_override_coords():
+    target_dims = ("dim_0", "dim_1")
+    target_index = ["a", "b"]
+    target_columns = ["A", "B"]
+    df = pd.DataFrame([[1, 2], [3, 4]], index=target_index, columns=target_columns)
+    with pytest.warns(UserWarning):
+        da = as_dataarray(df, coords=[[1, 2], [2, 3]])
+    assert isinstance(da, DataArray)
+    assert da.dims == target_dims
+    assert list(da.coords[target_dims[0]].values) == target_index
+    assert list(da.coords[target_dims[1]].values) == target_columns
+
+
+def test_as_dataarray_dataframe_aligned_coords():
+    "This should not give out a warning even though coords are given."
+    target_dims = ("dim_0", "dim_1")
+    target_index = ["a", "b"]
+    target_columns = ["A", "B"]
+    df = pd.DataFrame([[1, 2], [3, 4]], index=target_index, columns=target_columns)
+    da = as_dataarray(df, coords=[target_index, target_columns])
+    assert isinstance(da, DataArray)
+    assert da.dims == target_dims
+    assert list(da.coords[target_dims[0]].values) == target_index
+    assert list(da.coords[target_dims[1]].values) == target_columns
+
+    coords = dict(zip(target_dims, [target_index, target_columns]))
+    da = as_dataarray(df, coords=coords)
+    assert isinstance(da, DataArray)
+    assert da.dims == target_dims
+    assert list(da.coords[target_dims[0]].values) == target_index
+    assert list(da.coords[target_dims[1]].values) == target_columns
+
+
+def test_as_dataarray_with_ndarray_no_coords_no_dims():
+    target_dims = ("dim_0", "dim_1")
+    target_coords = [[0, 1], [0, 1]]
     arr = np.array([[1, 2], [3, 4]])
     da = as_dataarray(arr)
     assert isinstance(da, DataArray)
-    assert da.dims == ("dim_0", "dim_1")
-    assert list(da.coords["dim_0"].values) == list(range(arr.shape[0]))
-    assert list(da.coords["dim_1"].values) == list(range(arr.shape[1]))
+    assert da.dims == target_dims
+    for i, dim in enumerate(target_dims):
+        assert list(da.coords[dim]) == target_coords[i]
+
+
+def test_as_dataarray_with_ndarray_coords_list_no_dims():
+    target_dims = ("dim_0", "dim_1")
+    target_coords = [["a", "b"], ["A", "B"]]
+    arr = np.array([[1, 2], [3, 4]])
+    da = as_dataarray(arr, coords=target_coords)
+    assert isinstance(da, DataArray)
+    assert da.dims == target_dims
+    for i, dim in enumerate(target_dims):
+        assert list(da.coords[dim]) == target_coords[i]
+
+
+def test_as_dataarray_with_ndarray_coords_indexes_no_dims():
+    target_dims = ("dim1", "dim2")
+    target_coords = [
+        pd.Index(["a", "b"], name="dim1"),
+        pd.Index(["A", "B"], name="dim2"),
+    ]
+    arr = np.array([[1, 2], [3, 4]])
+    da = as_dataarray(arr, coords=target_coords)
+    assert isinstance(da, DataArray)
+    assert da.dims == target_dims
+    for i, dim in enumerate(target_dims):
+        assert list(da.coords[dim]) == list(target_coords[i])
+
+
+def test_as_dataarray_with_ndarray_coords_dict_set_no_dims():
+    "If no dims are given and coords are a dict, the keys of the dict should be used as dims."
+    target_dims = ("dim_0", "dim_2")
+    target_coords = {"dim_0": ["a", "b"], "dim_2": ["A", "B"]}
+    arr = np.array([[1, 2], [3, 4]])
+    da = as_dataarray(arr, coords=target_coords)
+    assert isinstance(da, DataArray)
+    assert da.dims == target_dims
+    for dim in target_dims:
+        assert list(da.coords[dim]) == target_coords[dim]
+
+
+def test_as_dataarray_with_ndarray_coords_list_dims():
+    target_dims = ("dim1", "dim2")
+    target_coords = [["a", "b"], ["A", "B"]]
+    arr = np.array([[1, 2], [3, 4]])
+    da = as_dataarray(arr, coords=target_coords, dims=target_dims)
+    assert isinstance(da, DataArray)
+    assert da.dims == target_dims
+    for i, dim in enumerate(target_dims):
+        assert list(da.coords[dim]) == target_coords[i]
+
+
+def test_as_dataarray_with_ndarray_coords_list_dims_superset():
+    target_dims = ("dim1", "dim2")
+    target_coords = [["a", "b"], ["A", "B"]]
+    arr = np.array([[1, 2], [3, 4]])
+    dims = [*target_dims, "dim3"]
+    da = as_dataarray(arr, coords=target_coords, dims=dims)
+    assert isinstance(da, DataArray)
+    assert da.dims == target_dims
+    for i, dim in enumerate(target_dims):
+        assert list(da.coords[dim]) == target_coords[i]
+
+
+def test_as_dataarray_with_ndarray_coords_list_dims_subset():
+    target_dims = ("dim0", "dim_1")
+    target_coords = [["a", "b"], ["A", "B"]]
+    arr = np.array([[1, 2], [3, 4]])
+    dims = ["dim0"]
+    da = as_dataarray(arr, coords=target_coords, dims=dims)
+    assert isinstance(da, DataArray)
+    assert da.dims == target_dims
+    for i, dim in enumerate(target_dims):
+        assert list(da.coords[dim]) == target_coords[i]
+
+
+def test_as_dataarray_with_ndarray_coords_indexes_dims_aligned():
+    target_dims = ("dim1", "dim2")
+    target_coords = [
+        pd.Index(["a", "b"], name="dim1"),
+        pd.Index(["A", "B"], name="dim2"),
+    ]
+    arr = np.array([[1, 2], [3, 4]])
+    da = as_dataarray(arr, coords=target_coords, dims=target_dims)
+    assert isinstance(da, DataArray)
+    assert da.dims == target_dims
+    for i, dim in enumerate(target_dims):
+        assert list(da.coords[dim]) == list(target_coords[i])
+
+
+def test_as_dataarray_with_ndarray_coords_indexes_dims_not_aligned():
+    target_dims = ("dim3", "dim4")
+    target_coords = [
+        pd.Index(["a", "b"], name="dim1"),
+        pd.Index(["A", "B"], name="dim2"),
+    ]
+    arr = np.array([[1, 2], [3, 4]])
+    with pytest.raises(ValueError):
+        as_dataarray(arr, coords=target_coords, dims=target_dims)
+
+
+def test_as_dataarray_with_ndarray_coords_dict_dims_aligned():
+    target_dims = ("dim_0", "dim_1")
+    target_coords = {"dim_0": ["a", "b"], "dim_1": ["A", "B"]}
+    arr = np.array([[1, 2], [3, 4]])
+    da = as_dataarray(arr, coords=target_coords, dims=target_dims)
+    assert isinstance(da, DataArray)
+    assert da.dims == target_dims
+    for dim in target_dims:
+        assert list(da.coords[dim]) == target_coords[dim]
+
+
+def test_as_dataarray_with_ndarray_coords_dict_set_dims_not_aligned():
+    target_dims = ("dim_0", "dim_1")
+    target_coords = {"dim_0": ["a", "b"], "dim_2": ["A", "B"]}
+    arr = np.array([[1, 2], [3, 4]])
+    with pytest.raises(ValueError):
+        as_dataarray(arr, coords=target_coords, dims=target_dims)
 
 
 def test_as_dataarray_with_number():

--- a/test/test_constraint.py
+++ b/test/test_constraint.py
@@ -241,9 +241,11 @@ def test_constraint_lhs_setter_with_variable(c, x):
 
 
 def test_constraint_lhs_setter_with_constant(c):
+    sizes = c.sizes
     c.lhs = 10
     assert (c.rhs == -10).all()
     assert c.lhs.nterm == 0
+    assert c.sizes["first"] == sizes["first"]
 
 
 def test_constraint_sign_setter(c):
@@ -263,8 +265,10 @@ def test_constraint_sign_setter_invalid(c):
 
 
 def test_constraint_rhs_setter(c):
+    sizes = c.sizes
     c.rhs = 2
     assert (c.rhs == 2).all()
+    assert c.sizes == sizes
 
 
 def test_constraint_rhs_setter_with_variable(c, x):


### PR DESCRIPTION
**Changes:**

The handling of `pandas` objects was improved. As `pandas` objects are fully aware of coordinates, their index and columns are now strictly taken into account. For example, when multiplying a `pandas.DataFrame` with a variable, linopy now checks the alignment of indexes and reindexes accordingly. Previously, if the axis shapes were the same, the indexes of the variable were inserted and the `pandas` indexes were effectively ignored. A warning has been added for cases where users should expect changes to the results with this version. **Important**: This does not apply to overwriting the coordinates when one expression is added to another, e.g. "x + df" still overwrites the index of "df" when the dimensional shapes are aligned.