### PR TITLE
fix: use HiGHS to parse CBC sol correctly

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -1,8 +1,13 @@
 Release Notes
 =============
 
-.. Upcoming Version
-.. ----------------
+Upcoming Version
+----------------
+
+**Bug Fixes**
+
+* Fix the parsing of solutions returned by the CBC solver when solving from a file to not
+  assume that variables start with `x`.
 
 Version 0.5.2
 --------------


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request

CBC's `solve_problem_from_file` method was assuming that all variables start with `x` which is not true when calling the solver on a pre-existing MPS file. This PR uses `highspy` to parse the input file and get the set of variable names, which can then be used as a more accurate filter when parsing CBC's solution file.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
