### PR TITLE
expression: support Expression init with constant values (pandas, numpy, scalar)

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -1,8 +1,10 @@
 Release Notes
 =============
 
-.. Upcoming Version
-.. ----------------
+Upcoming Version
+----------------
+
+* It is now possible to create LinearExpression from a `pandas.DataFrame`, `pandas.Series`, a `numpy.array` or constant scalar values, e.g. `linopy.LinearExpression(df)`. This will create a LinearExpression with constants only and the coordinates of the DataFrame, Series or array as dimensions.
 
 
 Version 0.3.6

--- a/test/test_linear_expression.py
+++ b/test/test_linear_expression.py
@@ -62,8 +62,6 @@ def test_empty_linexpr(m):
 
 
 def test_linexpr_with_wrong_data(m):
-    with pytest.raises(ValueError):
-        LinearExpression(1, m)
 
     with pytest.raises(ValueError):
         LinearExpression(xr.Dataset({"a": [1]}), m)
@@ -101,6 +99,41 @@ def test_linexpr_with_data_without_coords(m):
     data = xr.Dataset({"vars": vars, "coeffs": coeffs})
     expr = LinearExpression(data, m)
     assert_linequal(expr, lhs)
+
+
+def test_linexpr_from_constant_dataarray(m):
+    const = xr.DataArray([1, 2], dims=["dim_0"])
+    expr = LinearExpression(const, m)
+    assert (expr.const == const).all()
+    assert expr.nterm == 0
+
+
+def test_linexpr_from_constant_pandas_series(m):
+    const = pd.Series([1, 2], index=pd.RangeIndex(2, name="dim_0"))
+    expr = LinearExpression(const, m)
+    assert (expr.const == const).all()
+    assert expr.nterm == 0
+
+
+def test_linexpr_from_constant_pandas_dataframe(m):
+    const = pd.DataFrame([[1, 2], [3, 4]], columns=["a", "b"])
+    expr = LinearExpression(const, m)
+    assert (expr.const == const).all()
+    assert expr.nterm == 0
+
+
+def test_linexpr_from_constant_numpy_array(m):
+    const = np.array([1, 2])
+    expr = LinearExpression(const, m)
+    assert (expr.const == const).all()
+    assert expr.nterm == 0
+
+
+def test_linexpr_from_constant_scalar(m):
+    const = 1
+    expr = LinearExpression(const, m)
+    assert (expr.const == const).all()
+    assert expr.nterm == 0
 
 
 def test_repr(m):


### PR DESCRIPTION
It is now possible to create LinearExpression from a `pandas.DataFrame`, `pandas.Series`, a `numpy.array` or constant scalar values, e.g. `linopy.LinearExpression(df)`. This will create a LinearExpression with constants only and the coordinates of the DataFrame, Series or array as dimensions.
