### PR TITLE
Improve cleanliness method print_infeasibilities()

### DIFF
--- a/linopy/model.py
+++ b/linopy/model.py
@@ -1162,12 +1162,24 @@ class Model:
                 labels.append(int(line_decoded.split(":")[0][2:]))
         return labels
 
-    def print_infeasibilities(self, display_max_terms: None = None) -> None:
+    def print_infeasibilities(self, display_max_terms: int | None = None) -> None:
         """
         Print a list of infeasible constraints.
 
-        This function requires that the model was solved with `gurobi` and the
-        termination condition was infeasible.
+        This function requires that the model was solved using `gurobi`
+        and the termination condition was infeasible.
+
+        Parameters
+        ----------
+        display_max_terms : int, optional
+            The maximum number of infeasible terms to display. If `None`,
+            all infeasible terms will be displayed.
+
+        Returns
+        -------
+        None
+            This function does not return anything. It simply prints the
+            infeasible constraints.
         """
         labels = self.compute_infeasibilities()
         self.constraints.print_labels(labels, display_max_terms=display_max_terms)


### PR DESCRIPTION
Currently, this method takes an argument that is of type None, and by default this parameter is also None. This is confusing when we want to use this method. In this MR, I correct the typing of this method so that it can accept int and None, but by default None is passed.

Additionally, the docstring for this method was difficult to read, so the generated documentation could also mislead the user. In the generated documentation there was no word about what this parameter is and that this method is only available when the gurobi solver is used (only visible in codebase via comment or when exception raised).

![image](https://github.com/user-attachments/assets/5e4d2ae7-0ba0-450c-afd3-d1a56e1f631c)

The revised docstring after generating the documentation should correct this and indicate that this method is only available when using the gurobi solver

