### PR TITLE
Add useful error message for missing highspy. Allow variable objective

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ benchmark/notebooks/.ipynb_checkpoints
 benchmark/scripts/__pycache__
 benchmark/scripts/benchmarks-pypsa-eur/__pycache__
 benchmark/scripts/leftovers/
+
+# IDE
+.idea

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -12,6 +12,7 @@ Upcoming Version
   gap tolerance.
 * Improve the mapping of termination conditions for the SCIP solver
 * Treat GLPK's `integer undefined` status as not-OK
+* Allow the objective to be set by a variable instead of an expression
 
 Version 0.5.3
 --------------

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -683,7 +683,8 @@ class Model:
 
     def add_objective(
         self,
-        expr: LinearExpression
+        expr: Variable
+        | LinearExpression
         | QuadraticExpression
         | Sequence[tuple[ConstantLike, VariableLike]],
         overwrite: bool = False,
@@ -709,6 +710,8 @@ class Model:
                 "Objective already defined."
                 " Set `overwrite` to True to force overwriting."
             )
+        if isinstance(expr, Variable):
+            expr = expr * 1.0  #  Convert to expression
         self.objective.expression = expr  # type: ignore[assignment]
         self.objective.sense = sense
 

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -457,7 +457,7 @@ class CBC(Solver):
         # Use HiGHS to parse the problem file and find the set of variable names, needed to parse solution
         if "highs" not in available_solvers:
             raise ModuleNotFoundError(
-                f"highspy is not installed. Please install it to use {self.solver_name} solver."
+                f"highspy is not installed. Please install it to use {self.solver_name.name} solver."
             )
 
         h = highspy.Highs()

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -455,6 +455,11 @@ class CBC(Solver):
         status.legacy_status = first_line
 
         # Use HiGHS to parse the problem file and find the set of variable names, needed to parse solution
+        if "highs" not in available_solvers:
+            raise ModuleNotFoundError(
+                f"highspy is not installed. Please install it to use {self.solver_name} solver."
+            )
+
         h = highspy.Highs()
         h.readModel(path_to_string(problem_fn))
         variables = {v.name for v in h.getVariables()}

--- a/test/test_objective.py
+++ b/test/test_objective.py
@@ -26,6 +26,14 @@ def quadratic_objective() -> Objective:
     return m.objective
 
 
+def test_set_objective_from_variable() -> None:
+    m = Model()
+    v = m.add_variables(coords=[[1, 2, 3]])
+    m.add_objective(v)
+    assert isinstance(m.objective, Objective)
+    assert isinstance(m.objective.expression, LinearExpression)
+
+
 def test_model(linear_objective: Objective, quadratic_objective: Objective) -> None:
     assert isinstance(linear_objective.model, Model)
     assert isinstance(quadratic_objective.model, Model)

--- a/test/test_solvers.py
+++ b/test/test_solvers.py
@@ -5,12 +5,13 @@ Created on Tue Jan 28 09:03:35 2025.
 @author: sid
 """
 
+import importlib
 from pathlib import Path
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 
-from linopy import Model, solvers
+from linopy import solvers
 
 free_mps_problem = """NAME               sample_mip
 ROWS
@@ -68,8 +69,13 @@ def test_free_mps_solution_parsing(solver: str, tmp_path: Path) -> None:
 
 
 def test_highs_missing(monkeypatch: MonkeyPatch) -> None:
-    # Mock the value of "available_solvers" to exclude "highs"
     monkeypatch.setattr("linopy.solvers.available_solvers", ["cbc"])
+
+    import linopy.model
+
+    importlib.reload(linopy.model)
+
+    from linopy.model import Model
 
     model = Model()
     x = model.add_variables(lower=0.0, name="x")

--- a/test/test_solvers.py
+++ b/test/test_solvers.py
@@ -8,6 +8,7 @@ Created on Tue Jan 28 09:03:35 2025.
 from pathlib import Path
 
 import pytest
+from _pytest.monkeypatch import MonkeyPatch
 
 from linopy import Model, solvers
 
@@ -66,7 +67,7 @@ def test_free_mps_solution_parsing(solver: str, tmp_path: Path) -> None:
     assert result.solution.objective == 30.0
 
 
-def test_highs_missing(monkeypatch):
+def test_highs_missing(monkeypatch: MonkeyPatch) -> None:
     # Mock the value of "available_solvers" to exclude "highs"
     monkeypatch.setattr("linopy.solvers.available_solvers", ["cbc"])
 


### PR DESCRIPTION
Closes #452.

## Changes proposed in this Pull Request
-Add useful warning when using cbc without highspy installed
-Allow variable to be passed to objective

## Checklist
- [X] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [X] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [X] I consent to the release of this PR's code under the MIT license.
