### PR TITLE
Update JuMP syntax in syntax.rst

### DIFF
--- a/doc/syntax.rst
+++ b/doc/syntax.rst
@@ -25,9 +25,9 @@ In ``JuMP`` the formulation translates to the following code:
         m = Model()
         @variable(m, x[1:N, 1:N])
         @variable(m, y[1:N, 1:N])
-        @constraint(m, [i=1:N, j=1:N], x[i, j] - y[i, j] >= i)
-        @constraint(m, [i=1:N, j=1:N], x[i, j] + y[i, j] >= 0)
-        @objective(m, Min, sum(2 * x[i, j] + y[i, j] for i in 1:N, j in 1:N))
+        @constraint(m, x - y .>= 0:(N-1))
+        @constraint(m, x + y .>= 0)
+        @objective(m, Min, 2 * sum(x) + sum(y))
         return m
     end
 
@@ -48,7 +48,7 @@ The same model in ``linopy`` is initialized by
          m.add_objective((2 * x).sum() + y.sum())
          return m
 
-Note that the syntax is quiet similar. An important difference lays in the fact that ``linopy`` operates all arithmetic operations on **variable arrays**, while the JuMP syntax uses control variables `i` and `j`.
+Note that the syntax is quite similar.
 
 In ``Pyomo`` the code would look like
 

--- a/doc/syntax.rst
+++ b/doc/syntax.rst
@@ -8,7 +8,7 @@ In order to compare the syntax between different API's, let's initialize the fol
 
     & \min \;\; \sum_{i,j} 2 x_{i,j} + \; y_{i,j} \\
     s.t. & \\
-    & x_{i,j} - y_{i,j} \; \ge \; i \qquad \forall \; i,j \in \{1,...,N\} \\
+    & x_{i,j} - y_{i,j} \; \ge \; i-1 \qquad \forall \; i,j \in \{1,...,N\} \\
     & x_{i,j} + y_{i,j} \; \ge \; 0 \qquad \forall \; i,j \in \{1,...,N\}
 
 


### PR DESCRIPTION
I saw @pz-max's comment in https://github.com/PyPSA/linopy/issues/271.

This PR just updates to match the benchmark implementation:
https://github.com/PyPSA/linopy/blob/5d61f958a9b805d4c41ecb606a223d1125fa67c0/benchmark/scripts/benchmark_jump.jl#L9-L18 

It's fair that most people probably write out the scalar `I` and `j` version though, so up to you whether you want to merge this.