### PR TITLE
Maximize compatability with Datatypes by returning NotImplemented if __add__, __mul__ ... fail

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -4,6 +4,8 @@ Release Notes
 .. Upcoming Version
 .. ----------------
 
+.. * Added support for arithmetic operations with custom classes.
+
 Version 0.5.0
 --------------
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -1,10 +1,10 @@
 Release Notes
 =============
 
-.. Upcoming Version
-.. ----------------
+Upcoming Version
+----------------
 
-.. * Added support for arithmetic operations with custom classes.
+* Added support for arithmetic operations with custom classes.
 
 Version 0.5.0
 --------------

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -542,7 +542,10 @@ class LinearExpression:
         if isinstance(other, (LinearExpression, ScalarLinearExpression)):
             return self._multiply_by_linear_expression(other)
         else:
-            return self._multiply_by_constant(other)
+            try:
+                return self._multiply_by_constant(other)
+            except TypeError:
+                return NotImplemented
 
     def _multiply_by_linear_expression(
         self, other: LinearExpression | ScalarLinearExpression

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -491,7 +491,10 @@ class LinearExpression:
         if np.isscalar(other):
             return self.assign(const=self.const + other)
 
-        other = as_expression(other, model=self.model, dims=self.coord_dims)
+        try:
+            other = as_expression(other, model=self.model, dims=self.coord_dims)
+        except TypeError:
+            return NotImplemented
         return merge([self, other], cls=self.__class__)
 
     def __radd__(self, other: int) -> LinearExpression | NotImplementedType:
@@ -508,7 +511,10 @@ class LinearExpression:
         if np.isscalar(other):
             return self.assign_multiindex_safe(const=self.const - other)
 
-        other = as_expression(other, model=self.model, dims=self.coord_dims)
+        try:
+            other = as_expression(other, model=self.model, dims=self.coord_dims)
+        except TypeError:
+            return NotImplemented
         return merge([self, -other], cls=self.__class__)
 
     def __neg__(self) -> LinearExpression | QuadraticExpression:
@@ -1560,7 +1566,10 @@ class QuadraticExpression(LinearExpression):
         if np.isscalar(other):
             return self.assign(const=self.const + other)
 
-        other = as_expression(other, model=self.model, dims=self.coord_dims)
+        try:
+            other = as_expression(other, model=self.model, dims=self.coord_dims)
+        except TypeError:
+            return NotImplemented
         if type(other) is LinearExpression:
             other = other.to_quadexpr()
         return merge([self, other], cls=self.__class__)  # type: ignore
@@ -1588,8 +1597,10 @@ class QuadraticExpression(LinearExpression):
         """
         if np.isscalar(other):
             return self.assign(const=self.const - other)
-
-        other = as_expression(other, model=self.model, dims=self.coord_dims)
+        try:
+            other = as_expression(other, model=self.model, dims=self.coord_dims)
+        except TypeError:
+            return NotImplemented
         if type(other) is LinearExpression:
             other = other.to_quadexpr()
         return merge([self, -other], cls=self.__class__)  # type: ignore

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -608,15 +608,18 @@ class LinearExpression:
     def __div__(
         self, other: Variable | ConstantLike
     ) -> LinearExpression | QuadraticExpression:
-        if isinstance(
-            other, (LinearExpression, variables.Variable, variables.ScalarVariable)
-        ):
-            raise TypeError(
-                "unsupported operand type(s) for /: "
-                f"{type(self)} and {type(other)}"
-                "Non-linear expressions are not yet supported."
-            )
-        return self.__mul__(1 / other)
+        try:
+            if isinstance(
+                other, (LinearExpression, variables.Variable, variables.ScalarVariable)
+            ):
+                raise TypeError(
+                    "unsupported operand type(s) for /: "
+                    f"{type(self)} and {type(other)}"
+                    "Non-linear expressions are not yet supported."
+                )
+            return self.__mul__(1 / other)
+        except TypeError:
+            return NotImplemented
 
     def __truediv__(
         self, other: Variable | ConstantLike

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -488,14 +488,14 @@ class LinearExpression:
         Note: If other is a numpy array or pandas object without axes names,
         dimension names of self will be filled in other
         """
-        if np.isscalar(other):
-            return self.assign(const=self.const + other)
-
         try:
+            if np.isscalar(other):
+                return self.assign(const=self.const + other)
+
             other = as_expression(other, model=self.model, dims=self.coord_dims)
+            return merge([self, other], cls=self.__class__)
         except TypeError:
             return NotImplemented
-        return merge([self, other], cls=self.__class__)
 
     def __radd__(self, other: int) -> LinearExpression | NotImplementedType:
         # This is needed for using python's sum function
@@ -508,14 +508,14 @@ class LinearExpression:
         Note: If other is a numpy array or pandas object without axes names,
         dimension names of self will be filled in other
         """
-        if np.isscalar(other):
-            return self.assign_multiindex_safe(const=self.const - other)
-
         try:
+            if np.isscalar(other):
+                return self.assign_multiindex_safe(const=self.const - other)
+
             other = as_expression(other, model=self.model, dims=self.coord_dims)
+            return merge([self, -other], cls=self.__class__)
         except TypeError:
             return NotImplemented
-        return merge([self, -other], cls=self.__class__)
 
     def __neg__(self) -> LinearExpression | QuadraticExpression:
         """
@@ -530,22 +530,22 @@ class LinearExpression:
         """
         Multiply the expr by a factor.
         """
-        if isinstance(other, QuadraticExpression):
-            raise TypeError(
-                "unsupported operand type(s) for *: "
-                f"{type(self)} and {type(other)}. "
-                "Higher order non-linear expressions are not yet supported."
-            )
-        elif isinstance(other, (variables.Variable, variables.ScalarVariable)):
-            other = other.to_linexpr()
+        try:
+            if isinstance(other, QuadraticExpression):
+                raise TypeError(
+                    "unsupported operand type(s) for *: "
+                    f"{type(self)} and {type(other)}. "
+                    "Higher order non-linear expressions are not yet supported."
+                )
+            elif isinstance(other, (variables.Variable, variables.ScalarVariable)):
+                other = other.to_linexpr()
 
-        if isinstance(other, (LinearExpression, ScalarLinearExpression)):
-            return self._multiply_by_linear_expression(other)
-        else:
-            try:
+            if isinstance(other, (LinearExpression, ScalarLinearExpression)):
+                return self._multiply_by_linear_expression(other)
+            else:
                 return self._multiply_by_constant(other)
-            except TypeError:
-                return NotImplemented
+        except TypeError:
+            return NotImplemented
 
     def _multiply_by_linear_expression(
         self, other: LinearExpression | ScalarLinearExpression
@@ -1566,16 +1566,17 @@ class QuadraticExpression(LinearExpression):
         Note: If other is a numpy array or pandas object without axes names,
         dimension names of self will be filled in other
         """
-        if np.isscalar(other):
-            return self.assign(const=self.const + other)
-
         try:
+            if np.isscalar(other):
+                return self.assign(const=self.const + other)
+
             other = as_expression(other, model=self.model, dims=self.coord_dims)
+
+            if type(other) is LinearExpression:
+                other = other.to_quadexpr()
+            return merge([self, other], cls=self.__class__)  # type: ignore
         except TypeError:
             return NotImplemented
-        if type(other) is LinearExpression:
-            other = other.to_quadexpr()
-        return merge([self, other], cls=self.__class__)  # type: ignore
 
     def __radd__(
         self, other: LinearExpression | int
@@ -1598,15 +1599,16 @@ class QuadraticExpression(LinearExpression):
         Note: If other is a numpy array or pandas object without axes names,
         dimension names of self will be filled in other
         """
-        if np.isscalar(other):
-            return self.assign(const=self.const - other)
         try:
+            if np.isscalar(other):
+                return self.assign(const=self.const - other)
+
             other = as_expression(other, model=self.model, dims=self.coord_dims)
+            if type(other) is LinearExpression:
+                other = other.to_quadexpr()
+            return merge([self, -other], cls=self.__class__)  # type: ignore
         except TypeError:
             return NotImplemented
-        if type(other) is LinearExpression:
-            other = other.to_quadexpr()
-        return merge([self, -other], cls=self.__class__)  # type: ignore
 
     def __rsub__(self, other: LinearExpression) -> QuadraticExpression:
         """

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -388,9 +388,12 @@ class Variable:
         """
         Multiply variables with a coefficient.
         """
-        if isinstance(other, (expressions.LinearExpression, Variable, ScalarVariable)):
-            return self.to_linexpr() * other
         try:
+            if isinstance(
+                other, (expressions.LinearExpression, Variable, ScalarVariable)
+            ):
+                return self.to_linexpr() * other
+
             return self.to_linexpr(other)
         except TypeError:
             return NotImplemented
@@ -399,10 +402,13 @@ class Variable:
         """
         Power of the variables with a coefficient. The only coefficient allowed is 2.
         """
-        if not other == 2:
-            raise ValueError("Power must be 2.")
-        expr = self.to_linexpr()
-        return expr._multiply_by_linear_expression(expr)
+        try:
+            if not other == 2:
+                raise ValueError("Power must be 2.")
+            expr = self.to_linexpr()
+            return expr._multiply_by_linear_expression(expr)
+        except TypeError:
+            return NotImplemented
 
     def __rmul__(self, other: float | DataArray | int | ndarray) -> LinearExpression:
         """

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -402,13 +402,10 @@ class Variable:
         """
         Power of the variables with a coefficient. The only coefficient allowed is 2.
         """
-        try:
-            if not other == 2:
-                raise ValueError("Power must be 2.")
-            expr = self.to_linexpr()
-            return expr._multiply_by_linear_expression(expr)
-        except TypeError:
-            return NotImplemented
+        if not other == 2:
+            raise ValueError("Power must be 2.")
+        expr = self.to_linexpr()
+        return expr._multiply_by_linear_expression(expr)
 
     def __rmul__(self, other: float | DataArray | int | ndarray) -> LinearExpression:
         """

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -314,10 +314,7 @@ class Variable:
         linopy.LinearExpression
             Linear expression with the variables and coefficients.
         """
-        try:
-            coefficient = as_dataarray(coefficient, coords=self.coords, dims=self.dims)
-        except TypeError:
-            return NotImplemented
+        coefficient = as_dataarray(coefficient, coords=self.coords, dims=self.dims)
         ds = Dataset({"coeffs": coefficient, "vars": self.labels}).expand_dims(
             TERM_DIM, -1
         )

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -393,8 +393,10 @@ class Variable:
         """
         if isinstance(other, (expressions.LinearExpression, Variable, ScalarVariable)):
             return self.to_linexpr() * other
-        else:
+        try:
             return self.to_linexpr(other)
+        except TypeError:
+            return NotImplemented
 
     def __pow__(self, other: int) -> QuadraticExpression:
         """
@@ -409,7 +411,10 @@ class Variable:
         """
         Right-multiply variables with a coefficient.
         """
-        return self.to_linexpr(other)
+        try:
+            return self.to_linexpr(other)
+        except TypeError:
+            return NotImplemented
 
     def __matmul__(
         self, other: LinearExpression | ndarray | Variable
@@ -439,7 +444,10 @@ class Variable:
         """
         True divide variables with a coefficient.
         """
-        return self.__div__(coefficient)
+        try:
+            return self.__div__(coefficient)
+        except TypeError:
+            return NotImplemented
 
     def __add__(
         self, other: int | QuadraticExpression | LinearExpression | Variable
@@ -447,7 +455,10 @@ class Variable:
         """
         Add variables to linear expressions or other variables.
         """
-        return self.to_linexpr() + other
+        try:
+            return self.to_linexpr() + other
+        except TypeError:
+            return NotImplemented
 
     def __radd__(self, other: int) -> Variable | NotImplementedType:
         # This is needed for using python's sum function
@@ -459,7 +470,10 @@ class Variable:
         """
         Subtract linear expressions or other variables from the variables.
         """
-        return self.to_linexpr() - other
+        try:
+            return self.to_linexpr() - other
+        except TypeError:
+            return NotImplemented
 
     def __le__(self, other: SideLike) -> Constraint:
         return self.to_linexpr().__le__(other)

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -314,7 +314,10 @@ class Variable:
         linopy.LinearExpression
             Linear expression with the variables and coefficients.
         """
-        coefficient = as_dataarray(coefficient, coords=self.coords, dims=self.dims)
+        try:
+            coefficient = as_dataarray(coefficient, coords=self.coords, dims=self.dims)
+        except TypeError:
+            return NotImplemented
         ds = Dataset({"coeffs": coefficient, "vars": self.labels}).expand_dims(
             TERM_DIM, -1
         )

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -402,10 +402,10 @@ class Variable:
         """
         Power of the variables with a coefficient. The only coefficient allowed is 2.
         """
-        if not other == 2:
-            raise ValueError("Power must be 2.")
-        expr = self.to_linexpr()
-        return expr._multiply_by_linear_expression(expr)
+        if isinstance(other, int) and other == 2:
+            expr = self.to_linexpr()
+            return expr._multiply_by_linear_expression(expr)
+        return NotImplemented
 
     def __rmul__(self, other: float | DataArray | int | ndarray) -> LinearExpression:
         """

--- a/test/test_compatible_arithmetrics.py
+++ b/test/test_compatible_arithmetrics.py
@@ -1,0 +1,112 @@
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from linopy import Model
+from linopy.testing import assert_linequal
+
+
+class SomeOtherDatatype:
+    """
+    A class that is not a subclass of xarray.DataArray, but stores data in a compatible way.
+    It defines all necessary arithmetrics AND __array_ufunc__ to ensure that operations are
+    performed on the active_data.
+    """
+
+    def __init__(self, data: xr.DataArray) -> None:
+        self.data1 = data
+        self.data2 = data.copy()
+        self.active = 1
+
+    def activate(self, active: int) -> None:
+        self.active = active
+
+    @property
+    def active_data(self) -> xr.DataArray:
+        return self.data1 if self.active == 1 else self.data2
+
+    def __add__(self, other):
+        return self.active_data + other
+
+    def __sub__(self, other):
+        return self.active_data - other
+
+    def __mul__(self, other):
+        return self.active_data * other
+
+    def __truediv__(self, other):
+        return self.active_data / other
+
+    def __radd__(self, other):
+        return other + self.active_data
+
+    def __rsub__(self, other):
+        return other - self.active_data
+
+    def __rmul__(self, other):
+        return other * self.active_data
+
+    def __rtruediv__(self, other):
+        return other / self.active_data
+
+    def __neg__(self):
+        return -self.active_data
+
+    def __pos__(self):
+        return +self.active_data
+
+    def __abs__(self):
+        return abs(self.active_data)
+
+    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+        # Ensure we always use the active_data when interacting with numpy/xarray operations
+        new_inputs = [
+            inp.active_data if isinstance(inp, SomeOtherDatatype) else inp
+            for inp in inputs
+        ]
+        return getattr(ufunc, method)(*new_inputs, **kwargs)
+
+
+@pytest.fixture(
+    params=[
+        (pd.RangeIndex(10, name="first"),),
+        (
+            pd.Index(range(5), name="first"),
+            pd.Index(range(3), name="second"),
+            pd.Index(range(2), name="third"),
+        ),
+    ],
+    ids=["single_dim", "multi_dim"],
+)
+def m(request) -> Model:
+    m = Model()
+    m.add_variables(coords=request.param, name="x")
+    m.add_variables(0, 10, name="z")
+    m.add_constraints(m.variables["x"] >= 0, name="c")
+    return m
+
+
+def test_arithmetric_operations_variable(m: Model) -> None:
+    x = m.variables["x"]
+    data = xr.DataArray(np.random.Generator(*x.shape), coords=x.coords)
+    other_datatype = SomeOtherDatatype(data.copy())
+    assert_linequal(x + data, x + other_datatype)
+    assert_linequal(x - data, x - other_datatype)
+    assert_linequal(x * data, x * other_datatype)
+    assert_linequal(x / data, x / other_datatype)
+
+
+def test_arithmetric_operations_con(m: Model) -> None:
+    c = m.constraints["c"]
+    x = m.variables["x"]
+    data = xr.DataArray(np.random.Generator(*x.shape), coords=x.coords)
+    other_datatype = SomeOtherDatatype(data.copy())
+    assert_linequal(c.lhs + data, c.lhs + other_datatype)
+    assert_linequal(c.lhs - data, c.lhs - other_datatype)
+    assert_linequal(c.lhs * data, c.lhs * other_datatype)
+    assert_linequal(c.lhs / data, c.lhs / other_datatype)
+    assert_linequal(c.rhs + data, c.rhs + other_datatype)
+    assert_linequal(c.rhs - data, c.rhs - other_datatype)
+    assert_linequal(c.rhs * data, c.rhs * other_datatype)
+    assert_linequal(c.rhs / data, c.rhs / other_datatype)

--- a/test/test_compatible_arithmetrics.py
+++ b/test/test_compatible_arithmetrics.py
@@ -104,7 +104,7 @@ def test_arithmetric_operations_variable(m: Model) -> None:
     assert x.__mul__(object()) is NotImplemented  # type: ignore
     assert x.__truediv__(object()) is NotImplemented  # type: ignore
     assert x.__pow__(object()) is NotImplemented  # type: ignore
-    assert x.__pow__(3) is NotImplemented  # type: ignore
+    assert x.__pow__(3) is NotImplemented
 
 
 def test_arithmetric_operations_expr(m: Model) -> None:
@@ -117,10 +117,10 @@ def test_arithmetric_operations_expr(m: Model) -> None:
     assert_linequal(expr - data, expr - other_datatype)
     assert_linequal(expr * data, expr * other_datatype)
     assert_linequal(expr / data, expr / other_datatype)
-    assert expr.__add__(object()) is NotImplemented  # type: ignore
-    assert expr.__sub__(object()) is NotImplemented  # type: ignore
-    assert expr.__mul__(object()) is NotImplemented  # type: ignore
-    assert expr.__truediv__(object()) is NotImplemented  # type: ignore
+    assert expr.__add__(object()) is NotImplemented
+    assert expr.__sub__(object()) is NotImplemented
+    assert expr.__mul__(object()) is NotImplemented
+    assert expr.__truediv__(object()) is NotImplemented
 
 
 def test_arithmetric_operations_con(m: Model) -> None:

--- a/test/test_compatible_arithmetrics.py
+++ b/test/test_compatible_arithmetrics.py
@@ -99,6 +99,12 @@ def test_arithmetric_operations_variable(m: Model) -> None:
     assert_linequal(x * data, x * other_datatype)  # type: ignore
     assert_linequal(x / data, x / other_datatype)  # type: ignore
     assert_linequal(data * x, other_datatype * x)  # type: ignore
+    assert x.__add__(object()) is NotImplemented  # type: ignore
+    assert x.__sub__(object()) is NotImplemented  # type: ignore
+    assert x.__mul__(object()) is NotImplemented  # type: ignore
+    assert x.__truediv__(object()) is NotImplemented  # type: ignore
+    assert x.__pow__(object()) is NotImplemented  # type: ignore
+    assert x.__pow__(3) is NotImplemented  # type: ignore
 
 
 def test_arithmetric_operations_expr(m: Model) -> None:
@@ -111,6 +117,10 @@ def test_arithmetric_operations_expr(m: Model) -> None:
     assert_linequal(expr - data, expr - other_datatype)
     assert_linequal(expr * data, expr * other_datatype)
     assert_linequal(expr / data, expr / other_datatype)
+    assert expr.__add__(object()) is NotImplemented  # type: ignore
+    assert expr.__sub__(object()) is NotImplemented  # type: ignore
+    assert expr.__mul__(object()) is NotImplemented  # type: ignore
+    assert expr.__truediv__(object()) is NotImplemented  # type: ignore
 
 
 def test_arithmetric_operations_con(m: Model) -> None:

--- a/test/test_compatible_arithmetrics.py
+++ b/test/test_compatible_arithmetrics.py
@@ -98,6 +98,7 @@ def test_arithmetric_operations_variable(m: Model) -> None:
     assert_linequal(x - data, x - other_datatype)  # type: ignore
     assert_linequal(x * data, x * other_datatype)  # type: ignore
     assert_linequal(x / data, x / other_datatype)  # type: ignore
+    assert_linequal(data * x, other_datatype * x)  # type: ignore
 
 
 def test_arithmetric_operations_con(m: Model) -> None:

--- a/test/test_compatible_arithmetrics.py
+++ b/test/test_compatible_arithmetrics.py
@@ -89,7 +89,8 @@ def m(request) -> Model:
 
 def test_arithmetric_operations_variable(m: Model) -> None:
     x = m.variables["x"]
-    data = xr.DataArray(np.random.Generator(*x.shape), coords=x.coords)
+    rng = np.random.default_rng()
+    data = xr.DataArray(rng.random(x.shape), coords=x.coords)
     other_datatype = SomeOtherDatatype(data.copy())
     assert_linequal(x + data, x + other_datatype)
     assert_linequal(x - data, x - other_datatype)
@@ -100,7 +101,8 @@ def test_arithmetric_operations_variable(m: Model) -> None:
 def test_arithmetric_operations_con(m: Model) -> None:
     c = m.constraints["c"]
     x = m.variables["x"]
-    data = xr.DataArray(np.random.Generator(*x.shape), coords=x.coords)
+    rng = np.random.default_rng()
+    data = xr.DataArray(rng.random(x.shape), coords=x.coords)
     other_datatype = SomeOtherDatatype(data.copy())
     assert_linequal(c.lhs + data, c.lhs + other_datatype)
     assert_linequal(c.lhs - data, c.lhs - other_datatype)

--- a/test/test_compatible_arithmetrics.py
+++ b/test/test_compatible_arithmetrics.py
@@ -101,6 +101,18 @@ def test_arithmetric_operations_variable(m: Model) -> None:
     assert_linequal(data * x, other_datatype * x)  # type: ignore
 
 
+def test_arithmetric_operations_expr(m: Model) -> None:
+    x = m.variables["x"]
+    expr = x + 3
+    rng = np.random.default_rng()
+    data = xr.DataArray(rng.random(x.shape), coords=x.coords)
+    other_datatype = SomeOtherDatatype(data.copy())
+    assert_linequal(expr + data, expr + other_datatype)
+    assert_linequal(expr - data, expr - other_datatype)
+    assert_linequal(expr * data, expr * other_datatype)
+    assert_linequal(expr / data, expr / other_datatype)
+
+
 def test_arithmetric_operations_con(m: Model) -> None:
     c = m.constraints["c"]
     x = m.variables["x"]


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request
Arithmetic Operations with custom classes, which rely on xarray or another compatible Datatype are now able to define how they interact with `linopy.Variable`, `linopy.LinearExpression` and `linopy.QuadraticExpression`


## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
