### PR TITLE
Added the new pdlp solver (highs > 1.7) to the description, added warning

### DIFF
--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -386,7 +386,7 @@ def run_highs(
     Some exemplary options are:
 
         * presolve : "choose" by default - "on"/"off" are alternatives.
-        * solver :"choose" by default - "simplex"/"ipm" are alternatives.
+        * solver :"choose" by default - "simplex"/"ipm"/"pdlp" are alternatives. Only "choose" solves MIP / QP!
         * parallel : "choose" by default - "on"/"off" are alternatives.
         * time_limit : inf by default.
 
@@ -403,12 +403,12 @@ def run_highs(
     CONDITION_MAP = {}
 
     if warmstart_fn:
-        logger.warning("Warmstart not available with HiGHS solver. Ignore argument.")
+        logger.warning("Warmstart not implemented. Ignoring argument.")
 
-    if solver_options.get("solver") in ["simplex", "ipm"] and model.type == "QP":
+    if solver_options.get("solver") in ["simplex", "ipm", "pdlp"] and model.type in ["QP", "MILP"]:
         logger.warning(
-            "The HiGHS solver ignores quadratic terms if the solver is set to 'simplex' or 'ipm'. "
-            "Drop the solver option or use 'choose' to enable quadratic terms."
+            "The HiGHS solver ignores quadratic terms / integrality if the solver is set to 'simplex', 'ipm' or 'pdlp'. "
+            "Drop the solver option or use 'choose' to enable quadratic terms / integrality."
         )
 
     if io_api is None or io_api in ["lp", "mps"]:

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -405,7 +405,10 @@ def run_highs(
     if warmstart_fn:
         logger.warning("Warmstart not implemented. Ignoring argument.")
 
-    if solver_options.get("solver") in ["simplex", "ipm", "pdlp"] and model.type in ["QP", "MILP"]:
+    if solver_options.get("solver") in ["simplex", "ipm", "pdlp"] and model.type in [
+        "QP",
+        "MILP",
+    ]:
         logger.warning(
             "The HiGHS solver ignores quadratic terms / integrality if the solver is set to 'simplex', 'ipm' or 'pdlp'. "
             "Drop the solver option or use 'choose' to enable quadratic terms / integrality."


### PR DESCRIPTION
MIP warning probably relevant to most users; Highs solver is a bit special there, it just ignores integrality without notice.