### PR TITLE
ci: fix potential setuptools_scm issues in gh actions

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -26,6 +26,10 @@ jobs:
         - windows-latest
     steps:
     - uses: actions/checkout@v4
+
+    - name: Fetch all history for all tags and branches (necessary for setuptools_scm)
+      run: git fetch --prune --unshallow
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -65,7 +65,7 @@ jobs:
       run: |
         pip install flake8
         # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude=benchmark/scripts
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude=benchmark/scripts,.git/
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@master
+
+    - name: Fetch all history for all tags and branches (necessary for setuptools_scm)
+      run: git fetch --prune --unshallow
+
     - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
 
     - name: Fetch all history for all tags and branches (necessary for setuptools_scm)
       run: git fetch --prune --unshallow

--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -10,6 +10,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Fetch all history for all tags and branches (necessary for setuptools_scm)
+        run: git fetch --prune --unshallow
+
       - name: Release
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
In reference to https://github.com/PyPSA/PyPSA/pull/907 #279 and #292 I just add a fetch for the tags here so that `setuptools_scm` can detect the version correctly. Right now that doesn't lead to errors, so only to avoid the potential bug search in the future (which I just had).

Fore more details see [here](https://stackoverflow.com/questions/62968271/python-automatic-versioning-not-happening-while-running-in-github-actions).