### PR TITLE
avoid using highs_bindings, they are not needed and are removed in 1.7.1.dev

### DIFF
--- a/linopy/io.py
+++ b/linopy/io.py
@@ -512,7 +512,7 @@ def to_highspy(m):
 
     # change objective sense
     if m.objective.sense == "max":
-        h.changeObjectiveSense(highspy.highs_bindings.ObjSense.kMaximize)
+        h.changeObjectiveSense(highspy.ObjSense.kMaximize)
 
     return h
 


### PR DESCRIPTION
Mini change to get `ObjSense.kMaximize` directly from `highspy` instead of `highspy.highs_bindings`.

This will make linopy compatible with the dev version `1.7.1.dev1` of highspy, while keeping it compatible with the current stable version `1.5.3`.

However, when running the tests, I noticed that all `.mps` tests fail for `test/test_optimization.py::test_model_maximization`, as the `.mps` file generated with `1.7.1.dev1` no longer flips the objective coefficients, but instead uses `OBJSENSE MAX`.

`1.5.3` file:
```
NAME        
ROWS
 N  Obj     
 L  c0      
 L  c1      
COLUMNS
    x0        Obj       -1
    x0        c0        2
    x0        c1        4
    x1        Obj       -2
    x1        c0        6
    x1        c1        2
RHS
    RHS_V     c0        10
    RHS_V     c1        3
BOUNDS
 FR BOUND     x0      
 FR BOUND     x1      
ENDATA
```

`1.7.1.dev1` file:
```
NAME        
OBJSENSE
  MAX
ROWS
 N  Obj     
 L  c0      
 L  c1      
COLUMNS
    x0        Obj       1
    x0        c0        2
    x0        c1        4
    x1        Obj       2
    x1        c0        6
    x1        c1        2
RHS
    RHS_V     c0        10
    RHS_V     c1        3
BOUNDS
 FR BOUND     x0      
 FR BOUND     x1      
ENDATA
```

As `1.7.1.dev1` is no stable version, I didn't adjust the code for this change.