### PR TITLE
Fix MindOpt floating release

### DIFF
--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -2126,7 +2126,7 @@ class MindOpt(Solver):
 
         solution = self.safe_get_solution(status=status, func=get_solver_solution)
         solution = maybe_adjust_objective_sign(solution, io_api, sense)
-        
+
         m.dispose()
         env_.dispose()
 

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -2126,7 +2126,8 @@ class MindOpt(Solver):
 
         solution = self.safe_get_solution(status=status, func=get_solver_solution)
         solution = maybe_adjust_objective_sign(solution, io_api, sense)
-
+        
+        m.dispose()
         env_.dispose()
 
         return Result(status, solution, m)


### PR DESCRIPTION
## Changes proposed in this Pull Request
MindOpt's floating license token fails to release unless m.dispose() is called. Adding this under the MindOpt class in solvers.py fixes the issue. However, I am not sure if this is best place to dispose of the model or if the returned m value gets used further.

## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [ x] I consent to the release of this PR's code under the MIT license.
