### PR TITLE
remove future warned scalar get item

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -4,6 +4,10 @@ Release Notes
 Upcoming Version
 ----------------
 
+**Breaking Changes**
+
+* The selection of a single item in `__getitem__` now returns a `Variable` instead of a `ScalarVariable`.
+
 Version 0.5.1
 --------------
 

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -192,22 +192,9 @@ class Variable:
     def __getitem__(
         self, selector: list[int] | int | slice | tuple[int64, str_]
     ) -> Variable | ScalarVariable:
-        keys = selector if isinstance(selector, tuple) else (selector,)
-        if all(map(pd.api.types.is_scalar, keys)):
-            warn(
-                "Accessing a single value with `Variable[...]` and return type "
-                "ScalarVariable is deprecated. In future, this will return a Variable."
-                "To get a ScalarVariable use `Variable.at[...]` instead.",
-                FutureWarning,
-            )
-            return self.at[keys]
-
-        else:
-            # return selected Variable
-            data = Dataset(
-                {k: self.data[k][selector] for k in self.data}, attrs=self.attrs
-            )
-            return self.__class__(data, self.model, self.name)
+        # return selected Variable
+        data = Dataset({k: self.data[k][selector] for k in self.data}, attrs=self.attrs)
+        return self.__class__(data, self.model, self.name)
 
     @property
     def attrs(self) -> dict[str, Hashable]:

--- a/test/test_variable.py
+++ b/test/test_variable.py
@@ -72,11 +72,10 @@ def test_wrong_variable_init(m: Model, x: linopy.Variable) -> None:
 
 
 def test_variable_getter(x: linopy.Variable, z: linopy.Variable) -> None:
-    with pytest.warns(FutureWarning):
-        assert isinstance(x[0], linopy.variables.ScalarVariable)
-        assert isinstance(z[0], linopy.variables.ScalarVariable)
+    assert isinstance(x[0], linopy.variables.Variable)
+    assert isinstance(z[0], linopy.variables.Variable)
 
-    assert isinstance(x.at[0], linopy.variables.ScalarVariable)
+    assert isinstance(x.at[0], linopy.variables.Variable)
 
 
 def test_variable_getter_slice(x: linopy.Variable) -> None:


### PR DESCRIPTION
Removes feature that was future warned for a long time now:

The selection of a single item in `__getitem__` now returns a `Variable` instead of a `ScalarVariable`.


- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
