### PR TITLE
fix: call GLPK with --freemps instead of --mps

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -11,6 +11,7 @@ Version 0.4.4
 
 * **IMPORTANT BUGFIX**: The last slice of constraints was not correctly written to LP files in case the constraint size was not a multiple of the slice size. This is fixed now.
 * Solution files that following a different naming scheme of variables and constraints using more than on initial letter in the prefix (e.g. `col123`, `row456`) are now supported.
+* GLPK solver is always called with the `--freemps` option instead of the `--mps` when using the Solver API to solve an external MPS file. `--mps` is for the older fixed-column MPS format that is rarely used nowadays. Almost all fixed MPS files can be parsed by the free MPS format.
 
 Version 0.4.3
 --------------

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -551,7 +551,8 @@ class GLPK(Solver):
         Path(solution_fn).parent.mkdir(exist_ok=True)
 
         # TODO use --nopresol argument for non-optimal solution output
-        command = f"glpsol --{io_api} {problem_fn} --output {solution_fn} "
+        io_api_arg = "freemps" if io_api == "mps" else io_api
+        command = f"glpsol --{io_api_arg} {problem_fn} --output {solution_fn} "
         if log_fn is not None:
             command += f"--log {log_fn} "
         if warmstart_fn:

--- a/test/test_solvers.py
+++ b/test/test_solvers.py
@@ -9,7 +9,7 @@ import pytest
 
 from linopy import solvers
 
-free_mps_problem = """NAME          sample_mip
+free_mps_problem = """NAME               sample_mip
 ROWS
  N  obj
  G  c1


### PR DESCRIPTION
Closes #402


## Changes proposed in this Pull Request

GLPK solver is always called with the `--freemps` option instead of the `--mps` when using the Solver API to solve an external MPS file. `--mps` is for the older fixed-column MPS format that is rarely used nowadays. Almost all fixed MPS files can be parsed by the free MPS format.

As @odow says in #402:
> Just always pass --freemps. Pretty much any fixed format MPS file should be parseable as freemps. The only issue might be if there are variable or column names with leading spaces. But JuMP would never write one, and I don't think Linopy would. And anyone that does is cursed.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
