### PR TITLE
Fh/fix 266

### DIFF
--- a/linopy/matrices.py
+++ b/linopy/matrices.py
@@ -31,6 +31,14 @@ class MatrixAccessor:
     def __init__(self, model):
         self._parent = model
 
+    def clean_cached_properties(self):
+        "Clear the cache for all cached properties of an object"
+
+        for cached_prop in ["flat_vars", "flat_cons", "sol", "dual"]:
+            # check existence of cached_prop without creating it
+            if cached_prop in self.__dict__:
+                delattr(self, cached_prop)
+
     @cached_property
     def flat_vars(self):
         m = self._parent

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -998,11 +998,8 @@ class Model:
             Tuple containing the status and termination condition of the
             optimization process.
         """
-        # clear cached matrix properties from potentially present from previous solve commands
-        for cached_prop in ["flat_vars", "flat_cons", "sol", "dual"]:
-            # check existence of cached_prop without creating it
-            if cached_prop in self.matrices.__dict__:
-                delattr(self.matrices, cached_prop)
+        # clear cached matrix properties potentially present from previous solve commands
+        self.matrices.clean_cached_properties()
 
         if remote:
             solved = remote.solve_on_remote(

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -998,6 +998,12 @@ class Model:
             Tuple containing the status and termination condition of the
             optimization process.
         """
+        # clear cached matrix properties from potentially present from previous solve commands
+        for cached_prop in ["flat_vars", "flat_cons", "sol", "dual"]:
+            # check existence of cached_prop without creating it
+            if cached_prop in self.matrices.__dict__:
+                delattr(self.matrices, cached_prop)
+
         if remote:
             solved = remote.solve_on_remote(
                 self,

--- a/test/test_optimization.py
+++ b/test/test_optimization.py
@@ -651,6 +651,22 @@ def test_solver_attribute_getter(model, solver, io_api):
         assert set(rc) == set(model.variables)
 
 
+@pytest.mark.parametrize("solver,io_api", params)
+def test_model_resolve(model, solver, io_api):
+    status, condition = model.solve(solver, io_api=io_api)
+    assert status == "ok"
+    # x = -0.1, y = 1.7
+    assert np.isclose(model.objective.value, 3.3)
+
+    # add another constraint after solve
+    model.add_constraints(model.variables.y >= 3)
+
+    status, condition = model.solve(solver, io_api=io_api)
+    assert status == "ok"
+    # x = -0.75, y = 3.0
+    assert np.isclose(model.objective.value, 5.25)
+
+
 # def init_model_large():
 #     m = Model()
 #     time = pd.Index(range(10), name="time")


### PR DESCRIPTION
fix #266 

cached properties of the model's `MatrixAccessor` are cleared (if existent) at the start of `solve`, to avoid using old cached data on resolving the model after modification.

I also added a pytest for this, which failed before and works now.