### PR TITLE
Support pickling a linopy model

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -13,6 +13,10 @@ Version 0.5.2
 This is mainly affecting operations where single numerical items from  pandas objects
 are selected and used for multiplication.
 
+**Feature**
+
+* Support pickling models.
+
 Version 0.5.1
 --------------
 

--- a/linopy/constraints.py
+++ b/linopy/constraints.py
@@ -755,9 +755,12 @@ class Constraints:
         raise AttributeError(
             f"Constraints has no attribute `{name}` or the attribute is not accessible, e.g. raises an error."
         )
-    
-    def __getstate__(self): return self.__dict__
-    def __setstate__(self, d): return self.__dict__.update(d)
+
+    def __getstate__(self):
+        return self.__dict__
+
+    def __setstate__(self, d):
+        return self.__dict__.update(d)
 
     def __dir__(self) -> list[str]:
         base_attributes = list(super().__dir__())

--- a/linopy/constraints.py
+++ b/linopy/constraints.py
@@ -759,7 +759,7 @@ class Constraints:
     def __getstate__(self) -> dict:
         return self.__dict__
 
-    def __setstate__(self, d : dict):
+    def __setstate__(self, d: dict):
         self.__dict__.update(d)
 
     def __dir__(self) -> list[str]:

--- a/linopy/constraints.py
+++ b/linopy/constraints.py
@@ -755,6 +755,9 @@ class Constraints:
         raise AttributeError(
             f"Constraints has no attribute `{name}` or the attribute is not accessible, e.g. raises an error."
         )
+    
+    def __getstate__(self): return self.__dict__
+    def __setstate__(self, d): return self.__dict__.update(d)
 
     def __dir__(self) -> list[str]:
         base_attributes = list(super().__dir__())

--- a/linopy/constraints.py
+++ b/linopy/constraints.py
@@ -756,11 +756,11 @@ class Constraints:
             f"Constraints has no attribute `{name}` or the attribute is not accessible, e.g. raises an error."
         )
 
-    def __getstate__(self):
+    def __getstate__(self) -> dict:
         return self.__dict__
 
-    def __setstate__(self, d):
-        return self.__dict__.update(d)
+    def __setstate__(self, d : dict):
+        self.__dict__.update(d)
 
     def __dir__(self) -> list[str]:
         base_attributes = list(super().__dir__())

--- a/linopy/constraints.py
+++ b/linopy/constraints.py
@@ -759,7 +759,7 @@ class Constraints:
     def __getstate__(self) -> dict:
         return self.__dict__
 
-    def __setstate__(self, d: dict):
+    def __setstate__(self, d: dict) -> None:
         self.__dict__.update(d)
 
     def __dir__(self) -> list[str]:

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -1181,6 +1181,9 @@ class Variables:
         raise AttributeError(
             f"Variables has no attribute `{name}` or the attribute is not accessible / raises an error."
         )
+    
+    def __getstate__(self): return self.__dict__
+    def __setstate__(self, d): return self.__dict__.update(d)
 
     def __dir__(self) -> list[str]:
         base_attributes = list(super().__dir__())

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -1185,7 +1185,7 @@ class Variables:
     def __getstate__(self) -> dict:
         return self.__dict__
 
-    def __setstate__(self, d: dict):
+    def __setstate__(self, d: dict) -> None:
         self.__dict__.update(d)
 
     def __dir__(self) -> list[str]:

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -1182,11 +1182,11 @@ class Variables:
             f"Variables has no attribute `{name}` or the attribute is not accessible / raises an error."
         )
 
-    def __getstate__(self):
+    def __getstate__(self) -> dict:
         return self.__dict__
 
-    def __setstate__(self, d):
-        return self.__dict__.update(d)
+    def __setstate__(self, d : dict):
+        self.__dict__.update(d)
 
     def __dir__(self) -> list[str]:
         base_attributes = list(super().__dir__())

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -1185,7 +1185,7 @@ class Variables:
     def __getstate__(self) -> dict:
         return self.__dict__
 
-    def __setstate__(self, d : dict):
+    def __setstate__(self, d: dict):
         self.__dict__.update(d)
 
     def __dir__(self) -> list[str]:

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -1181,9 +1181,12 @@ class Variables:
         raise AttributeError(
             f"Variables has no attribute `{name}` or the attribute is not accessible / raises an error."
         )
-    
-    def __getstate__(self): return self.__dict__
-    def __setstate__(self, d): return self.__dict__.update(d)
+
+    def __getstate__(self):
+        return self.__dict__
+
+    def __setstate__(self, d):
+        return self.__dict__.update(d)
 
     def __dir__(self) -> list[str]:
         base_attributes = list(super().__dir__())

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -5,13 +5,13 @@ Created on Thu Mar 18 09:03:35 2021.
 @author: fabian
 """
 
+import pickle
 from pathlib import Path
 from typing import Union
 
 import pandas as pd
 import pytest
 import xarray as xr
-import pickle
 
 from linopy import LESS_EQUAL, Model, available_solvers, read_netcdf
 from linopy.testing import assert_model_equal
@@ -109,16 +109,17 @@ def test_model_to_netcdf_with_status_and_condition(
 
     assert_model_equal(m, p)
 
+
 def test_pickle_model(model_with_dash_names: Model, tmp_path: Path):
     m = model_with_dash_names
     fn = tmp_path / "test.nc"
     m._status = "ok"
     m._termination_condition = "optimal"
 
-    with open(fn, 'wb') as f:
+    with open(fn, "wb") as f:
         pickle.dump(m, f)
 
-    with open(fn, 'rb') as f:
+    with open(fn, "rb") as f:
         p = pickle.load(f)
 
     assert_model_equal(m, p)

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -11,6 +11,7 @@ from typing import Union
 import pandas as pd
 import pytest
 import xarray as xr
+import pickle
 
 from linopy import LESS_EQUAL, Model, available_solvers, read_netcdf
 from linopy.testing import assert_model_equal
@@ -105,6 +106,20 @@ def test_model_to_netcdf_with_status_and_condition(
     m._termination_condition = "optimal"
     m.to_netcdf(fn)
     p = read_netcdf(fn)
+
+    assert_model_equal(m, p)
+
+def test_pickle_model(model_with_dash_names: Model, tmp_path: Path):
+    m = model_with_dash_names
+    fn = tmp_path / "test.nc"
+    m._status = "ok"
+    m._termination_condition = "optimal"
+
+    with open(fn, 'wb') as f:
+        pickle.dump(m, f)
+
+    with open(fn, 'rb') as f:
+        p = pickle.load(f)
 
     assert_model_equal(m, p)
 

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -110,7 +110,7 @@ def test_model_to_netcdf_with_status_and_condition(
     assert_model_equal(m, p)
 
 
-def test_pickle_model(model_with_dash_names: Model, tmp_path: Path):
+def test_pickle_model(model_with_dash_names: Model, tmp_path: Path) -> None:
     m = model_with_dash_names
     fn = tmp_path / "test.nc"
     m._status = "ok"


### PR DESCRIPTION
Closes #340 .

## Changes proposed in this Pull Request

Defining `__getstate__` and `__setstate__` helps avoid a potential recursion error during pickling, especially in classes that override `__getattr__`. Since `__getattr__` is called whenever an attribute is not found, an implicit or default pickling process might unintentionally trigger it, leading to infinite recursion. By explicitly specifying how the object's state should be serialized (`__getstate__`) and restored (`__setstate__`), the class ensures that only its actual attributes are processed, preventing unnecessary lookups and recursion errors during pickling and unpickling.


## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
