### PR TITLE
expression: ensure alignment with pandas dataframes and xarray dataarrays

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -6,6 +6,10 @@ Upcoming Version
 
 * It is now possible to create LinearExpression from a `pandas.DataFrame`, `pandas.Series`, a `numpy.array` or constant scalar values, e.g. `linopy.LinearExpression(df)`. This will create a LinearExpression with constants only and the coordinates of the DataFrame, Series or array as dimensions.
 
+**Bugfixes**
+
+* When grouping an expression or a variable by a `pandas.DataFrame` or a `xarray.DataArray`, the coordinates of the `groupby` object were not properly aligned. So in cases, when the `groupby` object was not indexed in the same way as the variable/expression, the `groupby` operation led to wrong results. This is fixed now.
+
 
 Version 0.3.6
 -------------

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -171,6 +171,7 @@ class LinearExpressionGroupby:
 
             int_map = None
             if isinstance(group, pd.DataFrame):
+                group = group.reindex(self.data.indexes[group.index.name])
                 int_map = get_index_map(*group.values.T)
                 orig_group = group
                 group = group.apply(tuple, axis=1).map(int_map)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ SOLVERS = [
     "mosek",
     "mindoptpy",
     "coptpy",
-    "xpress; platform_system != 'Darwin' or python_version < '3.11'",
+    "xpress; platform_system != 'Darwin' and python_version < '3.11'",
     "pyscipopt; platform_system != 'Darwin'",
 ]
 

--- a/test/test_linear_expression.py
+++ b/test/test_linear_expression.py
@@ -567,15 +567,7 @@ def test_linear_expression_groupby_with_series_false(v):
     groups = pd.Series([1] * 10 + [2] * 10, index=v.indexes["dim_2"])
     groups.name = "dim_2"
     with pytest.raises(ValueError):
-        grouped = expr.groupby(groups).sum()
-
-
-def test_linear_expression_groupby_with_series_false(v):
-    expr = 1 * v
-    groups = pd.Series([1] * 10 + [2] * 10, index=v.indexes["dim_2"])
-    groups.name = "dim_2"
-    with pytest.raises(ValueError):
-        grouped = expr.groupby(groups).sum()
+        expr.groupby(groups).sum()
 
 
 def test_linear_expression_groupby_with_dataframe(v):
@@ -583,11 +575,36 @@ def test_linear_expression_groupby_with_dataframe(v):
     groups = pd.DataFrame(
         {"a": [1] * 10 + [2] * 10, "b": list(range(4)) * 5}, index=v.indexes["dim_2"]
     )
-    grouped = expr.groupby(xr.DataArray(groups)).sum()
+    grouped = expr.groupby(groups).sum()
     index = pd.MultiIndex.from_frame(groups)
     assert "group" in grouped.dims
     assert set(grouped.data.group.values) == set(index.values)
     assert grouped.nterm == 3
+
+
+def test_linear_expression_groupby_with_dataarray(v):
+    expr = 1 * v
+    df = pd.DataFrame(
+        {"a": [1] * 10 + [2] * 10, "b": list(range(4)) * 5}, index=v.indexes["dim_2"]
+    )
+    groups = xr.DataArray(df)
+    grouped = expr.groupby(groups).sum()
+    index = pd.MultiIndex.from_frame(df)
+    assert "group" in grouped.dims
+    assert set(grouped.data.group.values) == set(index.values)
+    assert grouped.nterm == 3
+
+
+def test_linear_expression_groupby_with_dataframe_non_aligned(v):
+    expr = 1 * v
+    groups = pd.DataFrame(
+        {"a": [1] * 10 + [2] * 10, "b": list(range(4)) * 5}, index=v.indexes["dim_2"]
+    )
+    target = expr.groupby(groups).sum()
+
+    groups_non_aligned = groups[::-1]
+    grouped = expr.groupby(groups_non_aligned).sum()
+    assert_linequal(grouped, target)
 
 
 @pytest.mark.parametrize("use_fallback", [True, False])


### PR DESCRIPTION
When grouping an expression or a variable by a `pandas.DataFrame` or a `xarray.DataArray`, the coordinates of the `groupby` object were not properly aligned. So in cases, when the `groupby` object was not indexed in the same way as the variable/expression, the `groupby` operation led to wrong results. This is fixed now.
