### PR TITLE
Improve run_gurobi to wait for available token

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -14,6 +14,8 @@ Upcoming Version
 
 * Up to now the `rhs` argument in the `add_constraints` function was not supporting an expression as an input type. This is now added.
 
+* Improve `run_gurobi` to optionally wait for an available token.
+
 Version 0.3.8
 -------------
 


### PR DESCRIPTION
When using a Gurobi floating token server license or a web single-use license, a program that calls Gurobi Optimizer must obtain a token from a Gurobi token server before it can solve an optimization model. When no token is available, an exception `gurobipy.GurobiError` is raised (source : https://support.gurobi.com/hc/en-us/articles/360029879251-How-do-I-check-the-availability-of-floating-license-tokens).

To avoid Gurobi Optimizer throwing an error, I suggest to optionally wait for an available token. This is the purpose of this PR. The waiting time (in seconds) can be configured in the solver options.

Side note : This enables scenarios in PyPSA-Eur.
