### PR TITLE
fix: let cplex handle infs in constraints

### DIFF
--- a/linopy/model.py
+++ b/linopy/model.py
@@ -1105,6 +1105,9 @@ class Model:
                     env=env,
                 )
             else:
+                # CPLEX does not handle infs and truncates them to 1e20
+                if solver_name in ["cplex"]:
+                    self.constraints.truncate_infs(value=1e20)
                 problem_fn = self.to_file(to_path(problem_fn), io_api)
                 result = solver.solve_problem_from_file(
                     problem_fn=to_path(problem_fn),

--- a/test/test_optimization.py
+++ b/test/test_optimization.py
@@ -499,7 +499,7 @@ def test_infeasible_model(model, solver, io_api):
 
 
 @pytest.mark.parametrize(
-    "solver,io_api", [p for p in params if p[0] not in ["glpk", "cplex", "mindopt"]]
+    "solver,io_api", [p for p in params if p[0] not in ["glpk", "mindopt"]]
 )
 def test_model_with_inf(model_with_inf, solver, io_api):
     status, condition = model_with_inf.solve(solver, io_api=io_api)


### PR DESCRIPTION
Closes #362
Closes https://github.com/PyPSA/PyPSA/issues/1057

- `cplex` can't read inf values from an lp file. But they have been introduced in a new optional constraint in PyPSA `0.31.0`
  - Instead they get truncated to `1e20` (see [here](https://www.ibm.com/docs/en/SSSA5P_20.1.0/ilog.odms.ide.help/OPL_Studio/opllang_quickref/topics/tlr_opl_infinity.html#d42923e83))
- This behaviour is now also implemented in here. Existing constraints in the model are modified, the change does not just affect the created problem file.