### PR TITLE
COPT update

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -5,6 +5,7 @@ Upcoming Version
 ----------------
 
 * Added support for arithmetic operations with custom classes.
+* Avoid allocating a floating license for COPT during the initial solver check
 
 Version 0.5.0
 --------------

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -108,8 +108,7 @@ with contextlib.suppress(ModuleNotFoundError):
 with contextlib.suppress(ModuleNotFoundError):
     import coptpy
 
-    with contextlib.suppress(coptpy.CoptError):
-        available_solvers.append("copt")
+    available_solvers.append("copt")
 
 quadratic_solvers = [s for s in QUADRATIC_SOLVERS if s in available_solvers]
 logger = logging.getLogger(__name__)

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -109,8 +109,6 @@ with contextlib.suppress(ModuleNotFoundError):
     import coptpy
 
     with contextlib.suppress(coptpy.CoptError):
-        coptpy.Envr()
-
         available_solvers.append("copt")
 
 quadratic_solvers = [s for s in QUADRATIC_SOLVERS if s in available_solvers]


### PR DESCRIPTION
Removing this line of code stops COPT calling a floating license from a server in cases where COPT is not used to solve the problem. 

Solver still solves as normal on my side after its removal.