### PR TITLE
feat: termination condition mapping for highs solver

### DIFF
--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -866,7 +866,9 @@ class Highs(Solver):
         h.run()
 
         condition = h.getModelStatus()
-        termination_condition = CONDITION_MAP.get(condition, TerminationCondition.unknown)
+        termination_condition = CONDITION_MAP.get(
+            condition, TerminationCondition.unknown
+        )
         status = Status.from_termination_condition(termination_condition)
         status.legacy_status = h.modelStatusToString(condition)
 


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request

Explicit mapping from highs model status to linopy termination conditions. Previously it was relying on calling `.lower()` on the output of `h.modelStatusToString`, but that only captures the `optimal` and `infeasible` cases.

See https://github.com/ERGO-Code/HiGHS/blob/fd8665394edfd096c4f847c4a6fbc187364ef474/src/lp_data/HighsModelUtils.cpp#L1330 for the outputs of `h.modelStatusToString`.

## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
