### PR TITLE
ci: disable pytest multiprocessing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,7 +88,7 @@ jobs:
       env:
         MOSEKLM_LICENSE_FILE: ${{ secrets.MSK_LICENSE }}
       run: |
-        pytest --cov=./ --cov-report=xml linopy --doctest-modules test --numprocesses=auto --dist=loadscope
+        pytest --cov=./ --cov-report=xml linopy --doctest-modules test
 
     - name: Upload code coverage report
       if: matrix.os == 'ubuntu-latest'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ docs = [
 dev = [
     "pytest",
     "pytest-cov",
-    "pytest-xdist",
     "netcdf4",
     "pre-commit",
     "paramiko",


### PR DESCRIPTION
Follow up on your request in #333 @FabianHofmann 

`print` can't handle multiprocessing, so it won't work. And logs can only be shown for all tests or none.
So it's either `pytest` in parallel or the log. I think we can revert multiprocessing, it doesn't take much time anyway (both around 30 sec).