### PR TITLE
support for warmstart in HiGHS

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -4,6 +4,7 @@ Release Notes
 Upcoming Version
 ----------------
 
+* Support for warmstart in HiGHS using basis or solution files, including support for writing basis and solution files of a solved model.
 
 Version 0.3.11
 --------------

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -449,10 +449,6 @@ def run_highs(
     """
     CONDITION_MAP: Dict[str, str] = {}
 
-    warmstart_fn = maybe_convert_path(warmstart_fn)
-    basis_fn = maybe_convert_path(basis_fn)
-    solution_fn = maybe_convert_path(solution_fn)
-
     if solver_options.get("solver") in ["simplex", "ipm", "pdlp"] and model.type in [
         "QP",
         "MILP",
@@ -481,10 +477,10 @@ def run_highs(
     for k, v in solver_options.items():
         h.setOptionValue(k, v)
 
-    if warmstart_fn and warmstart_fn.endswith(".sol"):
-        h.readSolution(warmstart_fn, 0)
+    if warmstart_fn is not None and warmstart_fn.suffix == ".sol":
+        h.readSolution(path_to_string(warmstart_fn), 0)
     elif warmstart_fn:
-        h.readBasis(warmstart_fn)
+        h.readBasis(path_to_string(warmstart_fn))
 
     h.run()
 
@@ -494,10 +490,10 @@ def run_highs(
     status.legacy_status = condition
 
     if basis_fn:
-        h.writeBasis(basis_fn)
+        h.writeBasis(path_to_string(basis_fn))
 
     if solution_fn:
-        h.writeSolution(solution_fn, 0)
+        h.writeSolution(path_to_string(solution_fn), 0)
 
     def get_solver_solution() -> Solution:
         objective = h.getObjectiveValue()

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -457,7 +457,7 @@ def run_highs(
     for k, v in solver_options.items():
         h.setOptionValue(k, v)
 
-    if warmstart_fn.endswith(".sol"):
+    if warmstart_fn and warmstart_fn.endswith(".sol"):
         h.readSolution(warmstart_fn, 0)
     elif warmstart_fn:
         h.readBasis(warmstart_fn)


### PR DESCRIPTION
It adds support for reading in solution or basis files for a warm start and functionality to write solution and basis files from solved HiGHS models.

I am currently identifying the kind of warm start (solution or basis) by the file suffix. Is this the best way? The documentation of the `Model.solve()` function currently states it's only a basis file that is used for the warm start (and that's how we have done it for the other solvers.)

The writing functions do not throw errors for unsolved models, so I am not handling these.

The `0` for writing the solution indicates the format of the `.sol` file. I am choosing raw.
