### PR TITLE
fix: change empty to property

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -3,6 +3,13 @@ Release Notes
 
 Upcoming Version
 ----------------
+**Deprecations**
+
+* Renamed `expression.empty()` to `expression.empty` to align with the use of empty in
+  pandas. A custom wrapper ensures that `expression.empty()` continues to work, but emits
+  a DeprecationWarning.
+
+**Features**
 
 * Added support for arithmetic operations with custom classes.
 * Avoid allocating a floating license for COPT during the initial solver check

--- a/linopy/common.py
+++ b/linopy/common.py
@@ -1026,10 +1026,10 @@ class EmptyDeprecationWrapper:
     def __bool__(self) -> bool:
         return self.value
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return repr(self.value)
 
-    def __call__(self):
+    def __call__(self) -> bool:
         warn(
             "Calling `.empty()` is deprecated, use `.empty` property instead",
             DeprecationWarning,

--- a/linopy/common.py
+++ b/linopy/common.py
@@ -1005,3 +1005,34 @@ class LocIndexer(Generic[LocT]):
             labels = indexing.expanded_indexer(key, self.object.ndim)
             key = dict(zip(self.object.dims, labels))
         return self.object.sel(key)
+
+
+class EmptyDeprecationWrapper:
+    """
+    Temporary wrapper for a smooth transition from .empty() to .empty
+
+    Use `bool(expr.empty)` to explicitly unwrap.
+
+    See Also
+    --------
+    https://github.com/PyPSA/linopy/pull/425
+    """
+
+    __slots__ = ("value",)
+
+    def __init__(self, value: bool):
+        self.value = value
+
+    def __bool__(self) -> bool:
+        return self.value
+
+    def __repr__(self):
+        return repr(self.value)
+
+    def __call__(self):
+        warn(
+            "Calling `.empty()` is deprecated, use `.empty` property instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.value

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -37,6 +37,7 @@ from xarray.core.utils import Frozen
 
 from linopy import constraints, variables
 from linopy.common import (
+    EmptyDeprecationWrapper,
     LocIndexer,
     as_dataarray,
     assign_multiindex_safe,
@@ -1348,11 +1349,15 @@ class LinearExpression:
         return self.vars.size
 
     @property
-    def empty(self) -> bool:
+    def empty(self) -> EmptyDeprecationWrapper:
         """
         Get whether the linear expression is empty.
+
+        .. versionchanged:: 0.5.1
+           Returns a EmptyDeprecationWrapper which behaves like a bool and emits
+           a DeprecationWarning when called.
         """
-        return not self.size
+        return EmptyDeprecationWrapper(not self.size)
 
     def densify_terms(self) -> LinearExpression:
         """

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -1347,6 +1347,7 @@ class LinearExpression:
         """
         return self.vars.size
 
+    @property
     def empty(self) -> bool:
         """
         Get whether the linear expression is empty.

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -9,10 +9,10 @@ from __future__ import annotations
 import logging
 import os
 import re
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 from tempfile import NamedTemporaryFile, gettempdir
-from typing import Any, Callable
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -705,7 +705,7 @@ class Model:
             The objective function assigned to the model.
         """
         if not overwrite:
-            assert self.objective.expression.empty(), (
+            assert self.objective.expression.empty, (
                 "Objective already defined."
                 " Set `overwrite` to True to force overwriting."
             )

--- a/test/test_linear_expression.py
+++ b/test/test_linear_expression.py
@@ -541,8 +541,8 @@ def test_linear_expression_loc(x: Variable, y: Variable) -> None:
 
 def test_linear_expression_empty(v: Variable) -> None:
     expr = 7 * v
-    assert not expr.empty()
-    assert expr.loc[[]].empty()
+    assert not expr.empty
+    assert expr.loc[[]].empty
 
 
 def test_linear_expression_isnull(v: Variable) -> None:

--- a/test/test_linear_expression.py
+++ b/test/test_linear_expression.py
@@ -544,6 +544,9 @@ def test_linear_expression_empty(v: Variable) -> None:
     assert not expr.empty
     assert expr.loc[[]].empty
 
+    with pytest.warns(DeprecationWarning, match="use `.empty` property instead"):
+        assert expr.loc[[]].empty()
+
 
 def test_linear_expression_isnull(v: Variable) -> None:
     expr = np.arange(20) * v


### PR DESCRIPTION
In view of #424 (ie. empty being mostly True automatically), i would argue the current use of `empty` is quite limited and i'd prefer to take this chance to make it a `property` as it is in pandas, since it is today too easy to misuse as `expr.empty` which is always truthy.

~Contrarily the upgrade path from `expr.empty()` to `expr.empty` will always raise a clear Exception.~

Update: Added the wrapper that @FabianHofmann sketched below to smooth the transition.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
