### PR TITLE
Get solution for gurobi before exiting enviornment context manager

### DIFF
--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -722,8 +722,8 @@ def run_gurobi(
 
             return Solution(sol, dual, objective)
 
-    solution = safe_get_solution(status, get_solver_solution)
-    maybe_adjust_objective_sign(solution, model.objective.sense, io_api)
+        solution = safe_get_solution(status, get_solver_solution)
+        maybe_adjust_objective_sign(solution, model.objective.sense, io_api)
 
     return Result(status, solution, m)
 


### PR DESCRIPTION
Not quite sure when this regression happened by this is the same fix as in #192, it seems it got lost in a merge at some point.

As discussed in the issue, I wonder if there should be a test that we dont access the model after it is closed, but maybe there is a better way to do this than an explicit test (i.e. make it impossible by a code change)

Closes #329 