### PR TITLE
Adding xpress postsolve if necessary

### DIFF
--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -1478,6 +1478,10 @@ class Xpress(Solver):
 
         m.solve()
 
+        # if the solver is stopped (timelimit for example), postsolve the problem
+        if m.getAttrib("solvestatus") == xpress.solvestatus_stopped:
+            m.postsolve()
+
         if basis_fn is not None:
             try:
                 m.writebasis(path_to_string(basis_fn))


### PR DESCRIPTION
Closes #420  (if applicable).

## Changes proposed in this Pull Request
Small modification to allow a post solve in Xpress, only if necessary, ie if the calculations were stopped.
This correction was tested on an internal problem.

## Checklist

- [ x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [X ] I consent to the release of this PR's code under the MIT license.
