### PR TITLE
build: use post-release versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ include = ["linopy"]
 
 [tool.setuptools_scm]
 write_to = "linopy/version.py"
+version_scheme = "no-guess-dev"
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
- Use post-release versioning and do not guess the next version.
- See [Version number construction - setuptools scm](https://setuptools-scm.readthedocs.io/en/latest/extending/#available-implementations)
- Same behavior as in PyPSA etc.