### PR TITLE
fix: make sure last slice is included in iterate slices

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -4,6 +4,8 @@ Release Notes
 Upcoming Version
 ----------------
 
+
+* IMPORTANT BUGFIX: The last slice of constraints was not correctly written to LP files in case the constraint size was not a multiple of the slice size. This is fixed now.
 * Solution files that following a different naming scheme of variables and constraints using more than on initial letter in the prefix (e.g. `col123`, `row456`) are now supported.
 
 Version 0.4.3

--- a/linopy/common.py
+++ b/linopy/common.py
@@ -519,7 +519,7 @@ def iterate_slices(
         return
 
     # number of slices
-    n_slices = max(size // slice_size, 1)
+    n_slices = max((size + slice_size - 1) // slice_size, 1)
 
     # leading dimension (the dimension with the largest size)
     sizes = {dim: ds.sizes[dim] for dim in slice_dims}
@@ -533,12 +533,12 @@ def iterate_slices(
     if size_of_leading_dim < n_slices:
         n_slices = size_of_leading_dim
 
-    chunk_size = ds.sizes[leading_dim] // n_slices
+    chunk_size = (ds.sizes[leading_dim] + n_slices - 1) // n_slices
 
     # Iterate over the Cartesian product of slice indices
     for i in range(n_slices):
         start = i * chunk_size
-        end = start + chunk_size
+        end = min(start + chunk_size, size_of_leading_dim)
         slice_dict = {leading_dim: slice(start, end)}
         yield ds.isel(slice_dict)
 


### PR DESCRIPTION
The iteration over constraints did not fully run to the end in case the data size was not divisible by the slice size. This is a really important fix, that people should be should aware of.  