### PR TITLE
Make polars frames lazy and stream into csv

### DIFF
--- a/linopy/common.py
+++ b/linopy/common.py
@@ -260,7 +260,7 @@ def check_has_nulls(df: pd.DataFrame, name: str):
         raise ValueError(f"{name} contains nan's in field(s) {fields}")
 
 
-def infer_schema_polars(ds: pl.DataFrame) -> dict:
+def infer_schema_polars(ds: Dataset, overwrites: dict[str, pl.DataType]) -> dict:
     """
     Infer the schema for a Polars DataFrame based on the data types of its columns.
 
@@ -272,7 +272,9 @@ def infer_schema_polars(ds: pl.DataFrame) -> dict:
     """
     schema = {}
     for col_name, array in ds.items():
-        if np.issubdtype(array.dtype, np.integer):
+        if col_name in overwrites:
+            schema[col_name] = overwrites[col_name]
+        elif np.issubdtype(array.dtype, np.integer):
             schema[col_name] = pl.Int32 if os.name == "nt" else pl.Int64
         elif np.issubdtype(array.dtype, np.floating):
             schema[col_name] = pl.Float64

--- a/linopy/common.py
+++ b/linopy/common.py
@@ -303,10 +303,10 @@ def to_polars(ds: Dataset, **kwargs) -> pl.DataFrame:
         DataFrame constructor.
     """
     data = broadcast(ds)[0]
-    return pl.DataFrame({k: v.values.reshape(-1) for k, v in data.items()}, **kwargs)
+    return pl.LazyFrame({k: v.values.reshape(-1) for k, v in data.items()}, **kwargs)
 
 
-def check_has_nulls_polars(df: pl.DataFrame, name: str = "") -> None:
+def check_has_nulls_polars(df: pl.LazyFrame, name: str = "") -> None:
     """
     Checks if the given DataFrame contains any null values and raises a ValueError if it does.
 
@@ -318,7 +318,7 @@ def check_has_nulls_polars(df: pl.DataFrame, name: str = "") -> None:
         ValueError: If the DataFrame contains null values,
         a ValueError is raised with a message indicating the name of the constraint and the fields containing null values.
     """
-    has_nulls = df.select(pl.col("*").is_null().any())
+    has_nulls = df.select(pl.col("*").is_null().any()).collect()
     null_columns = [col for col in has_nulls.columns if has_nulls[col][0]]
     if null_columns:
         raise ValueError(f"{name} contains nan's in field(s) {null_columns}")
@@ -347,7 +347,7 @@ def filter_nulls_polars(df: pl.DataFrame) -> pl.DataFrame:
     return df.filter(cond)
 
 
-def group_terms_polars(df: pl.DataFrame) -> pl.DataFrame:
+def group_terms_polars(df: pl.LazyFrame) -> pl.LazyFrame:
     """
     Groups terms in a polars DataFrame.
 

--- a/linopy/constraints.py
+++ b/linopy/constraints.py
@@ -578,8 +578,7 @@ class Constraint:
         check_has_nulls_polars(long, name=f"{self.type} {self.name}")
 
         short = ds[[k for k in ds if "_term" not in ds[k].dims]]
-        schema = infer_schema_polars(short)
-        schema["sign"] = pl.Enum(["=", "<=", ">="])
+        schema = infer_schema_polars(short, overwrites={"sign": pl.Enum(["=", "<=", ">="])})
         short = to_polars(short, schema=schema)
         short = filter_nulls_polars(short)
         check_has_nulls_polars(short, name=f"{self.type} {self.name}")

--- a/linopy/constraints.py
+++ b/linopy/constraints.py
@@ -583,12 +583,12 @@ class Constraint:
         short = filter_nulls_polars(short)
         check_has_nulls_polars(short, name=f"{self.type} {self.name}")
 
-        df = pl.concat([short, long], how="diagonal").sort(["labels", "rhs"])
+        lf = pl.concat([short, long], how="diagonal").sort(["labels", "rhs"])
         # delete subsequent non-null rhs (happens is all vars per label are -1)
-        is_non_null = df["rhs"].is_not_null()
+        is_non_null = lf["rhs"].is_not_null()
         prev_non_is_null = is_non_null.shift(1).fill_null(False)
-        df = df.filter(is_non_null & ~prev_non_is_null | ~is_non_null)
-        return df[["labels", "coeffs", "vars", "sign", "rhs"]]
+        lf = lf.filter(is_non_null & ~prev_non_is_null | ~is_non_null)
+        return lf[["labels", "coeffs", "vars", "sign", "rhs"]]
 
     sel = conwrap(Dataset.sel)
 

--- a/linopy/constraints.py
+++ b/linopy/constraints.py
@@ -587,10 +587,10 @@ class Constraint:
 
         lf = pl.concat([short, long], how="diagonal").sort(["labels", "rhs"])
         # delete subsequent non-null rhs (happens is all vars per label are -1)
-        is_non_null = lf["rhs"].is_not_null()
+        is_non_null = pl.col("rhs").is_not_null()
         prev_non_is_null = is_non_null.shift(1).fill_null(False)
         lf = lf.filter(is_non_null & ~prev_non_is_null | ~is_non_null)
-        return lf[["labels", "coeffs", "vars", "sign", "rhs"]]
+        return lf.select(pl.col(["labels", "coeffs", "vars", "sign", "rhs"]))
 
     sel = conwrap(Dataset.sel)
 

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -1268,9 +1268,9 @@ class LinearExpression:
         check_has_nulls(df, name=self.type)
         return df
 
-    def to_polars(self) -> pl.DataFrame:
+    def to_polars(self) -> pl.LazyFrame:
         """
-        Convert the expression to a polars DataFrame.
+        Convert the expression to a polars lazyFrame.
 
         The resulting DataFrame represents a long table format of the all
         non-masked expressions with non-zero coefficients. It contains the
@@ -1278,13 +1278,13 @@ class LinearExpression:
 
         Returns
         -------
-        df : polars.DataFrame
+        lf : polars.LazyFrame
         """
-        df = to_polars(self.data)
-        df = filter_nulls_polars(df)
-        df = group_terms_polars(df)
-        check_has_nulls_polars(df, name=self.type)
-        return df
+        lf = to_polars(self.data)
+        lf = filter_nulls_polars(lf)
+        lf = group_terms_polars(lf)
+        check_has_nulls_polars(lf, name=self.type)
+        return lf
 
     # Wrapped function which would convert variable to dataarray
     assign = exprwrap(Dataset.assign)
@@ -1480,7 +1480,7 @@ class QuadraticExpression(LinearExpression):
         check_has_nulls(df, name=self.type)
         return df
 
-    def to_polars(self, **kwargs):
+    def to_polars(self, **kwargs) -> pl.LazyFrame:
         """
         Convert the expression to a polars DataFrame.
 
@@ -1490,17 +1490,17 @@ class QuadraticExpression(LinearExpression):
 
         Returns
         -------
-        df : polars.DataFrame
+        lf : polars.LazyFrame
         """
         vars = self.data.vars.assign_coords(
             {FACTOR_DIM: ["vars1", "vars2"]}
         ).to_dataset(FACTOR_DIM)
         ds = self.data.drop_vars("vars").assign(vars)
-        df = to_polars(ds, **kwargs)
-        df = filter_nulls_polars(df)
-        df = group_terms_polars(df)
-        check_has_nulls_polars(df, name=self.type)
-        return df
+        lf = to_polars(ds, **kwargs)
+        lf = filter_nulls_polars(lf)
+        lf = group_terms_polars(lf)
+        check_has_nulls_polars(lf, name=self.type)
+        return lf
 
     def to_matrix(self):
         """

--- a/linopy/io.py
+++ b/linopy/io.py
@@ -300,11 +300,9 @@ def write_lazyframe(f, lf):
 
     def write_batch(batch):
         writer.write(batch.to_arrow())
-        return pl.DataFrame({"written": np.ones(batch.shape[0], dtype=int)})
+        return pl.DataFrame()
 
-    lf.map_batches(
-        write_batch, schema={"written": pl.Int64}, streamable=True
-    ).sum().collect()
+    lf.map_batches(write_batch, schema={}, streamable=True).collect()
 
 
 def objective_write_linear_terms_polars(f, lf):

--- a/linopy/io.py
+++ b/linopy/io.py
@@ -287,7 +287,7 @@ def write_lazyframe(f, lf):
     def to_pyarrow_schema(schema):
         return pa.schema(
             (k, pl.datatypes.py_type_to_arrow_type(pl.datatypes.dtype_to_py_type(v)))
-            for k, v in lf.schema.items()
+            for k, v in schema.items()
         )
 
     writer = pa.csv.CSVWriter(

--- a/linopy/io.py
+++ b/linopy/io.py
@@ -294,7 +294,7 @@ def write_lazyframe(f, lf):
         f,
         to_pyarrow_schema(lf.schema),
         write_options=pa.csv.WriteOptions(
-            include_header=False, delimiter=" ", quoting_style="none"
+            include_header=False, delimiter=";", quoting_style="none"
         ),
     )
 
@@ -325,7 +325,7 @@ def objective_write_quadratic_terms_polars(f, lf):
         pl.col("vars2").cast(pl.String),
     ]
     f.write(b"+ [\n")
-    write_lazyframe(lf.select(pl.concat_str(cols, ignore_nulls=True)))
+    write_lazyframe(f, lf.select(pl.concat_str(cols, ignore_nulls=True)))
     f.write(b"] / 2\n")
 
 
@@ -471,14 +471,14 @@ def constraints_to_file_polars(m, f, log=False, lazy=False):
         )
 
         columns = [
-            pl.when(pl.col("labels").is_not_null()).then(pl.lit("c")).alias("c"),
+            pl.when(pl.col("labels").is_not_null()).then(pl.lit("c")),
             pl.col("labels").cast(pl.String),
-            pl.when(pl.col("labels").is_not_null()).then(pl.lit(":\n")).alias(":"),
+            pl.when(pl.col("labels").is_not_null()).then(pl.lit(": ")),
             pl.when(pl.col("coeffs") >= 0).then(pl.lit("+")),
             pl.col("coeffs").cast(pl.String),
-            pl.when(pl.col("vars").is_not_null()).then(pl.lit(" x")).alias("x"),
+            pl.when(pl.col("vars").is_not_null()).then(pl.lit(" x")),
             pl.col("vars").cast(pl.String),
-            "sign",
+            pl.col("sign"),
             pl.lit(" "),
             pl.col("rhs").cast(pl.String),
         ]

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -159,7 +159,6 @@ class Variable:
         self._model = model
 
     def __getitem__(self, selector) -> Union["Variable", "ScalarVariable"]:
-
         keys = selector if isinstance(selector, tuple) else (selector,)
         if all(map(pd.api.types.is_scalar, keys)):
             warn(
@@ -799,10 +798,10 @@ class Variable:
         -------
         pl.DataFrame
         """
-        df = to_polars(self.data)
-        df = filter_nulls_polars(df)
-        check_has_nulls_polars(df, name=f"{self.type} {self.name}")
-        return df
+        lf = to_polars(self.data)
+        lf = filter_nulls_polars(lf)
+        check_has_nulls_polars(lf, name=f"{self.type} {self.name}")
+        return lf
 
     def sum(self, dim=None, **kwargs):
         """
@@ -935,7 +934,8 @@ class Variable:
             self.data.where(self.labels != -1)
             # .ffill(dim, limit=limit)
             # breaks with Dataset.ffill, use map instead
-            .map(DataArray.ffill, dim=dim, limit=limit).fillna(self._fill_value)
+            .map(DataArray.ffill, dim=dim, limit=limit)
+            .fillna(self._fill_value)
         )
         data = data.assign(labels=data.labels.astype(int))
         return self.__class__(data, self.model, self.name)
@@ -962,7 +962,8 @@ class Variable:
             self.data.where(~self.isnull())
             # .bfill(dim, limit=limit)
             # breaks with Dataset.bfill, use map instead
-            .map(DataArray.bfill, dim=dim, limit=limit).fillna(self._fill_value)
+            .map(DataArray.bfill, dim=dim, limit=limit)
+            .fillna(self._fill_value)
         )
         data = data.assign(labels=data.labels.astype(int))
         return self.__class__(data, self.model, self.name)
@@ -1020,7 +1021,6 @@ class AtIndexer:
         self.object = obj
 
     def __getitem__(self, keys) -> "ScalarVariable":
-
         keys = keys if isinstance(keys, tuple) else (keys,)
         object = self.object
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "xarray>=2023.9.0",
     "dask>=0.18.0",
     "polars",
+    "pyarrow",
     "tqdm",
     "deprecation",
 ]

--- a/test/test_constraint.py
+++ b/test/test_constraint.py
@@ -335,7 +335,7 @@ def test_constraint_flat(c):
 
 
 def test_constraint_to_polars(c):
-    assert isinstance(c.to_polars(), pl.DataFrame)
+    assert isinstance(c.to_polars(), pl.LazyFrame)
 
 
 def test_constraint_assignment_with_anonymous_constraints(m, x, y):

--- a/test/test_linear_expression.py
+++ b/test/test_linear_expression.py
@@ -529,8 +529,8 @@ def test_linear_expression_to_polars(v):
     coeff = np.arange(1, 21)  # use non-zero coefficients
     expr = coeff * v
     df = expr.to_polars()
-    assert isinstance(df, pl.DataFrame)
-    assert (df["coeffs"].to_numpy() == coeff).all()
+    assert isinstance(df, pl.LazyFrame)
+    assert (df.collect()["coeffs"].to_numpy() == coeff).all()
 
 
 def test_linear_expression_where(v):

--- a/test/test_quadratic_expression.py
+++ b/test/test_quadratic_expression.py
@@ -221,10 +221,10 @@ def test_quadratic_expression_flat(x, y):
 def test_linear_expression_to_polars(x, y):
     expr = x * y + x + 5
     df = expr.to_polars()
-    assert isinstance(df, pl.DataFrame)
+    assert isinstance(df, pl.LazyFrame)
     assert "vars1" in df.columns
     assert "vars2" in df.columns
-    assert len(df) == expr.nterm * 2
+    assert len(df.collect()) == expr.nterm * 2
 
 
 def test_quadratic_expression_to_matrix(model, x, y):

--- a/test/test_variable.py
+++ b/test/test_variable.py
@@ -260,8 +260,8 @@ def test_variable_flat(x):
 
 def test_variable_polars(x):
     result = x.to_polars()
-    assert isinstance(result, pl.DataFrame)
-    assert len(result) == x.size
+    assert isinstance(result, pl.LazyFrame)
+    assert len(result.collect()) == x.size
 
 
 def test_variable_sanitize(x):


### PR DESCRIPTION
Tests run fine. The extra pyarrow dependency should not hurt, since arrow is already a requirement for polars (and soon also pandas), while pandas is only the python frontend in addition.

We should check each of the invocations of `write_lazyframe` that `explain(streamable=True)` shows it can actually run the streaming pipeline.

If you decide to merge, please squash (the history is ugly :))