### PR TITLE
fix: don't disable presolve and fix dual value retrieval for SCIP

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -1,8 +1,12 @@
 Release Notes
 =============
 
-.. Upcoming Version
-.. ----------------
+Upcoming Version
+----------------
+
+**Bug Fixes**
+
+* Fix the retrieval of solutions from the SCIP solver, and do not turn off presolve.
 
 Version 0.5.2
 --------------

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -472,11 +472,6 @@ class CBC(Solver):
             sol = df[variables_b][2]
             dual = df[~variables_b][3]
 
-            # import ipdb
-            # ipdb.set_trace()
-            # TODO the problem is that this sol file has both rows and columns in it, and uses original names
-            # linopy requires highs for MPS files anyway, so we can use highs for MPS to tell which ones are vars
-
             return Solution(sol, dual, objective)
 
         solution = self.safe_get_solution(status=status, func=get_solver_solution)

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -1362,14 +1362,23 @@ class SCIP(Solver):
             objective = m.getObjVal()
 
             s = m.getSols()[0]
-            sol = pd.Series({v.name: s[v] for v in m.getVars()})
-            sol.drop(
-                ["quadobjvar", "qmatrixvar"], errors="ignore", inplace=True, axis=0
+            sol = pd.Series(
+                {
+                    v.name: s[v]
+                    for v in m.getVars()
+                    if v.name not in {"quadobjvar", "qmatrixvar"}
+                }
             )
 
             cons = m.getConss(False)
             if len(cons) != 0:
-                dual = pd.Series({c.name: m.getDualSolVal(c) for c in cons})
+                dual = pd.Series(
+                    {
+                        c.name: m.getDualSolVal(c)
+                        for c in cons
+                        if c.name not in {"quadobjvar", "qmatrixvar"}
+                    }
+                )
             else:
                 logger.warning("Dual values not available (is this an MILP?)")
                 dual = pd.Series(dtype=float)

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -1360,14 +1360,11 @@ class SCIP(Solver):
 
         def get_solver_solution() -> Solution:
             objective = m.getObjVal()
+            vars_to_ignore = {"quadobjvar", "qmatrixvar", "quadobj", "qmatrix"}
 
             s = m.getSols()[0]
             sol = pd.Series(
-                {
-                    v.name: s[v]
-                    for v in m.getVars()
-                    if v.name not in {"quadobjvar", "qmatrixvar"}
-                }
+                {v.name: s[v] for v in m.getVars() if v.name not in vars_to_ignore}
             )
 
             cons = m.getConss(False)
@@ -1376,7 +1373,7 @@ class SCIP(Solver):
                     {
                         c.name: m.getDualSolVal(c)
                         for c in cons
-                        if c.name not in {"quadobjvar", "qmatrixvar"}
+                        if c.name not in vars_to_ignore
                     }
                 )
             else:


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request

Feedback from SCIP developers in https://github.com/open-energy-transition/solver-benchmark/issues/148 indicates that linopy might be making an error when retrieving dual solution values from SCIP. Also, they recommend against disabling presolve, which might have been done in order to retrieve dual solution values. This PR makes both changes.

I think we might not need a separate function for LPs and MILPs, since the dual retrieval code is in an if-then block?

We should also test that removing the code that filters dual variable names to only those starting with `c` or `cf` is no longer necessary.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
