### PR TITLE
Matmul and dot operation

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -10,6 +10,15 @@ Upcoming Version
 
 * It is now possible to access variables and constraints, that don't have python variable name format, as attributes from the corresponding containers. Therefore, a new formatting scheme was introduced which converts dashes and white spaces into underscores. For example, a variable was added to the model with the label "my-variable". This variable can now be accessed with `model.variables.my_variable`. In particular, the autocompletion function of the IPython console is aware of this new formatting scheme. This allows easy access to variables and constraints with long labels.
 
+* Variables and LinearExpressions now have a new method `dot`, which allows computing the dot product of two objects. This multiplies objects and sums over common dimensions.
+
+* The matmul operator `@`, which runs the `dot` operation, is now supported for Variables and LinearExpression.
+
+**Bugfixes**
+
+* The multiplication of two linear expression with non-zero constants led to wrong results of the cross terms. Given the multiplication `(v1 + c1)  * (v2 + c2)` with `v` being a variable and `c` a constant, the operation did not calculate the cross terms `v1 * c2 + v2 * c1`. This is fixed now.
+
+
 Version 0.3.6
 -------------
 

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -454,6 +454,16 @@ class LinearExpression:
         """
         return self.__mul__(other)
 
+    def __matmul__(self, other):
+        """
+        Matrix multiplication with other, similar to xarray dot.
+        """
+        if isinstance(other, (variables.Variable, variables.ScalarVariable)):
+            other = other.to_linexpr()
+
+        common_dims = list(set(self.coord_dims).intersection(other.coord_dims))
+        return (self * other).sum(dims=common_dims)
+
     def __div__(self, other):
         if isinstance(
             other, (LinearExpression, variables.Variable, variables.ScalarVariable)

--- a/linopy/testing.py
+++ b/linopy/testing.py
@@ -15,6 +15,11 @@ def assert_linequal(a, b):
     return assert_equal(_expr_unwrap(a), _expr_unwrap(b))
 
 
+def assert_quadequal(a, b):
+    """Assert that two linear expressions are equal."""
+    return assert_equal(_expr_unwrap(a), _expr_unwrap(b))
+
+
 def assert_conequal(a, b):
     """Assert that two constraints are equal."""
     return assert_equal(_con_unwrap(a), _con_unwrap(b))

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -291,6 +291,12 @@ class Variable:
         """
         return self.to_linexpr(other)
 
+    def __matmul__(self, other):
+        """
+        Matrix multiplication of variables with a coefficient.
+        """
+        return self.to_linexpr() @ other
+
     def __div__(self, other):
         """
         Divide variables with a coefficient.

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -388,6 +388,19 @@ class Variable:
         """
         return self.__div__(other)
 
+    def pow(self, other):
+        """
+        Power of the variables with a coefficient. The only coefficient allowed is 2.
+        """
+        return self.__pow__(other)
+
+    def dot(self, other):
+        """
+        Generalized dot product for linopy and compatible objects. Like np.einsum if performs a
+        multiplaction of the two objects with a subsequent summation over common dimensions.
+        """
+        return self.__matmul__(other)
+
     def groupby(
         self,
         group,

--- a/test/test_linear_expression.py
+++ b/test/test_linear_expression.py
@@ -414,7 +414,29 @@ def test_linear_expression_multiplication(x, y, z):
     assert (mexpr.coeffs.sel(dim_1=0, dim_0=0, _term=0) == 1 / 10).item()
 
 
-def test_matmul(x, y, z):
+def test_matmul_variable_and_const(x, y):
+    const = np.array([1, 2])
+    expr = x @ const
+    assert expr.nterm == 2
+    assert_linequal(expr, (x * const).sum())
+
+    assert_linequal(x @ const, (x * const).sum())
+
+    assert_linequal(x.dot(const), x @ const)
+
+
+def test_matmul_expr_and_const(x, y):
+    expr = 10 * x + y
+    const = np.array([1, 2])
+    res = expr @ const
+    target = (10 * x) @ const + y @ const
+    assert res.nterm == 4
+    assert_linequal(res, target)
+
+    assert_linequal(expr.dot(const), target)
+
+
+def test_matmul_wrong_input(x, y, z):
     expr = 10 * x + y + z
     with pytest.raises(TypeError):
         expr @ expr

--- a/test/test_linear_expression.py
+++ b/test/test_linear_expression.py
@@ -369,6 +369,12 @@ def test_linear_expression_multiplication(x, y, z):
     assert (mexpr.coeffs.sel(dim_1=0, dim_0=0, _term=0) == 1 / 10).item()
 
 
+def test_matmul(x, y, z):
+    expr = 10 * x + y + z
+    with pytest.raises(TypeError):
+        expr @ expr
+
+
 def test_linear_expression_multiplication_invalid(x, y, z):
     expr = 10 * x + y + z
 


### PR DESCRIPTION
**New Features**

* Variables and LinearExpressions now have a new method `dot`, which allows computing the dot product of two objects. This multiplies objects and sums over common dimensions.

* The matmul operator `@`, which runs the `dot` operation, is now supported for Variables and LinearExpression.

**Bugfixes**

* The multiplication of two linear expression with non-zero constants led to wrong results of the cross terms. Given the multiplication `(v1 + c1)  * (v2 + c2)` with `v` being a variable and `c` a constant, the operation did not calculate the cross terms `v1 * c2 + v2 * c1`. This is fixed now.
