### PR TITLE
test: run tests in parallel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,7 +88,7 @@ jobs:
       env:
         MOSEKLM_LICENSE_FILE: ${{ secrets.MSK_LICENSE }}
       run: |
-        pytest --cov=./ --cov-report=xml linopy --doctest-modules test
+        pytest --cov=./ --cov-report=xml linopy --doctest-modules test --numprocesses=auto --dist=loadscope
 
     - name: Upload code coverage report
       if: matrix.os == 'ubuntu-latest'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ docs = [
 dev = [
     "pytest",
     "pytest-cov",
+    "pytest-xdist",
     'mypy',
     "pre-commit",
     "netcdf4",


### PR DESCRIPTION
This PR adds the excellent [pytest-xdist](https://github.com/pytest-dev/pytest-xdist) plugin to the dev dependencies.

The tests are run in parallel in CI.

This should speed up the CI run a bit.