### PR TITLE
fix: treat SCIP condition gaplimit as optimal

### DIFF
--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -1369,7 +1369,7 @@ class SCIP(Solver):
             "stallnodelimit": TerminationCondition.terminated_by_limit,
             "timelimit": TerminationCondition.time_limit,
             "memlimit": TerminationCondition.terminated_by_limit,
-            "gaplimit": TerminationCondition.terminated_by_limit,
+            "gaplimit": TerminationCondition.optimal,
             "primallimit": TerminationCondition.terminated_by_limit,
             "duallimit": TerminationCondition.terminated_by_limit,
             "sollimit": TerminationCondition.terminated_by_limit,


### PR DESCRIPTION
## Changes proposed in this Pull Request

As a SCIP developer pointed out in https://github.com/PyPSA/linopy/pull/447#issuecomment-2830165553 the "gap limit reached" condition should be treated as an optimal termination condition.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
