### PR TITLE
add check for solver installation when initializing solver class instances

### DIFF
--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -210,6 +210,11 @@ class Solver(ABC):
     ):
         self.solver_options = solver_options
 
+        # Check for the solver to be initialized whether the package is installed or not.
+        if self.get_name_str() not in available_solvers:
+            msg = f"Solver package for '{self.get_name_str()}' is not installed. Please install first to initialize solver instance."
+            raise ImportError(msg)
+
     def safe_get_solution(self, status: Status, func: Callable) -> Solution:
         """
         Get solution from function call, if status is unknown still try to run it.
@@ -302,14 +307,8 @@ class Solver(ABC):
             msg = "No problem file or model specified."
             raise ValueError(msg)
 
-    def check_solver_installation(self, package_name: str):
-        """
-        Check for the solver to be initialized whether the package is installed or not.
-        Gives an ImportError if that is not the case.
-        """
-        if importlib.util.find_spec(package_name) is None:
-            msg = f"Solver package '{package_name}' is not installed. Please install first to initialize solver instance."
-            raise ImportError(msg)
+    def get_name_str(self):
+        return SolverName[self.__class__.__name__].value
 
 
 class CBC(Solver):
@@ -322,22 +321,11 @@ class CBC(Solver):
         options for the given solver
     """
 
-    package_name = "coin-or-cbc"
-
     def __init__(
         self,
         **solver_options,
     ):
-        self.check_solver_installation(self.package_name)
         super().__init__(**solver_options)
-
-    def check_solver_installation(self, package_name):
-        if (
-            sub.run([which, "cbc"], stdout=sub.DEVNULL, stderr=sub.STDOUT).returncode
-            != 0
-        ):
-            msg = f"Solver package '{package_name}' is not installed. Please install first to initialize solver instance."
-            raise ImportError(msg)
 
     def solve_problem_from_model(
         self,
@@ -490,22 +478,11 @@ class GLPK(Solver):
         options for the given solver
     """
 
-    package_name = "glpk"
-
     def __init__(
         self,
         **solver_options,
     ):
-        self.check_solver_installation(self.package_name)
         super().__init__(**solver_options)
-
-    def check_solver_installation(self, package_name):
-        if (
-            sub.run([which, "glpsol"], stdout=sub.DEVNULL, stderr=sub.STDOUT).returncode
-            != 0
-        ):
-            msg = f"Solver package '{package_name}' is not installed. Please install first to initialize solver instance."
-            raise ImportError(msg)
 
     def solve_problem_from_model(
         self,
@@ -683,13 +660,10 @@ class Highs(Solver):
         options for the given solver
     """
 
-    package_name = "highspy"
-
     def __init__(
         self,
         **solver_options,
     ):
-        self.check_solver_installation(self.package_name)
         super().__init__(**solver_options)
 
     def solve_problem_from_model(
@@ -903,13 +877,10 @@ class Gurobi(Solver):
         options for the given solver
     """
 
-    package_name = "gurobipy"
-
     def __init__(
         self,
         **solver_options,
     ):
-        self.check_solver_installation(self.package_name)
         super().__init__(**solver_options)
 
     def solve_problem_from_model(
@@ -1138,13 +1109,10 @@ class Cplex(Solver):
         options for the given solver
     """
 
-    package_name = "cplex"
-
     def __init__(
         self,
         **solver_options,
     ):
-        self.check_solver_installation(self.package_name)
         super().__init__(**solver_options)
 
     def solve_problem_from_model(
@@ -1283,13 +1251,10 @@ class SCIP(Solver):
         options for the given solver
     """
 
-    package_name = "pyscipopt"
-
     def __init__(
         self,
         **solver_options,
     ):
-        self.check_solver_installation(self.package_name)
         super().__init__(**solver_options)
 
     def solve_problem_from_model(
@@ -1427,13 +1392,10 @@ class Xpress(Solver):
         options for the given solver
     """
 
-    package_name = "xpress"
-
     def __init__(
         self,
         **solver_options,
     ):
-        self.check_solver_installation(self.package_name)
         super().__init__(**solver_options)
 
     def solve_problem_from_model(
@@ -1575,13 +1537,10 @@ class Mosek(Solver):
         options for the given solver
     """
 
-    package_name = "mosek"
-
     def __init__(
         self,
         **solver_options,
     ):
-        self.check_solver_installation(self.package_name)
         super().__init__(**solver_options)
 
     def solve_problem_from_model(
@@ -1900,13 +1859,10 @@ class COPT(Solver):
         options for the given solver
     """
 
-    package_name = "coptpy"
-
     def __init__(
         self,
         **solver_options,
     ):
-        self.check_solver_installation(self.package_name)
         super().__init__(**solver_options)
 
     def solve_problem_from_model(
@@ -2045,13 +2001,10 @@ class MindOpt(Solver):
         options for the given solver
     """
 
-    package_name = "mindoptpy"
-
     def __init__(
         self,
         **solver_options,
     ):
-        self.check_solver_installation(self.package_name)
         super().__init__(**solver_options)
 
     def solve_problem_from_model(

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -210,7 +210,7 @@ class Solver(ABC):
         self.solver_options = solver_options
 
         # Check for the solver to be initialized whether the package is installed or not.
-        if self.get_name_str() not in available_solvers:
+        if self.solver_name.value not in available_solvers:
             msg = f"Solver package for '{self.get_name_str()}' is not installed. Please install first to initialize solver instance."
             raise ImportError(msg)
 
@@ -306,8 +306,9 @@ class Solver(ABC):
             msg = "No problem file or model specified."
             raise ValueError(msg)
 
-    def get_name_str(self):
-        return SolverName[self.__class__.__name__].value
+    @property
+    def solver_name(self) -> SolverName:
+        return SolverName[self.__class__.__name__]
 
 
 class CBC(Solver):

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import contextlib
 import enum
-import importlib.util
 import io
 import logging
 import os

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -211,7 +211,7 @@ class Solver(ABC):
 
         # Check for the solver to be initialized whether the package is installed or not.
         if self.solver_name.value not in available_solvers:
-            msg = f"Solver package for '{self.get_name_str()}' is not installed. Please install first to initialize solver instance."
+            msg = f"Solver package for '{self.solver_name.value}' is not installed. Please install first to initialize solver instance."
             raise ImportError(msg)
 
     def safe_get_solution(self, status: Status, func: Callable) -> Solution:

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -6,6 +6,7 @@ Linopy module for solving lp files with different solvers.
 from __future__ import annotations
 
 import contextlib
+import importlib.util
 import enum
 import io
 import logging
@@ -301,6 +302,15 @@ class Solver(ABC):
             msg = "No problem file or model specified."
             raise ValueError(msg)
 
+    def check_solver_installation(self, package_name: str):
+        """
+        Check for the solver to be initialized whether the package is installed or not.
+        Gives an ImportError if that is not the case.
+        """
+        if importlib.util.find_spec(package_name) is None:
+            msg = f"Solver package '{package_name}' is not installed. Please install first to initialize solver instance."
+            raise ImportError(msg)
+
 
 class CBC(Solver):
     """
@@ -312,11 +322,19 @@ class CBC(Solver):
         options for the given solver
     """
 
+    package_name = "coin-or-cbc"
+
     def __init__(
         self,
         **solver_options,
     ):
+        self.check_solver_installation(self.package_name)
         super().__init__(**solver_options)
+
+    def check_solver_installation(self, package_name):
+        if sub.run([which, "cbc"], stdout=sub.DEVNULL, stderr=sub.STDOUT).returncode != 0:
+            msg = f"Solver package '{package_name}' is not installed. Please install first to initialize solver instance."
+            raise ImportError(msg)
 
     def solve_problem_from_model(
         self,
@@ -469,11 +487,19 @@ class GLPK(Solver):
         options for the given solver
     """
 
+    package_name = "glpk"
+
     def __init__(
         self,
         **solver_options,
     ):
+        self.check_solver_installation(self.package_name)
         super().__init__(**solver_options)
+
+    def check_solver_installation(self, package_name):
+        if sub.run([which, "glpsol"], stdout=sub.DEVNULL, stderr=sub.STDOUT).returncode != 0:
+            msg = f"Solver package '{package_name}' is not installed. Please install first to initialize solver instance."
+            raise ImportError(msg)
 
     def solve_problem_from_model(
         self,
@@ -651,10 +677,13 @@ class Highs(Solver):
         options for the given solver
     """
 
+    package_name = "highspy"
+
     def __init__(
         self,
         **solver_options,
     ):
+        self.check_solver_installation(self.package_name)
         super().__init__(**solver_options)
 
     def solve_problem_from_model(
@@ -868,10 +897,13 @@ class Gurobi(Solver):
         options for the given solver
     """
 
+    package_name = "gurobipy"
+
     def __init__(
         self,
         **solver_options,
     ):
+        self.check_solver_installation(self.package_name)
         super().__init__(**solver_options)
 
     def solve_problem_from_model(
@@ -1100,10 +1132,13 @@ class Cplex(Solver):
         options for the given solver
     """
 
+    package_name = "cplex"
+
     def __init__(
         self,
         **solver_options,
     ):
+        self.check_solver_installation(self.package_name)
         super().__init__(**solver_options)
 
     def solve_problem_from_model(
@@ -1242,10 +1277,13 @@ class SCIP(Solver):
         options for the given solver
     """
 
+    package_name = "pyscipopt"
+
     def __init__(
         self,
         **solver_options,
     ):
+        self.check_solver_installation(self.package_name)
         super().__init__(**solver_options)
 
     def solve_problem_from_model(
@@ -1383,10 +1421,13 @@ class Xpress(Solver):
         options for the given solver
     """
 
+    package_name = "xpress"
+
     def __init__(
         self,
         **solver_options,
     ):
+        self.check_solver_installation(self.package_name)
         super().__init__(**solver_options)
 
     def solve_problem_from_model(
@@ -1528,10 +1569,13 @@ class Mosek(Solver):
         options for the given solver
     """
 
+    package_name = "mosek"
+
     def __init__(
         self,
         **solver_options,
     ):
+        self.check_solver_installation(self.package_name)
         super().__init__(**solver_options)
 
     def solve_problem_from_model(
@@ -1850,10 +1894,13 @@ class COPT(Solver):
         options for the given solver
     """
 
+    package_name = "coptpy"
+
     def __init__(
         self,
         **solver_options,
     ):
+        self.check_solver_installation(self.package_name)
         super().__init__(**solver_options)
 
     def solve_problem_from_model(
@@ -1992,10 +2039,13 @@ class MindOpt(Solver):
         options for the given solver
     """
 
+    package_name = "mindoptpy"
+
     def __init__(
         self,
         **solver_options,
     ):
+        self.check_solver_installation(self.package_name)
         super().__init__(**solver_options)
 
     def solve_problem_from_model(

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -6,8 +6,8 @@ Linopy module for solving lp files with different solvers.
 from __future__ import annotations
 
 import contextlib
-import importlib.util
 import enum
+import importlib.util
 import io
 import logging
 import os
@@ -332,7 +332,10 @@ class CBC(Solver):
         super().__init__(**solver_options)
 
     def check_solver_installation(self, package_name):
-        if sub.run([which, "cbc"], stdout=sub.DEVNULL, stderr=sub.STDOUT).returncode != 0:
+        if (
+            sub.run([which, "cbc"], stdout=sub.DEVNULL, stderr=sub.STDOUT).returncode
+            != 0
+        ):
             msg = f"Solver package '{package_name}' is not installed. Please install first to initialize solver instance."
             raise ImportError(msg)
 
@@ -497,7 +500,10 @@ class GLPK(Solver):
         super().__init__(**solver_options)
 
     def check_solver_installation(self, package_name):
-        if sub.run([which, "glpsol"], stdout=sub.DEVNULL, stderr=sub.STDOUT).returncode != 0:
+        if (
+            sub.run([which, "glpsol"], stdout=sub.DEVNULL, stderr=sub.STDOUT).returncode
+            != 0
+        ):
             msg = f"Solver package '{package_name}' is not installed. Please install first to initialize solver instance."
             raise ImportError(msg)
 


### PR DESCRIPTION
This PR adds a check to the initialization of a solver instance to check whether the solver package is installed or not. An `ImportError` is raised if the necessary package is not installed.
fyi @FabianHofmann @lkstrp 