### PR TITLE
xpress: writesol instead of tofile

### DIFF
--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -890,7 +890,7 @@ def run_xpress(
 
     if solution_fn is not None:
         try:
-            m.tofile(path_to_string(solution_fn), filetype="sol")
+            m.writesol(path_to_string(solution_fn))
         except Exception as err:
             logger.info("Unable to save solution file. Raised error: %s", err)
 


### PR DESCRIPTION
closes #361

https://www.fico.com/fico-xpress-optimization/docs/latest/solver/optimizer/python/HTML/problem.writesol.html

The function `tofile` does not seem to exist.