### PR TITLE
io: allow setting progress=False in solver to disable stdout even for larger models

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -1,8 +1,11 @@
 Release Notes
 =============
 
-.. Upcoming Version
-.. ----------------
+Upcoming Version
+----------------
+
+* The method :meth:`model.to_file <linopy.model.Model.to_file>` now includes a progress argument to enable or disable the progress bar while writing.
+
 
 Version 0.4.2
 --------------

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -969,6 +969,7 @@ class Model:
         sanitize_infinities: bool = True,
         slice_size: int = 2_000_000,
         remote: None = None,
+        progress: bool | None = None,
         **solver_options,
     ) -> tuple[str, str]:
         """
@@ -1027,6 +1028,10 @@ class Model:
             Remote handler to use for solving model on a server. Note that when
             solving on a rSee
             linopy.remote.RemoteHandler for more details.
+        progress : bool, optional
+            Whether to show a progress bar of writing the lp file. The default is
+            None, which means that the progress bar is shown if the model has more
+            than 10000 variables and constraints.
         **solver_options : kwargs
             Options passed to the solver.
 
@@ -1124,7 +1129,9 @@ class Model:
                     env=env,
                 )
             else:
-                problem_fn = self.to_file(to_path(problem_fn), io_api)
+                problem_fn = self.to_file(
+                    to_path(problem_fn), io_api, progress=progress
+                )
                 result = solver.solve_problem_from_file(
                     problem_fn=to_path(problem_fn),
                     solution_fn=to_path(solution_fn),

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -1130,7 +1130,10 @@ class Model:
                 )
             else:
                 problem_fn = self.to_file(
-                    to_path(problem_fn), io_api, slice_size, progress=progress
+                    to_path(problem_fn),
+                    io_api,
+                    slice_size=slice_size,
+                    progress=progress,
                 )
                 result = solver.solve_problem_from_file(
                     problem_fn=to_path(problem_fn),


### PR DESCRIPTION
This was unnecessary when solving a lot of problems programatically.

The `log` param of the solve function does have three states:

* `None`: log tqdm to stdout if model is > 10k constraints
* `True`: always creates tqdm for model
* `False`: never creates tqdm for model

For better usage, the log param is renamed to `progress` on all occurrences