### PR TITLE
ci: disable pip package caching in actions/setup-python

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -33,7 +33,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-        cache: pip
 
     - name: Install ubuntu dependencies
       if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
This reverts the change introduced in d5e476a74808f4f9bff0d93e053a8ca2553d2ad3.

I did not realize how many items your test matrix includes, each cache artifact is a few 100 megs and you have a lot of them. Your [cache is overflowing](https://github.com/PyPSA/linopy/actions/caches), sorry about that. I suggest turning off the cache again.