### PR TITLE
fix: don't return OK for GLPK status integer undefined

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -9,6 +9,7 @@ Upcoming Version
 * Fix the parsing of solutions returned by the CBC solver when setting a MIP duality
   gap tolerance.
 * Improve the mapping of termination conditions for the SCIP solver
+* Treat GLPK's `integer undefined` status as not-OK
 
 Version 0.5.3
 --------------

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -573,6 +573,7 @@ class GLPK(Solver):
         """
         CONDITION_MAP = {
             "integer optimal": "optimal",
+            "integer undefined": "infeasible_or_unbounded",
             "undefined": "infeasible_or_unbounded",
         }
         sense = read_sense_from_problem_file(problem_fn)

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -1369,7 +1369,7 @@ class SCIP(Solver):
             "stallnodelimit": TerminationCondition.terminated_by_limit,
             "timelimit": TerminationCondition.time_limit,
             "memlimit": TerminationCondition.terminated_by_limit,
-            "gaplimit": TerminationCondition.terminated_by_limit,
+            "gaplimit": TerminationCondition.optimal,
             "primallimit": TerminationCondition.terminated_by_limit,
             "duallimit": TerminationCondition.terminated_by_limit,
             "sollimit": TerminationCondition.terminated_by_limit,


### PR DESCRIPTION
## Changes proposed in this Pull Request

When running GLPK on [this file](https://raw.githubusercontent.com/jump-dev/open-energy-modeling-benchmarks/main/instances/Sienna_modified_RTS_GMLC_DA_sys_NetCopperPlate_Horizon12_Day314-16130d073126ae057331ac06d84b99ec39ec673d90e6905b97d4a63326b48708.mps.gz), it has an internal error and returns
```
Status:     INTEGER UNDEFINED
```
along with an all-zero solution. Currently, linopy treats this as an `ok` status because `solvers.safe_get_solution` converts unknown status to ok if solutions can be parsed (even though this is a zero solution) -- should this behavior be changed?
https://github.com/PyPSA/linopy/blob/6ea300fd04a722dad0f2ac7008e539a53e4b40a8/linopy/solvers.py#L226-L230

For now, I've added this status to the condition map and this makes linopy return a `warning` status instead, which is good enough for the benchmark project.

(Note: I've chained this PR to be merged after the previous one, in an attempt to optimize the number of times the CI is run 😅 )

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
