### PR TITLE
fix: remove highs log file default

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -1,9 +1,13 @@
 Release Notes
 =============
 
-.. Upcoming Version
-.. ----------------
+Upcoming Version
+----------------
 
+**Bug Fixes**
+
+* Remove default highs log file when `log_fn=None` and `io_api="direct"`. This caused `log_file` in
+`solver_options` to be ignored.
 
 Version 0.5.3
 --------------

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -733,9 +733,6 @@ class Highs(Solver):
 
         h = model.to_highspy(explicit_coordinate_names=explicit_coordinate_names)
 
-        if log_fn is None and model is not None:
-            log_fn = model.solver_dir / "highs.log"
-
         return self._solve(
             h,
             solution_fn,


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request

The linopy interface to highs seems to be the only solver interface that will default to writing a log file if the users leaves `log_fn` as `None`. This may be intentional but it doesn't seem like it! It's only for the `io_api="direct"` route this happens.

I realised this because I am passing `log_file` in `solver_options` instead of using `log_fn` argument, but what I was specifying in `solver_options` was being ignored.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
