### PR TITLE
constraints & varaibles: add formatted attribute getter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ benchmark/gurobi.log
 benchmark/notebooks/.ipynb_checkpoints
 benchmark/scripts/__pycache__
 benchmark/scripts/benchmarks-pypsa-eur/__pycache__
+benchmark/scripts/leftovers/

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -8,6 +8,7 @@ Upcoming Version
 
 * The LinearExpression and QuadraticExpression class have a new attribute `solution` which returns the optimal values of the expression if the underlying model was optimized.
 
+* It is now possible to access variables and constraints, that don't have python variable name format, as attributes from the corresponding containers. Therefore, a new formatting scheme was introduced which converts dashes and white spaces into underscores. For example, a variable was added to the model with the label "my-variable". This variable can now be accessed with `model.variables.my_variable`. In particular, the autocompletion function of the IPython console is aware of this new formatting scheme. This allows easy access to variables and constraints with long labels.
 
 Version 0.3.6
 -------------

--- a/linopy/common.py
+++ b/linopy/common.py
@@ -62,6 +62,19 @@ def maybe_replace_signs(sign):
     return apply_ufunc(func, sign, dask="parallelized", output_dtypes=[sign.dtype])
 
 
+def format_string_as_variable_name(name):
+    """
+    Format a string to a valid python variable name.
+
+    Parameters:
+        name (str): The name to be converted.
+
+    Returns:
+        str: The formatted name.
+    """
+    return name.replace(" ", "_").replace("-", "_")
+
+
 def get_from_list(lst: Optional[list], index: int):
     """
     Returns the element at the specified index of the list, or None if the index

--- a/linopy/constraints.py
+++ b/linopy/constraints.py
@@ -23,6 +23,7 @@ from linopy import expressions, variables
 from linopy.common import (
     LocIndexer,
     align_lines_by_delimiter,
+    format_string_as_variable_name,
     forward_as_properties,
     generate_indices_for_printout,
     get_label_position,
@@ -519,6 +520,14 @@ class Constraints:
         "Right-hand-side constants",
     ]
 
+    def _formatted_names(self):
+        """
+        Get a dictionary of formatted names to the proper constraint names.
+        This map enables a attribute like accession of variable names which
+        are not valid python variable names.
+        """
+        return {format_string_as_variable_name(n): n for n in self}
+
     def __repr__(self):
         """
         Return a string representation of the linopy model.
@@ -547,9 +556,18 @@ class Constraints:
         if name in self.data:
             return self.data[name]
         else:
-            raise AttributeError(
-                f"Constraints has no attribute `{name}` or the attribute is not accessible, e.g. raises an error."
-            )
+            if name in (formatted_names := self._formatted_names()):
+                return self.data[formatted_names[name]]
+        raise AttributeError(
+            f"Constraints has no attribute `{name}` or the attribute is not accessible, e.g. raises an error."
+        )
+
+    def __dir__(self):
+        base_attributes = super().__dir__()
+        formatted_names = [
+            n for n in self._formatted_names() if n not in base_attributes
+        ]
+        return base_attributes + formatted_names
 
     def __len__(self):
         return self.data.__len__()

--- a/test/test_constraints.py
+++ b/test/test_constraints.py
@@ -40,6 +40,13 @@ def test_constraint_assignment():
     assert_conequal(m.constraints.con0, con0)
 
 
+def test_constraints_getattr_formatted():
+    m = Model()
+    x = m.add_variables(0, 10, name="x")
+    m.add_constraints(1 * x == 0, name="con-0")
+    assert_conequal(m.constraints.con_0, m.constraints["con-0"])
+
+
 def test_anonymous_constraint_assignment():
     m = Model()
 

--- a/test/test_variables.py
+++ b/test/test_variables.py
@@ -26,6 +26,12 @@ def test_variables_repr(m):
     m.variables.__repr__()
 
 
+def test_variables_getattr_formatted():
+    m = Model()
+    m.add_variables(name="y-0")
+    assert_varequal(m.variables.y_0, m.variables["y-0"])
+
+
 def test_variables_assignment_with_merge():
     """
     Test the merger of a variables with same dimension name but with different


### PR DESCRIPTION
It is now possible to access variables and constraints, that don't have python variable name format, as attributes from the corresponding containers. Therefore, a new formatting scheme was introduced which converts dashes and white spaces into underscores. For example, a variable was added to the model with the label "my-variable". This variable can now be accessed with `model.variables.my_variable`. In particular, the autocompletion function of the IPython console is aware of this new formatting scheme. This allows easy access to variables and constraints with long labels.   
