### PR TITLE
Add a subsection for modification of variable bounds in docs

### DIFF
--- a/examples/creating-variables.ipynb
+++ b/examples/creating-variables.ipynb
@@ -348,7 +348,7 @@
    "outputs": [],
    "source": [
     "other = Model(force_dim_names=True)\n",
-    "try: \n",
+    "try:\n",
     "    other.add_variables(lower=lower, coords=coords)\n",
     "except ValueError as e:\n",
     "    print(\"This raised an error:\", e)"
@@ -587,6 +587,44 @@
    "outputs": [],
    "source": [
     "m.variables.x"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Modifying variable bounds\n",
+    "\n",
+    "You can modify the bounds of the variables after instantiation like this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.variables.x.lower = 7\n",
+    "m.variables.x.upper = 42\n",
+    "m.variables.x"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you want to change the bounds of a variable on specific dimensions, you have\n",
+    "to access the respective bound and make the slicing on that:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.variables.supply.lower.loc[1, :] = 4\n",
+    "m.variables.supply"
    ]
   }
  ],


### PR DESCRIPTION
I was trying to modify variable bounds instead of creating additional constraints for already instantiated variables and could not find a subsection in the respective chapter. It does not work with something like `variable.loc[slice, other_slice].lower = 42` and I did not immediately understand why, so I thought a hint on how to do this might be useful.

If this is bad practice, I would be happy to get a rejection of the PR (and also be curious why it would be :)).

Thank you!

