### PR TITLE
feat: termination condition map for SCIP solver

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -1,9 +1,12 @@
 Release Notes
 =============
 
-.. Upcoming Version
-.. ----------------
+Upcoming Version
+----------------
 
+**Bug Fixes**
+
+* Improve the mapping of termination conditions for the SCIP solver
 
 Version 0.5.3
 --------------

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -1341,7 +1341,23 @@ class SCIP(Solver):
         -------
         Result
         """
-        CONDITION_MAP: dict[str, str] = {}
+        CONDITION_MAP: dict[str, str] = {
+            # https://github.com/scipopt/scip/blob/b2bac412222296ff2b7f2347bb77d5fc4e05a2a1/src/scip/type_stat.h#L40
+            "inforunbd": TerminationCondition.infeasible_or_unbounded,
+            "userinterrupt": TerminationCondition.user_interrupt,
+            "terminate": TerminationCondition.user_interrupt,
+            "nodelimit": TerminationCondition.terminated_by_limit,
+            "totalnodelimit": TerminationCondition.terminated_by_limit,
+            "stallnodelimit": TerminationCondition.terminated_by_limit,
+            "timelimit": TerminationCondition.time_limit,
+            "memlimit": TerminationCondition.terminated_by_limit,
+            "gaplimit": TerminationCondition.terminated_by_limit,
+            "primallimit": TerminationCondition.terminated_by_limit,
+            "duallimit": TerminationCondition.terminated_by_limit,
+            "sollimit": TerminationCondition.terminated_by_limit,
+            "bestsollimit": TerminationCondition.terminated_by_limit,
+            "restartlimit": TerminationCondition.terminated_by_limit,
+        }
 
         io_api = read_io_api_from_problem_file(problem_fn)
         sense = read_sense_from_problem_file(problem_fn)

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -1341,7 +1341,7 @@ class SCIP(Solver):
         -------
         Result
         """
-        CONDITION_MAP: dict[str, str] = {
+        CONDITION_MAP: dict[str, TerminationCondition] = {
             # https://github.com/scipopt/scip/blob/b2bac412222296ff2b7f2347bb77d5fc4e05a2a1/src/scip/type_stat.h#L40
             "inforunbd": TerminationCondition.infeasible_or_unbounded,
             "userinterrupt": TerminationCondition.user_interrupt,


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request

Currently, if the user sets the `limits/gap` SCIP solver option to stop solving MIPs when a certain duality gap is reached, then linopy reports the termination condition as unknown. This PR tries to map the SCIP statuses to linopy termination conditions, using
https://github.com/scipopt/scip/blob/b2bac412222296ff2b7f2347bb77d5fc4e05a2a1/src/scip/type_stat.h#L40

(CC @pfetsch, I couldn't find the exact mapping from the enum integers to the strings returned by `pyscipopt` so I guessed that it's the same as the names of the enums)

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
