### PR TITLE
Consolidate getitem functionality

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -5,6 +5,13 @@ Upcoming Version
 ----------------
 
 
+Version 0.3.10
+--------------
+
+* The classes `Variable`, `LinearExpression` and `Constraint` now have a new `getitem` method that allows selecting a subset of the object in the same way as `xarray` objects, i.e. by labels or boolean index. Example usage: `x[['a', 'b']]` or `x[x.indexes["some_index"] > 5]`.
+
+
+
 Version 0.3.9
 -------------
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -8,8 +8,11 @@ Upcoming Version
 Version 0.3.10
 --------------
 
-* The classes `Variable`, `LinearExpression` and `Constraint` now have a new `getitem` method that allows selecting a subset of the object in the same way as `xarray` objects, i.e. by labels or boolean index. Example usage: `x[['a', 'b']]` or `x[x.indexes["some_index"] > 5]`.
+* The classes `Variable`, `LinearExpression` and `Constraint` now have a new `getitem` method that allows selecting a subset of the object in the same way as `xarray` objects, i.e. by integer labels or boolean index. Example usage: `x[[1, 2]]` or `x[x.indexes["some_index"] > 5]`.
 
+* The class `Constraint` now has a new method `.loc` to select a subset of the constraint by labels.
+
+* Selecting a single variable with the `getitem` (`[]`) method now raises a `FutureWarning` that the return type will change to `Variable` instead of a `ScalarVariable` in the future. To get a `ScalarVariable` in the future, use the `at[]` method.
 
 
 Version 0.3.9

--- a/examples/migrating-from-pyomo.ipynb
+++ b/examples/migrating-from-pyomo.ipynb
@@ -33,7 +33,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x[0, 'a']"
+    "x.at[0, 'a']"
    ]
   },
   {
@@ -41,6 +41,11 @@
    "id": "a1631a76",
    "metadata": {},
    "source": [
+    ".. important::\n",
+    "    The creation of scalar variables has changed in version `0.3.10` to use the `.at[]` method. The previous method of using the `[]` operator is still supported but will be removed in a future.  \n",
+    "\n",
+    "\n",
+    "\n",
     "Such a `ScalarVariable` is very light-weight and can be used in functions in order to create expressions, just like you know it from `Pyomo`. The following function shows how:"
    ]
   },
@@ -53,9 +58,9 @@
    "source": [
     "def bound(m, i, j):\n",
     "     if i % 2:\n",
-    "         return (i / 2) * x[i, j]\n",
+    "         return (i / 2) * x.at[i, j]\n",
     "     else:\n",
-    "         return i * x[i, j]\n",
+    "         return i * x.at[i, j]\n",
     "\n",
     "expr = m.linexpr(bound, coords)\n",
     "expr"
@@ -84,7 +89,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x[0, 'a'] <= 3"
+    "x.at[0, 'a'] <= 3"
    ]
   },
   {
@@ -96,9 +101,9 @@
    "source": [
     "def bound(m, i, j):\n",
     "     if i % 2:\n",
-    "         return (i / 2) * x[i, j] >= i\n",
+    "         return (i / 2) * x.at[i, j] >= i\n",
     "     else:\n",
-    "         return i * x[i, j]  == 0.\n",
+    "         return i * x.at[i, j]  == 0.\n",
     "\n",
     "con = m.add_constraints(bound, coords=coords)\n",
     "con"

--- a/examples/migrating-from-pyomo.ipynb
+++ b/examples/migrating-from-pyomo.ipynb
@@ -42,7 +42,7 @@
    "metadata": {},
    "source": [
     ".. important::\n",
-    "    The creation of scalar variables has changed in version `0.3.10` to use the `.at[]` method. The previous method of using the `[]` operator is still supported but will be removed in a future.  \n",
+    "    The creation of scalar variables has changed in version `0.3.10` to use the `.at[]` method. When creating a `ScalarVariable` with the `[]` operator, a future warning is raised. The `[]` operator will reserver for integer and boolean indexing only, aligning to the xarray functionality. \n",
     "\n",
     "\n",
     "\n",

--- a/linopy/constraints.py
+++ b/linopy/constraints.py
@@ -120,6 +120,19 @@ class Constraint:
         self._data = data
         self._model = model
 
+    def __getitem__(self, selector) -> "Constraints":
+        """
+        Get selection from the constraint.
+        This is a wrapper around the xarray __getitem__ method. It returns a
+        new object with the selected data.
+        """
+        data = Dataset({k: self.data[k][selector] for k in self.data}, attrs=self.attrs)
+        return self.__class__(data, self.model, self.name)
+
+    @property
+    def loc(self):
+        return LocIndexer(self)
+
     @property
     def data(self):
         """
@@ -591,10 +604,6 @@ class Constraints:
         Remove constraint `name` from the constraints.
         """
         self.data.pop(name)
-
-    @property
-    def loc(self):
-        return LocIndexer(self)
 
     @property
     def labels(self):

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -344,6 +344,15 @@ class LinearExpression:
         self._model = model
         self._data = data
 
+    def __getitem__(self, selector) -> Union["LinearExpression", "QuadraticExpression"]:
+        """
+        Get selection from the expression.
+        This is a wrapper around the xarray __getitem__ method. It returns a
+        new LinearExpression object with the selected data.
+        """
+        data = Dataset({k: self.data[k][selector] for k in self.data}, attrs=self.attrs)
+        return self.__class__(data, self.model)
+
     def __repr__(self):
         """
         Print the expression arrays.

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -344,15 +344,6 @@ class LinearExpression:
         self._model = model
         self._data = data
 
-    def __getitem__(self, selector) -> Union["LinearExpression", "QuadraticExpression"]:
-        """
-        Get selection from the expression.
-        This is a wrapper around the xarray __getitem__ method. It returns a
-        new LinearExpression object with the selected data.
-        """
-        data = Dataset({k: self.data[k][selector] for k in self.data}, attrs=self.attrs)
-        return self.__class__(data, self.model)
-
     def __repr__(self):
         """
         Print the expression arrays.
@@ -588,6 +579,15 @@ class LinearExpression:
         Matrix multiplication with other, similar to xarray dot.
         """
         return self.__matmul__(other)
+
+    def __getitem__(self, selector) -> Union["LinearExpression", "QuadraticExpression"]:
+        """
+        Get selection from the expression.
+        This is a wrapper around the xarray __getitem__ method. It returns a
+        new LinearExpression object with the selected data.
+        """
+        data = Dataset({k: self.data[k][selector] for k in self.data}, attrs=self.attrs)
+        return self.__class__(data, self.model)
 
     @property
     def loc(self):

--- a/test/test_constraint.py
+++ b/test/test_constraint.py
@@ -153,9 +153,9 @@ def test_anonymous_constraint_with_expression_on_both_sides(x, y):
 
 
 def test_anonymous_scalar_constraint_with_scalar_variable_on_rhs(x, y):
-    expr = 10 * x[0] + y[1]
+    expr = 10 * x.at[0] + y.at[1]
     with pytest.raises(TypeError):
-        con = expr == x[0]
+        con = expr == x.at[0]
         # assert isinstance(con.lhs, LinearExpression)
         # assert (con.sign == EQUAL).all()
         # assert (con.rhs == 0).all()
@@ -167,9 +167,21 @@ def test_anonymous_constraint_sel(x, y):
     assert isinstance(con.sel(first=[1, 2]), Constraint)
 
 
+def test_anonymous_constraint_loc(x, y):
+    expr = 10 * x + y
+    con = expr <= 10
+    assert isinstance(con.loc[[1, 2]], Constraint)
+
+
+def test_anonymous_constraint_getitem(x, y):
+    expr = 10 * x + y
+    con = expr <= 10
+    assert isinstance(con[1], Constraint)
+
+
 def test_constraint_from_rule(m, x, y):
     def bound(m, i, j):
-        return (i - 1) * x[i - 1] + y[j] >= 0 if i % 2 else i * x[i] >= 0
+        return (i - 1) * x.at[i - 1] + y.at[j] >= 0 if i % 2 else i * x.at[i] >= 0
 
     coords = [x.coords["first"], y.coords["second"]]
     con = Constraint.from_rule(m, bound, coords)
@@ -181,7 +193,7 @@ def test_constraint_from_rule(m, x, y):
 def test_constraint_from_rule_with_none_return(m, x, y):
     def bound(m, i, j):
         if i % 2:
-            return i * x[i] + y[j] >= 0
+            return i * x.at[i] + y.at[j] >= 0
 
     coords = [x.coords["first"], y.coords["second"]]
     con = Constraint.from_rule(m, bound, coords)

--- a/test/test_linear_expression.py
+++ b/test/test_linear_expression.py
@@ -264,7 +264,11 @@ def test_linear_expression_with_errors(m, x):
 
 def test_linear_expression_from_rule(m, x, y):
     def bound(m, i):
-        return (i - 1) * x[i - 1] + y[i] + 1 * x[i] if i == 1 else i * x[i] - y[i]
+        return (
+            (i - 1) * x.at[i - 1] + y.at[i] + 1 * x.at[i]
+            if i == 1
+            else i * x.at[i] - y.at[i]
+        )
 
     expr = LinearExpression.from_rule(m, bound, x.coords)
     assert isinstance(expr, LinearExpression)
@@ -276,7 +280,7 @@ def test_linear_expression_from_rule_with_return_none(m, x, y):
     # with return type None
     def bound(m, i):
         if i == 1:
-            return (i - 1) * x[i - 1] + y[i]
+            return (i - 1) * x.at[i - 1] + y.at[i]
 
     expr = LinearExpression.from_rule(m, bound, x.coords)
     assert isinstance(expr, LinearExpression)
@@ -462,6 +466,34 @@ def test_linear_expression_multiplication_invalid(x, y, z):
     with pytest.raises(TypeError):
         expr = 10 * x + y + z
         expr / x
+
+
+def test_linear_expression_getitem_single(x, y):
+    expr = 10 * x + y + 3
+    sel = expr[0]
+    assert isinstance(sel, LinearExpression)
+    assert sel.nterm == 2
+    # one expression with two terms (constant is not counted)
+    assert sel.size == 2
+
+
+def test_linear_expression_getitem_slice(x, y):
+    expr = 10 * x + y + 3
+    sel = expr[:1]
+
+    assert isinstance(sel, LinearExpression)
+    assert sel.nterm == 2
+    # one expression with two terms (constant is not counted)
+    assert sel.size == 2
+
+
+def test_linear_expression_getitem_list(x, y, z):
+    expr = 10 * x + z + 10
+    sel = expr[:, [0, 2]]
+    assert isinstance(sel, LinearExpression)
+    assert sel.nterm == 2
+    # four expressions with two terms (constant is not counted)
+    assert sel.size == 8
 
 
 def test_linear_expression_loc(x, y):

--- a/test/test_repr.py
+++ b/test/test_repr.py
@@ -90,7 +90,7 @@ def test_variable_repr(var):
 @pytest.mark.parametrize("var", variables)
 def test_scalar_variable_repr(var):
     coord = tuple(var.indexes[c][0] for c in var.dims)
-    repr(var[coord])
+    repr(var.at[coord])
 
 
 @pytest.mark.parametrize("var", variables)
@@ -111,7 +111,7 @@ def test_linear_expression_long():
 @pytest.mark.parametrize("var", variables)
 def test_scalar_linear_expression_repr(var):
     coord = tuple(var.indexes[c][0] for c in var.dims)
-    repr(1 * var[coord])
+    repr(1 * var.at[coord])
 
 
 @pytest.mark.parametrize("var", variables)
@@ -132,7 +132,7 @@ def test_anonymous_constraint_repr(con):
 
 
 def test_scalar_constraint_repr():
-    repr(u[0, 0] >= 0)
+    repr(u.at[0, 0] >= 0)
 
 
 @pytest.mark.parametrize("var", variables)

--- a/test/test_scalar_constraint.py
+++ b/test/test_scalar_constraint.py
@@ -22,22 +22,22 @@ def x(m):
 
 
 def test_scalar_constraint_repr(x):
-    c = x[0] >= 0
+    c = x.at[0] >= 0
     c.__repr__()
 
 
 def test_scalar_constraint_initialization(m, x):
-    c = x[0] >= 0
+    c = x.at[0] >= 0
     assert isinstance(c, linopy.constraints.AnonymousScalarConstraint)
 
-    c = m.add_constraints(x[0] >= 0)
+    c = m.add_constraints(x.at[0] >= 0)
     assert isinstance(c, linopy.constraints.Constraint)
 
-    c = m.add_constraints(x[0] + x[1] >= 0)
+    c = m.add_constraints(x.at[0] + x.at[1] >= 0)
     assert isinstance(c, linopy.constraints.Constraint)
 
-    c = m.add_constraints(x[0], GREATER_EQUAL, 0)
+    c = m.add_constraints(x.at[0], GREATER_EQUAL, 0)
     assert isinstance(c, linopy.constraints.Constraint)
 
-    c = m.add_constraints(x[0] + x[1], GREATER_EQUAL, 0)
+    c = m.add_constraints(x.at[0] + x.at[1], GREATER_EQUAL, 0)
     assert isinstance(c, linopy.constraints.Constraint)

--- a/test/test_scalar_linear_expression.py
+++ b/test/test_scalar_linear_expression.py
@@ -31,22 +31,22 @@ def z(m):
 
 
 def test_scalar_expression_initialization(x, y, z):
-    expr = 10 * x[0]
+    expr = 10 * x.at[0]
     assert isinstance(expr, ScalarLinearExpression)
 
-    expr = 10 * x[0] + y[1] + z[1, 1]
+    expr = 10 * x.at[0] + y.at[1] + z.at[1, 1]
     assert isinstance(expr, ScalarLinearExpression)
 
 
 def test_scalar_expression_multiplication(x):
-    expr = 10 * x[0]
+    expr = 10 * x.at[0]
     expr2 = 2 * expr
     assert isinstance(expr2, ScalarLinearExpression)
     assert expr2.coeffs == (20,)
 
 
 def test_scalar_expression_division(x):
-    expr = 10 * x[0]
+    expr = 10 * x.at[0]
     expr2 = expr / 2
     assert isinstance(expr2, ScalarLinearExpression)
     assert expr2.coeffs == (5,)
@@ -57,7 +57,7 @@ def test_scalar_expression_division(x):
 
 
 def test_scalar_expression_negation(x):
-    expr = 10 * x[0]
+    expr = 10 * x.at[0]
     expr3 = -expr
     assert isinstance(expr3, ScalarLinearExpression)
     assert expr3.coeffs == (-10,)
@@ -65,25 +65,25 @@ def test_scalar_expression_negation(x):
 
 def test_scalar_expression_multiplication_raises_type_error(x):
     with pytest.raises(TypeError):
-        x[1] * x[1]
+        x.at[1] * x.at[1]
 
 
 def test_scalar_expression_division_raises_type_error(x):
     with pytest.raises(TypeError):
-        x[1] / x[1]
+        x.at[1] / x.at[1]
 
 
 def test_scalar_expression_sum(x, y, z):
-    target = 10 * x[0] + y[1] + z[1, 1]
-    expr = sum((10 * x[0], y[1], z[1, 1]))
+    target = 10 * x.at[0] + y.at[1] + z.at[1, 1]
+    expr = sum((10 * x.at[0], y.at[1], z.at[1, 1]))
     assert isinstance(expr, ScalarLinearExpression)
     assert expr.vars == target.vars
     assert expr.coeffs == target.coeffs
 
 
 def test_scalar_expression_sum_from_variables(x, y):
-    target = x[0] + y[0]
-    expr = sum((x[0], y[0]))
+    target = x.at[0] + y.at[0]
+    expr = sum((x.at[0], y.at[0]))
     assert isinstance(expr, ScalarLinearExpression)
     assert expr.vars == target.vars
     assert expr.coeffs == target.coeffs

--- a/test/test_variable.py
+++ b/test/test_variable.py
@@ -13,6 +13,7 @@ import xarray as xr
 from xarray.testing import assert_equal
 
 import linopy
+import linopy.variables
 from linopy import Model
 
 
@@ -62,18 +63,35 @@ def test_wrong_variable_init(m, x):
 
 
 def test_variable_getter(x, z):
-    assert isinstance(x[0], linopy.variables.ScalarVariable)
 
-    assert isinstance(z[0], linopy.variables.ScalarVariable)
+    with pytest.warns(FutureWarning):
+        assert isinstance(x[0], linopy.variables.ScalarVariable)
+        assert isinstance(z[0], linopy.variables.ScalarVariable)
 
+    assert isinstance(x.at[0], linopy.variables.ScalarVariable)
+
+
+def test_variable_getter_slice(x):
+    res = x[:5]
+    assert isinstance(res, linopy.Variable)
+    assert res.size == 5
+
+
+def test_variable_getter_slice_with_step(x):
+    res = x[::2]
+    assert isinstance(res, linopy.Variable)
+    assert res.size == 5
+
+
+def test_variables_getter_list(x):
+    res = x[[1, 2, 3]]
+    assert isinstance(res, linopy.Variable)
+    assert res.size == 3
+
+
+def test_variable_getter_invalid_shape(x):
     with pytest.raises(AssertionError):
-        x[0, 0]
-
-    with pytest.raises(AssertionError):
-        x[:5]
-
-    with pytest.raises(AssertionError):
-        x[[1, 2, 3]]
+        x.at[0, 0]
 
 
 def test_variable_loc(x):
@@ -158,13 +176,13 @@ def test_variable_where(x):
     assert isinstance(x, linopy.variables.Variable)
     assert x.labels[9] == x._fill_value["labels"]
 
-    x = x.where([True] * 4 + [False] * 6, x[0])
+    x = x.where([True] * 4 + [False] * 6, x.at[0])
     assert isinstance(x, linopy.variables.Variable)
-    assert x.labels[9] == x[0].label
+    assert x.labels[9] == x.at[0].label
 
     x = x.where([True] * 4 + [False] * 6, x.loc[0])
     assert isinstance(x, linopy.variables.Variable)
-    assert x.labels[9] == x[0].label
+    assert x.labels[9] == x.at[0].label
 
 
 def test_variable_where_deprecation_warning(x):
@@ -190,7 +208,7 @@ def test_variable_fillna(x):
     with pytest.warns(FutureWarning):
         x.fillna(0)
 
-    isinstance(x.fillna(x[0]), linopy.variables.Variable)
+    isinstance(x.fillna(x.at[0]), linopy.variables.Variable)
 
 
 def test_variable_bfill(x):


### PR DESCRIPTION
From release notes:

* The classes `Variable`, `LinearExpression` and `Constraint` now have a new `getitem` method that allows selecting a subset of the object in the same way as `xarray` objects, i.e. by integer labels or boolean index. Example usage: `x[[1, 2]]` or `x[x.indexes["some_index"] > 5]`.

* The class `Constraint` now has a new method `.loc` to select a subset of the constraint by labels.

* Selecting a single variable with the `getitem` (`[]`) method now raises a `FutureWarning` that the return type will change to `Variable` instead of a `ScalarVariable` in the future. To get a `ScalarVariable` in the future, use the `at[]` method.
