### PR TITLE
linexpression: drop squeeze argument in groupby

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -4,6 +4,7 @@ Release Notes
 Upcoming Version
 ----------------
 
+* Ensure compatibility with xarray >= v2024.07.0, which has drop the ``squeeze`` argument from the ``groupby`` function.
 
 Version 0.3.13
 --------------

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -1212,7 +1212,6 @@ class LinearExpression:
     def groupby(
         self,
         group: DataFrame | Series | DataArray,
-        squeeze: bool = True,
         restore_coord_dims: bool | None = None,
         **kwargs,
     ) -> LinearExpressionGroupby:
@@ -1227,10 +1226,6 @@ class LinearExpression:
         group : str, DataArray or IndexVariable
             Array whose unique values should be used to group this array. If a
             string, must be the name of a variable contained in this dataset.
-        squeeze : bool, optional
-            If "group" is a dimension of any arrays in this dataset, `squeeze`
-            controls whether the subarrays have a dimension of length 1 along
-            that dimension or if the dimension is squeezed out.
         restore_coord_dims : bool, optional
             If True, also restore the dimension order of multi-dimensional
             coordinates.
@@ -1242,7 +1237,7 @@ class LinearExpression:
             the correct return type.
         """
         ds = self.data
-        kwargs = dict(squeeze=squeeze, restore_coord_dims=restore_coord_dims, **kwargs)
+        kwargs = dict(restore_coord_dims=restore_coord_dims, **kwargs)
         return LinearExpressionGroupby(ds, group, model=self.model, kwargs=kwargs)
 
     def rolling(

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -907,7 +907,7 @@ def run_xpress(
             dual_ = [str(d) for d in m.getConstraint()]
             dual = pd.Series(m.getDual(dual_), index=dual_, dtype=float)
             dual = set_int_index(dual)
-        except xpress.SolverError:
+        except (xpress.SolverError, SystemError):
             logger.warning("Dual values of MILP couldn't be parsed")
             dual = pd.Series(dtype=float)
 

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -516,7 +516,6 @@ class Variable:
     def groupby(
         self,
         group: DataArray,
-        squeeze: bool = True,
         restore_coord_dims: bool | None = None,
     ) -> LinearExpressionGroupby:
         """
@@ -530,10 +529,6 @@ class Variable:
         group : str, DataArray or IndexVariable
             Array whose unique values should be used to group this array. If a
             string, must be the name of a variable contained in this dataset.
-        squeeze : bool, optional
-            If "group" is a dimension of any arrays in this dataset, `squeeze`
-            controls whether the subarrays have a dimension of length 1 along
-            that dimension or if the dimension is squeezed out.
         restore_coord_dims : bool, optional
             If True, also restore the dimension order of multi-dimensional
             coordinates.
@@ -545,7 +540,7 @@ class Variable:
             the correct return type.
         """
         return self.to_linexpr().groupby(
-            group=group, squeeze=squeeze, restore_coord_dims=restore_coord_dims
+            group=group, restore_coord_dims=restore_coord_dims
         )
 
     def rolling(


### PR DESCRIPTION
remove the deprecated squeeze argument  