### PR TITLE
fix: more robust solver installed check

### DIFF
--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -49,11 +49,11 @@ available_solvers = []
 which = "where" if os.name == "nt" else "which"
 
 # the first available solver will be the default solver
-with contextlib.suppress(ImportError):
+with contextlib.suppress(ModuleNotFoundError):
     import gurobipy
 
     available_solvers.append("gurobi")
-with contextlib.suppress(ImportError):
+with contextlib.suppress(ModuleNotFoundError):
     _new_highspy_mps_layout = None
     import highspy
 
@@ -72,19 +72,22 @@ if sub.run([which, "glpsol"], stdout=sub.DEVNULL, stderr=sub.STDOUT).returncode 
 if sub.run([which, "cbc"], stdout=sub.DEVNULL, stderr=sub.STDOUT).returncode == 0:
     available_solvers.append("cbc")
 
-with contextlib.suppress(ImportError):
+with contextlib.suppress(ModuleNotFoundError):
     import pyscipopt as scip
 
     available_solvers.append("scip")
-with contextlib.suppress(ImportError):
+
+with contextlib.suppress(ModuleNotFoundError):
     import cplex
 
     available_solvers.append("cplex")
-with contextlib.suppress(ImportError):
+
+with contextlib.suppress(ModuleNotFoundError):
     import xpress
 
     available_solvers.append("xpress")
-with contextlib.suppress(ImportError):
+
+with contextlib.suppress(ModuleNotFoundError):
     import mosek
 
     with contextlib.suppress(mosek.Error):
@@ -95,11 +98,12 @@ with contextlib.suppress(ImportError):
 
         available_solvers.append("mosek")
 
-with contextlib.suppress(ImportError):
+with contextlib.suppress(ModuleNotFoundError):
     import mindoptpy
 
     available_solvers.append("mindopt")
-with contextlib.suppress(ImportError):
+
+with contextlib.suppress(ModuleNotFoundError):
     import coptpy
 
     with contextlib.suppress(coptpy.CoptError):


### PR DESCRIPTION
Check if solver is installed via `ModuleNotFoundError` instead of `ImportError`.

Right now there is an issue with `scip` in pypsa-eur (see [here](https://github.com/PyPSA/pypsa-eur/actions/runs/11051619052/job/30701902379)). Linopy is stating that scip is not installed, even if it is installed and just the import fails. `ModuleNotFoundError` is more specific than `ImportError` so that actual issues with the dependency even if it is installed are not catched.