### PR TITLE
Workflow for auto releasing on GH

### DIFF
--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -1,0 +1,17 @@
+name: Release on GitHub
+
+on:
+  push:
+    tags:
+      - v*.*.*
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          generate_release_notes: true


### PR DESCRIPTION
Continuing on #283 I suggest to add a workflow for auto releasing on GitHub. This can be done by using the action `gh-release`. One can configure it, so that it auto generates the release notes as well (Same outcome as using the button from the web GUI).

I marked this as draft for two reasons:
- Need to discuss if combine this into the existing workflow `.github/workflows/deploy.yml`
- The job in this PR filters the tag, as linopy uses `v*.*.*` as the tag for releases and you don't want to make a release for every tag. Need to discuss if adding this filter to the `.github/workflows/deploy.yml` as well.