### PR TITLE
fix: empty for linear expressions with terms

### DIFF
--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -9,13 +9,12 @@ from __future__ import annotations
 
 import functools
 import logging
-from collections.abc import Hashable, Iterator, Mapping, Sequence
+from collections.abc import Callable, Hashable, Iterator, Mapping, Sequence
 from dataclasses import dataclass, field
 from itertools import product, zip_longest
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
 )
 from warnings import warn
 
@@ -1352,7 +1351,7 @@ class LinearExpression:
         """
         Get whether the linear expression is empty.
         """
-        return self.shape == (0,)
+        return not self.size
 
     def densify_terms(self) -> LinearExpression:
         """

--- a/test/test_linear_expression.py
+++ b/test/test_linear_expression.py
@@ -539,6 +539,12 @@ def test_linear_expression_loc(x: Variable, y: Variable) -> None:
     assert expr.loc[0].size < expr.loc[:5].size
 
 
+def test_linear_expression_empty(v: Variable) -> None:
+    expr = 7 * v
+    assert not expr.empty()
+    assert expr.loc[[]].empty()
+
+
 def test_linear_expression_isnull(v: Variable) -> None:
     expr = np.arange(20) * v
     filter = (expr.coeffs >= 10).any(TERM_DIM)


### PR DESCRIPTION
## Changes proposed in this Pull Request

The `.empty()` method was testing for `.shape == (0,)` which is incorrect, when there
are any other dimensions. Instead here we rely on `not .size` which is equivalent to `np.prod(.shape)`.

The first commit adds a failing test. The second commit fixes it.


## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
