### PR TITLE
feat: move set_int_index to solution assignment in model.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,14 @@ Highs.log
 paper/
 monkeytype.sqlite3
 
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
 
 benchmark/*.pdf
 benchmark/benchmarks

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -1,8 +1,10 @@
 Release Notes
 =============
 
-.. Upcoming Version
-.. ----------------
+Upcoming Version
+----------------
+
+* The internal handling of `Solution` objects was improved for more consistency. Solution objects created from solver calls now preserve the exact index names from the input file, ensuring consistent behavior across all solver functions.
 
 Version 0.4.4
 --------------

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -4,7 +4,7 @@ Release Notes
 Upcoming Version
 ----------------
 
-* The internal handling of `Solution` objects was improved for more consistency. Solution objects created from solver calls now preserve the exact index names from the input file, ensuring consistent behavior across all solver functions.
+* The internal handling of `Solution` objects was improved for more consistency. Solution objects created from solver calls now preserve the exact index names from the input file.
 
 Version 0.4.4
 --------------

--- a/linopy/common.py
+++ b/linopy/common.py
@@ -38,6 +38,16 @@ if TYPE_CHECKING:
     from linopy.variables import Variable
 
 
+def set_int_index(series: pd.Series) -> pd.Series:
+    """
+    Convert string index to int index.
+    """
+    if not series.empty and not series.index.is_integer():
+        cutoff = count_initial_letters(str(series.index[0]))
+        series.index = series.index.str[cutoff:].astype(int)
+    return series
+
+
 def maybe_replace_sign(sign: str) -> str:
     """
     Replace the sign with an alternative sign if available.

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -30,6 +30,7 @@ from linopy.common import (
     best_int,
     maybe_replace_signs,
     replace_by_map,
+    set_int_index,
     to_path,
 )
 from linopy.constants import (
@@ -1189,6 +1190,7 @@ class Model:
 
         # map solution and dual to original shape which includes missing values
         sol = result.solution.primal.copy()
+        sol = set_int_index(sol)
         sol.loc[-1] = nan
 
         for name, var in self.variables.items():
@@ -1201,6 +1203,7 @@ class Model:
 
         if not result.solution.dual.empty:
             dual = result.solution.dual.copy()
+            dual = set_int_index(dual)
             dual.loc[-1] = nan
 
             for name, con in self.constraints.items():

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -47,12 +47,12 @@ from linopy.common import (
     print_coord,
     print_single_variable,
     save_join,
+    set_int_index,
     to_dataframe,
     to_polars,
 )
 from linopy.config import options
 from linopy.constants import HELPER_DIMS, TERM_DIM
-from linopy.solvers import set_int_index
 from linopy.types import NotImplementedType
 
 if TYPE_CHECKING:

--- a/test/test_solvers.py
+++ b/test/test_solvers.py
@@ -53,7 +53,7 @@ def test_free_mps_solution_parsing(solver):
     except ValueError:
         raise ValueError(f"Solver '{solver}' is not recognized")
 
-    with NamedTemporaryFile(mode="w", suffix=".mps") as mps_file:
+    with NamedTemporaryFile(mode="w", suffix=".mps", delete_on_close=False) as mps_file:
         mps_file.write(free_mps_problem)
         mps_file.close()
 

--- a/test/test_solvers.py
+++ b/test/test_solvers.py
@@ -12,8 +12,7 @@ import pytest
 
 from linopy import solvers
 
-free_mps_problem = """
-NAME        sample_mip
+free_mps_problem = """NAME        sample_mip
 ROWS
  N  obj
  G  c1
@@ -54,7 +53,7 @@ def test_free_mps_solution_parsing(solver):
     except ValueError:
         raise ValueError(f"Solver '{solver}' is not recognized")
 
-    with NamedTemporaryFile(mode="w", suffix=".mps", delete_on_close=False) as mps_file:
+    with NamedTemporaryFile(mode="w", suffix=".mps") as mps_file:
         mps_file.write(free_mps_problem)
         mps_file.close()
 

--- a/test/test_solvers.py
+++ b/test/test_solvers.py
@@ -15,10 +15,10 @@ from linopy import solvers
 free_mps_problem = """
 NAME        sample_mip
 ROWS
- N  obj     
- G  c1      
- L  c2      
- E  c3      
+ N  obj
+ G  c1
+ L  c2
+ E  c3
 COLUMNS
     col1        obj       5
     col1        c1        2
@@ -45,6 +45,7 @@ BOUNDS
 ENDATA
 """
 
+
 @pytest.mark.parametrize("solver", solvers.available_solvers)
 def test_free_mps_solution_parsing(solver):
     try:
@@ -59,7 +60,9 @@ def test_free_mps_solution_parsing(solver):
 
         s = solver_class()
         with NamedTemporaryFile(suffix=".sol") as sol_file:
-            result = s.solve_problem(problem_fn=Path(mps_file.name), solution_fn=Path(sol_file.name))
+            result = s.solve_problem(
+                problem_fn=Path(mps_file.name), solution_fn=Path(sol_file.name)
+            )
 
     assert result.status.is_ok
     assert result.solution.objective == 30.0

--- a/test/test_solvers.py
+++ b/test/test_solvers.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""
+Created on Tue Jan 28 09:03:35 2025.
+
+@author: sid
+"""
+
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+import pytest
+
+from linopy import solvers
+
+free_mps_problem = """
+NAME        sample_mip
+ROWS
+ N  obj     
+ G  c1      
+ L  c2      
+ E  c3      
+COLUMNS
+    col1        obj       5
+    col1        c1        2
+    col1        c2        4
+    col1        c3        1
+    MARK0000  'MARKER'                 'INTORG'
+    colu2        obj       3
+    colu2        c1        3
+    colu2        c2        2
+    colu2        c3        1
+    col3        obj       7
+    col3        c1        4
+    col3        c2        3
+    col3        c3        1
+    MARK0001  'MARKER'                 'INTEND'
+RHS
+    RHS_V     c1        12
+    RHS_V     c2        15
+    RHS_V     c3        6
+BOUNDS
+ UP BOUND     col1        4
+ UI BOUND     colu2        3
+ UI BOUND     col3        5
+ENDATA
+"""
+
+@pytest.mark.parametrize("solver", solvers.available_solvers)
+def test_free_mps_solution_parsing(solver):
+    try:
+        solver_enum = solvers.SolverName(solver.lower())
+        solver_class = getattr(solvers, solver_enum.name)
+    except ValueError:
+        raise ValueError(f"Solver '{solver}' is not recognized")
+
+    with NamedTemporaryFile(mode="w", suffix=".mps", delete_on_close=False) as mps_file:
+        mps_file.write(free_mps_problem)
+        mps_file.close()
+
+        s = solver_class()
+        with NamedTemporaryFile(suffix=".sol") as sol_file:
+            result = s.solve_problem(problem_fn=Path(mps_file.name), solution_fn=Path(sol_file.name))
+
+    assert result.status.is_ok
+    assert result.solution.objective == 30.0

--- a/test/test_solvers.py
+++ b/test/test_solvers.py
@@ -53,7 +53,7 @@ def test_free_mps_solution_parsing(solver):
     except ValueError:
         raise ValueError(f"Solver '{solver}' is not recognized")
 
-    with NamedTemporaryFile(mode="w", suffix=".mps", delete_on_close=False) as mps_file:
+    with NamedTemporaryFile(mode="w", suffix=".mps", delete=False) as mps_file:
         mps_file.write(free_mps_problem)
         mps_file.close()
 

--- a/test/test_solvers.py
+++ b/test/test_solvers.py
@@ -9,7 +9,7 @@ import pytest
 
 from linopy import solvers
 
-free_mps_problem = """NAME        sample_mip
+free_mps_problem = """NAME          sample_mip
 ROWS
  N  obj
  G  c1
@@ -42,7 +42,7 @@ ENDATA
 """
 
 
-@pytest.mark.parametrize("solver", solvers.available_solvers)
+@pytest.mark.parametrize("solver", set(solvers.available_solvers))
 def test_free_mps_solution_parsing(solver, tmp_path):
     try:
         solver_enum = solvers.SolverName(solver.lower())


### PR DESCRIPTION
Follow up on #396 

The internal handling of `Solution` objects was improved for more consistency. Solution objects created from solver calls now preserve the exact index names from the input file.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
