### PR TITLE
fix: codecov report

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,3 +93,5 @@ jobs:
     - name: Upload code coverage report
       if: matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ci:
   autoupdate_schedule: monthly
-  
+
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+  autoupdate_schedule: monthly
+  
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false


### PR DESCRIPTION
- fix codecov report (report upload failed because of breaking change in action)
- Adds `codecov.yml` to disable codecov comment
  - Report can still be viewed on codecov.com and in PR checks
- Run pre-commit ci update monthly instead of weekly
  - With the new pre-commit setup we get a weekly PR and I think that is not needed. Monthly is cleaner, especially in the less active repositories.

