### PR TITLE
add check for valid dimension name before creating new variable

### DIFF
--- a/linopy/model.py
+++ b/linopy/model.py
@@ -377,10 +377,7 @@ class Model:
         None.
         """
         unsupported_dim_names = ["labels", "coeffs", "vars", "sign", "rhs"]
-        contains_unsupported_dim_names = any(
-            dim in unsupported_dim_names for dim in list(ds.dims)
-        )
-        if contains_unsupported_dim_names:
+        if any(dim in unsupported_dim_names for dim in ds.dims):
             raise ValueError(
                 "Added data contains unsupported dimension names. "
                 "Dimensions cannot be named 'labels', 'coeffs', 'vars', 'sign' or 'rhs'."

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -357,6 +357,37 @@ class Model:
         else:
             return
 
+    def check_valid_dim_names(self, ds: DataArray | Dataset) -> None:
+        """
+        Ensure that the added data does not lead to a naming conflict.
+
+        Parameters
+        ----------
+        model : linopy.Model
+        ds : xr.DataArray/Variable/LinearExpression
+            Data that should be added to the model.
+
+        Raises
+        ------
+        ValueError
+            If broadcasted data leads to unsupported dimension names.
+
+        Returns
+        -------
+        None.
+        """
+        unsupported_dim_names = ["labels", "coeffs", "vars", "sign", "rhs"]
+        contains_unsupported_dim_names = any(
+            dim in unsupported_dim_names for dim in list(ds.dims)
+        )
+        if contains_unsupported_dim_names:
+            raise ValueError(
+                "Added data contains unsupported dimension names. "
+                "Dimensions cannot be named 'labels', 'coeffs', 'vars', 'sign' or 'rhs'."
+            )
+        else:
+            return
+
     def add_variables(
         self,
         lower: Any = -inf,
@@ -464,6 +495,7 @@ class Model:
         )
         (data,) = xr.broadcast(data)
         self.check_force_dim_names(data)
+        self.check_valid_dim_names(data)
 
         if mask is not None:
             mask = as_dataarray(mask, coords=data.coords, dims=data.dims).astype(bool)

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -382,8 +382,6 @@ class Model:
                 "Added data contains unsupported dimension names. "
                 "Dimensions cannot be named 'labels', 'coeffs', 'vars', 'sign' or 'rhs'."
             )
-        else:
-            return
 
     def add_variables(
         self,

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -490,7 +490,7 @@ class Model:
         )
         (data,) = xr.broadcast(data)
         self.check_force_dim_names(data)
-        self.check_valid_dim_names(data)
+        self._check_valid_dim_names(data)
 
         if mask is not None:
             mask = as_dataarray(mask, coords=data.coords, dims=data.dims).astype(bool)

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -357,7 +357,7 @@ class Model:
         else:
             return
 
-    def check_valid_dim_names(self, ds: DataArray | Dataset) -> None:
+    def _check_valid_dim_names(self, ds: DataArray | Dataset) -> None:
         """
         Ensure that the added data does not lead to a naming conflict.
 

--- a/test/test_variable_assignment.py
+++ b/test/test_variable_assignment.py
@@ -131,6 +131,15 @@ def test_variable_assignment_without_coords_and_dims_names():
     assert x.dims == ("i", "j")
 
 
+def test_variable_assignment_without_coords_and_invalid_dims_names():
+    # setting bounds without explicit coords
+    m = Model()
+    lower = np.zeros((10, 10))
+    upper = np.ones((10, 10))
+    with pytest.raises(ValueError):
+        m.add_variables(lower, upper, name="x", dims=["sign", "j"])
+
+
 def test_variable_assignment_without_coords_in_bounds():
     # setting bounds without explicit coords
     m = Model()
@@ -139,6 +148,15 @@ def test_variable_assignment_without_coords_in_bounds():
     x = m.add_variables(lower, upper, name="x")
     assert x.shape == target_shape
     assert x.dims == ("i", "j")
+
+
+def test_variable_assignment_without_coords_in_bounds_invalid_dims_names():
+    # setting bounds without explicit coords
+    m = Model()
+    lower = xr.DataArray(np.zeros((10, 10)), dims=["i", "sign"])
+    upper = xr.DataArray(np.ones((10, 10)), dims=["i", "sign"])
+    with pytest.raises(ValueError):
+        m.add_variables(lower, upper, name="x")
 
 
 def test_variable_assignment_without_coords_pandas_types():


### PR DESCRIPTION
Add function to ensure that added variables do not use unvalid dimension names.
Add test for variable assignment with invalid dimension name.
This code adds a more meaning full error message if users try to create new variables with invalid dimension names.
Old behavior is described in #359.