### PR TITLE
fix: unpin numpy<2 for python>3.10

### DIFF
--- a/linopy/common.py
+++ b/linopy/common.py
@@ -8,7 +8,6 @@ This module contains commonly used functions.
 from __future__ import annotations
 
 import operator
-import os
 from collections.abc import Generator, Hashable, Iterable, Sequence
 from functools import reduce, wraps
 from pathlib import Path

--- a/linopy/common.py
+++ b/linopy/common.py
@@ -8,6 +8,7 @@ This module contains commonly used functions.
 from __future__ import annotations
 
 import operator
+import os
 from collections.abc import Generator, Hashable, Iterable, Sequence
 from functools import reduce, wraps
 from pathlib import Path
@@ -317,9 +318,11 @@ def infer_schema_polars(ds: Dataset) -> dict[Hashable, pl.DataType]:
         dict: A dictionary mapping column names to their corresponding Polars data types.
     """
     schema = {}
+    np_major_version = int(np.__version__.split(".")[0])
+    use_int32 = os.name == "nt" and np_major_version < 2
     for name, array in ds.items():
         if np.issubdtype(array.dtype, np.integer):
-            schema[name] = pl.Int64
+            schema[name] = pl.Int32 if use_int32 else pl.Int64
         elif np.issubdtype(array.dtype, np.floating):
             schema[name] = pl.Float64  # type: ignore
         elif np.issubdtype(array.dtype, np.bool_):

--- a/linopy/common.py
+++ b/linopy/common.py
@@ -320,7 +320,7 @@ def infer_schema_polars(ds: Dataset) -> dict[Hashable, pl.DataType]:
     schema = {}
     for name, array in ds.items():
         if np.issubdtype(array.dtype, np.integer):
-            schema[name] = pl.Int32 if os.name == "nt" else pl.Int64
+            schema[name] = pl.Int64
         elif np.issubdtype(array.dtype, np.floating):
             schema[name] = pl.Float64  # type: ignore
         elif np.issubdtype(array.dtype, np.bool_):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ classifiers = [
 
 requires-python = ">=3.9"
 dependencies = [
-    "numpy; sys_platform != 'win32' and python_version > '3.10'",
-    "numpy<2; sys_platform == 'win32' or python_version <= '3.10'",
+    "numpy; python_version > '3.10'",
+    "numpy<2; python_version <= '3.10'",
     "scipy",
     "bottleneck",
     "toolz",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "numpy; sys_platform != 'win32'",
-    "numpy<2; sys_platform == 'win32",
+    "numpy<2; sys_platform == 'win32'",
     "scipy",
     "bottleneck",
     "toolz",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ classifiers = [
 
 requires-python = ">=3.9"
 dependencies = [
-    "numpy<2.0",
+    "numpy; sys_platform != 'win32'",
+    "numpy<2; sys_platform == 'win32",
     "scipy",
     "bottleneck",
     "toolz",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ classifiers = [
 
 requires-python = ">=3.9"
 dependencies = [
-    "numpy; sys_platform != 'win32'",
-    "numpy<2; sys_platform == 'win32'",
+    "numpy; sys_platform != 'win32' and python_version > '3.10'",
+    "numpy<2; sys_platform == 'win32' or python_version <= '3.10'",
     "scipy",
     "bottleneck",
     "toolz",


### PR DESCRIPTION
Remove numpy<2 pin for python>3.10

Taking over from https://github.com/PyPSA/linopy/pull/332