### PR TITLE
feat: add method wrapper for xr.align

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -4,7 +4,10 @@ Release Notes
 Upcoming Version
 ----------------
 
+** Features **
+
 * Added support for arithmetic operations with custom classes.
+* Added `align` function as a wrapper around :func:`xr.align`.
 
 Version 0.5.0
 --------------

--- a/linopy/__init__.py
+++ b/linopy/__init__.py
@@ -12,6 +12,7 @@ __version__ = version("linopy")
 # Note: For intercepting multiplications between xarray dataarrays, Variables and Expressions
 # we need to extend their __mul__ functions with a quick special case
 import linopy.monkey_patch_xarray  # noqa: F401
+from linopy.common import align
 from linopy.config import options
 from linopy.constants import EQUAL, GREATER_EQUAL, LESS_EQUAL
 from linopy.constraints import Constraint, Constraints
@@ -35,6 +36,7 @@ __all__ = (
     "Variable",
     "Variables",
     "available_solvers",
+    "align",
     "merge",
     "options",
     "read_netcdf",

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -9,15 +9,20 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
+from test_linear_expression import m, u, x  # noqa: F401
 from xarray import DataArray
+from xarray.testing.assertions import assert_equal
 
+from linopy import Model, Variable
 from linopy.common import (
+    align,
     as_dataarray,
     assign_multiindex_safe,
     best_int,
     get_dims_with_index_levels,
     iterate_slices,
 )
+from linopy.testing import assert_linequal, assert_varequal
 
 
 def test_as_dataarray_with_series_dims_default() -> None:
@@ -644,3 +649,42 @@ def test_get_dims_with_index_levels() -> None:
     # Test case 5: Empty dataset
     ds5 = xr.Dataset()
     assert get_dims_with_index_levels(ds5) == []
+
+
+def test_align(m: Model, x: Variable, u: Variable) -> None:
+    alpha = xr.DataArray([1, 2], [[1, 2]])
+    beta = xr.DataArray(
+        [1, 2, 3],
+        [
+            (
+                "dim_3",
+                pd.MultiIndex.from_tuples(
+                    [(1, "b"), (2, "b"), (1, "c")], names=["level1", "level2"]
+                ),
+            )
+        ],
+    )
+
+    # inner join
+    x_obs, alpha_obs = align(x, alpha)
+    assert x_obs.shape == alpha_obs.shape == (1,)
+    assert_varequal(x_obs, x.loc[[1]])
+
+    # left-join
+    x_obs, alpha_obs = align(x, alpha, join="left")
+    assert x_obs.shape == alpha_obs.shape == (2,)
+    assert_varequal(x_obs, x)
+    assert_equal(alpha_obs, DataArray([np.nan, 1], [[0, 1]]))
+
+    # multiindex
+    beta_obs, u_obs = align(beta, u)
+    assert u_obs.shape == beta_obs.shape == (2,)
+    assert_varequal(u_obs, u.loc[[(1, "b"), (2, "b")]])
+    assert_equal(beta_obs, beta.loc[[(1, "b"), (2, "b")]])
+
+    # with linear expression
+    expr = 20 * x
+    x_obs, expr_obs, alpha_obs = align(x, expr, alpha)
+    assert x_obs.shape == alpha_obs.shape == (1,)
+    assert expr_obs.shape == (1, 1)  # _term dim
+    assert_linequal(expr_obs, expr.loc[[1]])


### PR DESCRIPTION
## Changes proposed in this Pull Request

Adds a wrapper which allows aligning linear expressions and dataarrays and variables.

### Usage

```python
>>> import linopy as lp
>>> m = lp.Model()
>>> x = m.add_variables(pd.Series([0, 0]), 1, name="x")
>>> alpha = xr.DataArray([1, 2], [[1, 2]])
>>> x_a, alpha = lp.align(x, alpha)
>>> x_a
Variable (dim_0: 1)
-------------------
[1]: x[1] ∈ [0, 1]
```

### Alternative

Note that there would also be the alternative implementation strategy to implement the `Alignable` protocol for `Variable` and `LinearExpression`.

https://github.com/pydata/xarray/blob/852ad1135b9b8c46d8e301c9badbe898bd6d262d/xarray/core/types.py#L125-L166

but i did not test that, and i am unsure whether we could choose dimension exclusions that way. 





## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
