### PR TITLE
Fixed typing of arithmetic methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ benchmark/notebooks/.ipynb_checkpoints
 benchmark/scripts/__pycache__
 benchmark/scripts/benchmarks-pypsa-eur/__pycache__
 benchmark/scripts/leftovers/
+
+# IDE
+.idea/

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -12,6 +12,7 @@ Upcoming Version
   gap tolerance.
 * Improve the mapping of termination conditions for the SCIP solver
 * Treat GLPK's `integer undefined` status as not-OK
+* Fixed variable/expression arithmetic methods so that they correctly handle types
 
 Version 0.5.3
 --------------

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -6,6 +6,8 @@ Upcoming Version
 
 **Bug Fixes**
 
+* Remove default highs log file when `log_fn=None` and `io_api="direct"`. This caused `log_file` in
+`solver_options` to be ignored.
 * Fix the parsing of solutions returned by the CBC solver when setting a MIP duality
   gap tolerance.
 * Improve the mapping of termination conditions for the SCIP solver

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -4,6 +4,7 @@ Release Notes
 Future Version
 ---------------
 **Minor Improvements**
+
 * Improved variable/expression arithmetic methods so that they correctly handle types
 
 Upcoming Version

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -9,6 +9,7 @@ Upcoming Version
 * Fix the parsing of solutions returned by the CBC solver when setting a MIP duality
   gap tolerance.
 * Improve the mapping of termination conditions for the SCIP solver
+* Treat GLPK's `integer undefined` status as not-OK
 
 Version 0.5.3
 --------------

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -4,6 +4,7 @@ Release Notes
 .. Upcoming Version
 .. ----------------
 
+
 * Improved variable/expression arithmetic methods so that they correctly handle types
 
 Version 0.5.5

--- a/linopy/common.py
+++ b/linopy/common.py
@@ -1000,7 +1000,7 @@ def align(
     indexes: Any = None,
     exclude: str | Iterable[Hashable] = frozenset(),
     fill_value: Any = dtypes.NA,
-) -> tuple[LinearExpression| QuadraticExpression | Variable | T_Alignable, ...]:
+) -> tuple[LinearExpression | QuadraticExpression | Variable | T_Alignable, ...]:
     """
     Given any number of Variables, Expressions, Dataset and/or DataArray objects,
     returns new objects with aligned indexes and dimension sizes.
@@ -1090,7 +1090,14 @@ def align(
     return tuple([f(da) for f, da in zip(finisher, aligned)])
 
 
-LocT = TypeVar("LocT", "Dataset", "Variable", "LinearExpression", "QuadraticExpression", "Constraint")
+LocT = TypeVar(
+    "LocT",
+    "Dataset",
+    "Variable",
+    "LinearExpression",
+    "QuadraticExpression",
+    "Constraint",
+)
 
 
 class LocIndexer(Generic[LocT]):

--- a/linopy/common.py
+++ b/linopy/common.py
@@ -37,7 +37,7 @@ from linopy.types import CoordsLike, DimsLike
 
 if TYPE_CHECKING:
     from linopy.constraints import Constraint
-    from linopy.expressions import LinearExpression
+    from linopy.expressions import LinearExpression, QuadraticExpression
     from linopy.variables import Variable
 
 
@@ -994,13 +994,13 @@ def check_common_keys_values(list_of_dicts: list[dict[str, Any]]) -> bool:
 
 
 def align(
-    *objects: LinearExpression | Variable | T_Alignable,
+    *objects: LinearExpression | QuadraticExpression | Variable | T_Alignable,
     join: JoinOptions = "inner",
     copy: bool = True,
     indexes: Any = None,
     exclude: str | Iterable[Hashable] = frozenset(),
     fill_value: Any = dtypes.NA,
-) -> tuple[LinearExpression | Variable | T_Alignable, ...]:
+) -> tuple[LinearExpression| QuadraticExpression | Variable | T_Alignable, ...]:
     """
     Given any number of Variables, Expressions, Dataset and/or DataArray objects,
     returns new objects with aligned indexes and dimension sizes.
@@ -1055,13 +1055,13 @@ def align(
 
 
     """
-    from linopy.expressions import LinearExpression
+    from linopy.expressions import LinearExpression, QuadraticExpression
     from linopy.variables import Variable
 
     finisher: list[partial[Any] | Callable[[Any], Any]] = []
     das: list[Any] = []
     for obj in objects:
-        if isinstance(obj, LinearExpression):
+        if isinstance(obj, (LinearExpression, QuadraticExpression)):
             finisher.append(partial(obj.__class__, model=obj.model))
             das.append(obj.data)
         elif isinstance(obj, Variable):
@@ -1090,7 +1090,7 @@ def align(
     return tuple([f(da) for f, da in zip(finisher, aligned)])
 
 
-LocT = TypeVar("LocT", "Dataset", "Variable", "LinearExpression", "Constraint")
+LocT = TypeVar("LocT", "Dataset", "Variable", "LinearExpression", "QuadraticExpression", "Constraint")
 
 
 class LocIndexer(Generic[LocT]):

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -539,7 +539,7 @@ class LinearExpression:
         Multiply the expr by a factor.
         """
         if isinstance(other, QuadraticExpression):
-            return other.__rmul__(self)  # type: ignore
+            return other.__rmul__(self)
 
         try:
             if isinstance(other, (variables.Variable, variables.ScalarVariable)):
@@ -1594,7 +1594,7 @@ class QuadraticExpression(LinearExpression):
         """
         Add others to expression.
         """
-        return other.__add__(self)
+        return self.__add__(other)
 
     def __sub__(self, other: SideLike) -> QuadraticExpression:
         """

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -523,7 +523,10 @@ class LinearExpression:
     def __sub__(self, other: QuadraticExpression) -> QuadraticExpression: ...
 
     def __sub__(self, other: SideLike) -> LinearExpression | QuadraticExpression:
-        return self.__add__(-other)
+        try:
+            return self.__add__(-other)
+        except TypeError:
+            return NotImplemented
 
     def __neg__(self) -> LinearExpression:
         """
@@ -1641,7 +1644,10 @@ class QuadraticExpression(LinearExpression):
         """
         Subtract expression from others.
         """
-        return self.__neg__().__add__(other)
+        try:
+            return self.__neg__() + other
+        except TypeError:
+            return NotImplemented
 
     def __neg__(self) -> QuadraticExpression:
         """

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -13,7 +13,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Hashable, Iterator, Mapping, Sequence
 from dataclasses import dataclass, field
 from itertools import product, zip_longest
-from typing import TYPE_CHECKING, Any, Type, TypeVar, overload
+from typing import TYPE_CHECKING, Any, TypeVar, overload
 from warnings import warn
 
 import numpy as np
@@ -1151,8 +1151,8 @@ class BaseExpression(ABC):
 
     @classmethod
     def _sum(
-        cls: Type[GenericExpression],
-        expr: GenericExpression | Dataset,
+        cls,
+        expr: BaseExpression | Dataset,
         dim: DimsLike | None = None,
     ) -> Dataset:
         data = _expr_unwrap(expr)

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -484,6 +484,14 @@ class LinearExpression:
             )
             print(self)
 
+    @overload
+    def __add__(
+        self, other: ConstantLike | Variable | ScalarLinearExpression | LinearExpression
+    ) -> LinearExpression: ...
+
+    @overload
+    def __add__(self, other: QuadraticExpression) -> QuadraticExpression: ...
+
     def __add__(self, other: SideLike) -> LinearExpression | QuadraticExpression:
         """
         Add an expression to others.
@@ -506,24 +514,16 @@ class LinearExpression:
     def __radd__(self, other: ConstantLike) -> LinearExpression:
         return self.__add__(other)
 
-    def __sub__(self, other: SideLike) -> LinearExpression:
-        """
-        Subtract others from expression.
+    @overload
+    def __sub__(
+        self, other: ConstantLike | Variable | ScalarLinearExpression | LinearExpression
+    ) -> LinearExpression: ...
 
-        Note: If other is a numpy array or pandas object without axes names,
-        dimension names of self will be filled in other
-        """
-        if isinstance(other, QuadraticExpression):
-            return other.__rsub__(self)
+    @overload
+    def __sub__(self, other: QuadraticExpression) -> QuadraticExpression: ...
 
-        try:
-            if np.isscalar(other):
-                return self.assign_multiindex_safe(const=self.const - other)
-
-            other = as_expression(other, model=self.model, dims=self.coord_dims)
-            return merge([self, -other], cls=self.__class__)
-        except TypeError:
-            return NotImplemented
+    def __sub__(self, other: SideLike) -> LinearExpression | QuadraticExpression:
+        return self.__add__(-other)
 
     def __neg__(self) -> LinearExpression:
         """

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -1655,6 +1655,13 @@ class QuadraticExpression(BaseExpression):
     def type(self) -> str:
         return "QuadraticExpression"
 
+    @property
+    def shape(self) -> tuple[int, ...]:
+        # TODO Implement this
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support shape property"
+        )
+
     def __mul__(self, other: SideLike) -> QuadraticExpression:
         """
         Multiply the expr by a factor.

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -512,7 +512,10 @@ class LinearExpression:
             return NotImplemented
 
     def __radd__(self, other: ConstantLike) -> LinearExpression:
-        return self.__add__(other)
+        try:
+            return self.__add__(other)
+        except TypeError:
+            return NotImplemented
 
     @overload
     def __sub__(
@@ -611,7 +614,10 @@ class LinearExpression:
         """
         Right-multiply the expr by a factor.
         """
-        return self.__mul__(other)
+        try:
+            return self.__mul__(other)
+        except TypeError:
+            return NotImplemented
 
     def __matmul__(
         self, other: LinearExpression | Variable | ndarray | DataArray

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -508,7 +508,7 @@ class BaseExpression(ABC):
         # merge on factor dimension only returns v1 * v2 + c1 * c2
         ds = other.data[["coeffs", "vars"]].sel(_term=0).broadcast_like(self.data)
         ds = assign_multiindex_safe(ds, const=other.const)
-        res = merge([self, ds], dim=FACTOR_DIM, cls=QuadraticExpression)
+        res = merge([self, ds], dim=FACTOR_DIM, cls=QuadraticExpression) # type: ignore
         # deal with cross terms c1 * v2 + c2 * v1
         if self.has_constant:
             res = res + self.const * other.reset_const()

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -1345,7 +1345,7 @@ class LinearExpression(BaseExpression):
 
     def __rsub__(self, other: ConstantLike | Variable) -> LinearExpression:
         try:
-            return self.__add__(-other)
+            return self.__neg__().__add__(other)
         except TypeError:
             return NotImplemented
 
@@ -1674,13 +1674,7 @@ class QuadraticExpression(BaseExpression):
                 "Higher order non-linear expressions are not yet supported."
             )
         try:
-            if isinstance(other, (variables.Variable, variables.ScalarVariable)):
-                other = other.to_linexpr()
-
-            if isinstance(other, (LinearExpression, ScalarLinearExpression)):
-                return self._multiply_by_linear_expression(other)
-            else:
-                return self._multiply_by_constant(other)
+            return self._multiply_by_constant(other)
         except TypeError:
             return NotImplemented
 
@@ -1736,7 +1730,7 @@ class QuadraticExpression(BaseExpression):
         Subtract expression from others.
         """
         try:
-            return self.__neg__() + other
+            return self.__neg__().__add__(other)
         except TypeError:
             return NotImplemented
 

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -1623,7 +1623,7 @@ class LinearExpression(BaseExpression):
             if len(t) == 2:
                 # assume first element is coefficient and second is variable
                 c, v = t
-                if isinstance(v, ScalarVariable):
+                if isinstance(v, variables.ScalarVariable):
                     if not isinstance(c, (int, float)):
                         raise TypeError(
                             "Expected int or float as coefficient of scalar variable (first element of tuple)."

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -1317,7 +1317,7 @@ class LinearExpression(BaseExpression):
 
     def __radd__(self, other: ConstantLike) -> LinearExpression:
         try:
-            return self.__add__(other)
+            return self + other
         except TypeError:
             return NotImplemented
 
@@ -1345,7 +1345,7 @@ class LinearExpression(BaseExpression):
 
     def __rsub__(self, other: ConstantLike | Variable) -> LinearExpression:
         try:
-            return self.__neg__().__add__(other)
+            return (self * -1) + other
         except TypeError:
             return NotImplemented
 
@@ -1389,7 +1389,7 @@ class LinearExpression(BaseExpression):
         Right-multiply the expr by a factor.
         """
         try:
-            return self.__mul__(other)
+            return self * other
         except TypeError:
             return NotImplemented
 
@@ -1725,7 +1725,7 @@ class QuadraticExpression(BaseExpression):
             return NotImplemented
 
     def __rmul__(self, other: SideLike) -> QuadraticExpression:
-        return self.__mul__(other)
+        return self * other
 
     def __add__(self, other: SideLike) -> QuadraticExpression:
         """
@@ -1776,7 +1776,7 @@ class QuadraticExpression(BaseExpression):
         Subtract expression from others.
         """
         try:
-            return self.__neg__().__add__(other)
+            return (self * -1) + other
         except TypeError:
             return NotImplemented
 

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -884,16 +884,12 @@ class Model:
     @overload
     def linexpr(
         self, *args: Sequence[Sequence | pd.Index | DataArray] | Mapping
-    ) -> LinearExpression:
-        ...
-        # A function and tuples of coordinates
+    ) -> LinearExpression: ...
 
     @overload
     def linexpr(
         self, *args: tuple[ConstantLike, str | Variable | ScalarVariable] | ConstantLike
-    ) -> LinearExpression:
-        ...
-        # A mixture of tuples of (coefficients, variables) and constants
+    ) -> LinearExpression: ...
 
     def linexpr(
         self,

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -12,7 +12,7 @@ import re
 from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 from tempfile import NamedTemporaryFile, gettempdir
-from typing import Any
+from typing import Any, overload
 
 import numpy as np
 import pandas as pd
@@ -878,17 +878,37 @@ class Model:
         blocks = replace_by_map(self.objective.vars, block_map)
         self.objective = self.objective.assign(blocks=blocks)
 
+    @overload
     def linexpr(
-        self, *args: tuple[ConstantLike, str | Variable | ScalarVariable] | Callable
+        self, *args: Sequence[Sequence | pd.Index | DataArray] | Mapping
+    ) -> LinearExpression:
+        ...
+        # A function and tuples of coordinates
+
+    @overload
+    def linexpr(
+        self, *args: tuple[ConstantLike, str | Variable | ScalarVariable] | ConstantLike
+    ) -> LinearExpression:
+        ...
+        # A mixture of tuples of (coefficients, variables) and constants
+
+    def linexpr(
+        self,
+        *args: tuple[ConstantLike, str | Variable | ScalarVariable]
+        | ConstantLike
+        | Callable
+        | Sequence[Sequence | pd.Index | DataArray]
+        | Mapping,
     ) -> LinearExpression:
         """
         Create a linopy.LinearExpression from argument list.
 
         Parameters
         ----------
-        args : tuples of (coefficients, variables) or tuples of
-               coordinates and a function
-            If args is a collection of coefficients-variables-tuples, the resulting
+        args : A mixture of tuples of (coefficients, variables) and constants
+            or a function and tuples of coordinates
+
+            If args is a collection of coefficients-variables-tuples and constants, the resulting
             linear expression is built with the function LinearExpression.from_tuples.
             * coefficients : int/float/array_like
                 The coefficient(s) in the term, if the coefficients array
@@ -897,6 +917,8 @@ class Model:
             * variables : str/array_like/linopy.Variable
                 The variable(s) going into the term. These may be referenced
                 by name.
+            * constant: int/float/array_like
+                The constant value to add to the expression
 
             If args is a collection of coordinates with an appended function at the
             end, the function LinearExpression.from_rule is used to build the linear
@@ -907,7 +929,7 @@ class Model:
                 The first argument of the function is the underlying `linopy.Model`.
                 The following arguments are given by the coordinates for accessing
                 the variables. The function has to return a
-                `ScalarLinearExpression`. Therefore use the direct getter when
+                `ScalarLinearExpression`. Therefore, use the direct getter when
                 indexing variables.
             * coords : coordinate-like
                 Coordinates to be processed by `xarray.DataArray`. For each
@@ -954,9 +976,14 @@ class Model:
             return LinearExpression.from_rule(self, rule, coords)  # type: ignore
         if not isinstance(args, tuple):
             raise TypeError(f"Not supported type {args}.")
-        tuples = [  # type: ignore
-            (c, self.variables[v]) if isinstance(v, str) else (c, v) for (c, v) in args
-        ]
+
+        tuples: list[tuple[ConstantLike, VariableLike] | ConstantLike] = []
+        for arg in args:
+            if isinstance(arg, tuple):
+                c, v = arg
+                tuples.append((c, self.variables[v]) if isinstance(v, str) else (c, v))
+            else:
+                tuples.append(arg)
         return LinearExpression.from_tuples(*tuples, model=self)
 
     @property

--- a/linopy/monkey_patch_xarray.py
+++ b/linopy/monkey_patch_xarray.py
@@ -26,6 +26,13 @@ def monkey_patch(cls: type[DataArray], pass_unpatched_method: bool = False) -> C
 def __mul__(
     da: DataArray, other: Any, unpatched_method: Callable
 ) -> DataArray | NotImplementedType:
-    if isinstance(other, (variables.Variable, expressions.LinearExpression, expressions.QuadraticExpression)):
+    if isinstance(
+        other,
+        (
+            variables.Variable,
+            expressions.LinearExpression,
+            expressions.QuadraticExpression,
+        ),
+    ):
         return NotImplemented
     return unpatched_method(da, other)

--- a/linopy/monkey_patch_xarray.py
+++ b/linopy/monkey_patch_xarray.py
@@ -26,6 +26,6 @@ def monkey_patch(cls: type[DataArray], pass_unpatched_method: bool = False) -> C
 def __mul__(
     da: DataArray, other: Any, unpatched_method: Callable
 ) -> DataArray | NotImplementedType:
-    if isinstance(other, (variables.Variable, expressions.LinearExpression)):
+    if isinstance(other, (variables.Variable, expressions.LinearExpression, expressions.QuadraticExpression)):
         return NotImplemented
     return unpatched_method(da, other)

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -752,9 +752,6 @@ class Highs(Solver):
 
         h = model.to_highspy(explicit_coordinate_names=explicit_coordinate_names)
 
-        if log_fn is None and model is not None:
-            log_fn = model.solver_dir / "highs.log"
-
         return self._solve(
             h,
             solution_fn,

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -573,6 +573,7 @@ class GLPK(Solver):
         """
         CONDITION_MAP = {
             "integer optimal": "optimal",
+            "integer undefined": "infeasible_or_unbounded",
             "undefined": "infeasible_or_unbounded",
         }
         sense = read_sense_from_problem_file(problem_fn)

--- a/linopy/testing.py
+++ b/linopy/testing.py
@@ -22,8 +22,8 @@ def assert_linequal(
     return assert_equal(_expr_unwrap(a), _expr_unwrap(b))
 
 
-def assert_quadequal(a: QuadraticExpression, b: QuadraticExpression) -> None:
-    """Assert that two linear expressions are equal."""
+def assert_quadequal(a: LinearExpression | QuadraticExpression, b: LinearExpression | QuadraticExpression) -> None:
+    """Assert that two quadratic or linear expressions are equal."""
     return assert_equal(_expr_unwrap(a), _expr_unwrap(b))
 
 

--- a/linopy/testing.py
+++ b/linopy/testing.py
@@ -13,8 +13,12 @@ def assert_varequal(a: Variable, b: Variable) -> None:
     return assert_equal(_var_unwrap(a), _var_unwrap(b))
 
 
-def assert_linequal(a: LinearExpression, b: LinearExpression) -> None:
+def assert_linequal(
+    a: LinearExpression | QuadraticExpression, b: LinearExpression | QuadraticExpression
+) -> None:
     """Assert that two linear expressions are equal."""
+    assert isinstance(a, LinearExpression)
+    assert isinstance(b, LinearExpression)
     return assert_equal(_expr_unwrap(a), _expr_unwrap(b))
 
 

--- a/linopy/testing.py
+++ b/linopy/testing.py
@@ -22,7 +22,9 @@ def assert_linequal(
     return assert_equal(_expr_unwrap(a), _expr_unwrap(b))
 
 
-def assert_quadequal(a: LinearExpression | QuadraticExpression, b: LinearExpression | QuadraticExpression) -> None:
+def assert_quadequal(
+    a: LinearExpression | QuadraticExpression, b: LinearExpression | QuadraticExpression
+) -> None:
     """Assert that two quadratic or linear expressions are equal."""
     return assert_equal(_expr_unwrap(a), _expr_unwrap(b))
 

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -1516,8 +1516,7 @@ class ScalarVariable:
     """
     A scalar variable container.
 
-    In contrast to the Variable class, a ScalarVariable only contains
-    only one label. Use this class to create a expression or constraint
+    In contrast to the Variable class, a ScalarVariable only contains one label. Use this class to create a expression or constraint
     in a rule.
     """
 

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -382,21 +382,23 @@ class Variable:
         """
         return self.to_linexpr(-1)
 
-    def __mul__(
-        self, other: float | int | ndarray | Variable
-    ) -> LinearExpression | QuadraticExpression:
+    def __mul__(self, other: SideLike) -> LinearExpression | QuadraticExpression:
         """
-        Multiply variables with a coefficient.
+        Multiply variables with a coefficient, variable, or expression.
         """
         try:
-            if isinstance(
-                other, (expressions.LinearExpression, Variable, ScalarVariable)
-            ):
+            if isinstance(other, (Variable, ScalarVariable)):
                 return self.to_linexpr() * other
 
             return self.to_linexpr(other)
         except TypeError:
             return NotImplemented
+
+    def __rmul__(self, other: ConstantLike) -> LinearExpression:
+        """
+        Right-multiply variables by a constant
+        """
+        return self.to_linexpr(other)
 
     def __pow__(self, other: int) -> QuadraticExpression:
         """
@@ -406,15 +408,6 @@ class Variable:
             expr = self.to_linexpr()
             return expr._multiply_by_linear_expression(expr)
         return NotImplemented
-
-    def __rmul__(self, other: float | DataArray | int | ndarray) -> LinearExpression:
-        """
-        Right-multiply variables with a coefficient.
-        """
-        try:
-            return self.to_linexpr(other)
-        except TypeError:
-            return NotImplemented
 
     def __matmul__(
         self, other: LinearExpression | ndarray | Variable
@@ -449,9 +442,7 @@ class Variable:
         except TypeError:
             return NotImplemented
 
-    def __add__(
-        self, other: int | QuadraticExpression | LinearExpression | Variable
-    ) -> QuadraticExpression | LinearExpression:
+    def __add__(self, other: SideLike) -> LinearExpression:
         """
         Add variables to linear expressions or other variables.
         """
@@ -460,18 +451,27 @@ class Variable:
         except TypeError:
             return NotImplemented
 
-    def __radd__(self, other: int) -> Variable | NotImplementedType:
-        # This is needed for using python's sum function
-        return self if other == 0 else NotImplemented
+    def __radd__(self, other: ConstantLike) -> LinearExpression:
+        try:
+            return self.__add__(other)
+        except ValueError:
+            return NotImplemented
 
-    def __sub__(
-        self, other: QuadraticExpression | LinearExpression | Variable
-    ) -> QuadraticExpression | LinearExpression:
+    def __sub__(self, other: SideLike) -> LinearExpression:
         """
         Subtract linear expressions or other variables from the variables.
         """
         try:
             return self.to_linexpr() - other
+        except TypeError:
+            return NotImplemented
+
+    def __rsub__(self, other: ConstantLike) -> LinearExpression:
+        """
+        Subtract linear expressions or other variables from the variables.
+        """
+        try:
+            return self.to_linexpr(-1) + other
         except TypeError:
             return NotImplemented
 

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -421,7 +421,9 @@ class Variable:
         """
         Power of the variables with a coefficient. The only coefficient allowed is 2.
         """
-        if isinstance(other, int) and other == 2:
+        if not isinstance(other, int):
+            return NotImplemented
+        if other == 2:
             expr = self.to_linexpr()
             return expr._multiply_by_linear_expression(expr)
         raise ValueError("Can only raise to the power of 2")

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -1568,7 +1568,7 @@ class ScalarVariable:
             raise TypeError(f"Coefficient must be a numeric value, got {type(coeff)}.")
         return expressions.ScalarLinearExpression((coeff,), (self.label,), self.model)
 
-    def to_linexpr(self, coeff: int = 1) -> LinearExpression:
+    def to_linexpr(self, coeff: int | float = 1) -> LinearExpression:
         return self.to_scalar_linexpr(coeff).to_linexpr()
 
     def __neg__(self) -> ScalarLinearExpression:

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -424,7 +424,7 @@ class Variable:
         if isinstance(other, int) and other == 2:
             expr = self.to_linexpr()
             return expr._multiply_by_linear_expression(expr)
-        return NotImplemented
+        raise ValueError("Can only raise to the power of 2")
 
     @overload
     def __matmul__(self, other: ConstantLike) -> LinearExpression: ...

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -52,7 +52,14 @@ from linopy.common import (
 )
 from linopy.config import options
 from linopy.constants import HELPER_DIMS, TERM_DIM
-from linopy.types import ConstantLike, DimsLike, NotImplementedType, SideLike
+from linopy.types import (
+    ConstantLike,
+    DimsLike,
+    ExpressionLike,
+    NotImplementedType,
+    SideLike,
+    VariableLike,
+)
 
 if TYPE_CHECKING:
     from linopy.constraints import AnonymousScalarConstraint, Constraint
@@ -382,7 +389,13 @@ class Variable:
         """
         return self.to_linexpr(-1)
 
-    def __mul__(self, other: SideLike) -> LinearExpression | QuadraticExpression:
+    @overload
+    def __mul__(self, other: ConstantLike) -> LinearExpression: ...
+
+    @overload
+    def __mul__(self, other: ExpressionLike | VariableLike) -> QuadraticExpression: ...
+
+    def __mul__(self, other: SideLike) -> ExpressionLike:
         """
         Multiply variables with a coefficient, variable, or expression.
         """
@@ -398,7 +411,7 @@ class Variable:
         """
         Right-multiply variables by a constant
         """
-        return self.to_linexpr(other)
+        return self * other
 
     def __pow__(self, other: int) -> QuadraticExpression:
         """
@@ -1539,6 +1552,8 @@ class ScalarVariable:
         return self.to_scalar_linexpr(coeff)
 
     def __rmul__(self, coeff: int | float) -> ScalarLinearExpression:
+        if isinstance(coeff, Variable):
+            return NotImplemented
         return self.to_scalar_linexpr(coeff)
 
     def __div__(self, coeff: int | float) -> ScalarLinearExpression:

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -455,7 +455,15 @@ class Variable:
         except TypeError:
             return NotImplemented
 
-    def __add__(self, other: SideLike) -> LinearExpression:
+    @overload
+    def __add__(
+        self, other: ConstantLike | Variable | ScalarLinearExpression | LinearExpression
+    ) -> LinearExpression: ...
+
+    @overload
+    def __add__(self, other: QuadraticExpression) -> QuadraticExpression: ...
+
+    def __add__(self, other: SideLike) -> LinearExpression | QuadraticExpression:
         """
         Add variables to linear expressions or other variables.
         """
@@ -470,7 +478,15 @@ class Variable:
         except ValueError:
             return NotImplemented
 
-    def __sub__(self, other: SideLike) -> LinearExpression:
+    @overload
+    def __sub__(
+        self, other: ConstantLike | Variable | ScalarLinearExpression | LinearExpression
+    ) -> LinearExpression: ...
+
+    @overload
+    def __sub__(self, other: QuadraticExpression) -> QuadraticExpression: ...
+
+    def __sub__(self, other: SideLike) -> LinearExpression | QuadraticExpression:
         """
         Subtract linear expressions or other variables from the variables.
         """

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -490,7 +490,7 @@ class Variable:
 
     def __radd__(self, other: ConstantLike) -> LinearExpression:
         try:
-            return self.__add__(other)
+            return self + other
         except TypeError:
             return NotImplemented
 
@@ -1588,7 +1588,7 @@ class ScalarVariable:
         return self.to_scalar_linexpr(coeff)
 
     def __rmul__(self, coeff: int | float) -> ScalarLinearExpression:
-        if isinstance(coeff, Variable):
+        if isinstance(coeff, (Variable, ScalarVariable)):
             return NotImplemented
         return self.to_scalar_linexpr(coeff)
 

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -64,6 +64,7 @@ from linopy.types import (
 if TYPE_CHECKING:
     from linopy.constraints import AnonymousScalarConstraint, Constraint
     from linopy.expressions import (
+        GenericExpression,
         LinearExpression,
         LinearExpressionGroupby,
         QuadraticExpression,
@@ -425,9 +426,17 @@ class Variable:
             return expr._multiply_by_linear_expression(expr)
         return NotImplemented
 
+    @overload
+    def __matmul__(self, other: ConstantLike) -> LinearExpression: ...
+
+    @overload
     def __matmul__(
-        self, other: LinearExpression | ndarray | Variable
-    ) -> QuadraticExpression | LinearExpression:
+        self, other: VariableLike | ExpressionLike
+    ) -> QuadraticExpression: ...
+
+    def __matmul__(
+        self, other: ConstantLike | VariableLike | ExpressionLike
+    ) -> LinearExpression | QuadraticExpression:
         """
         Matrix multiplication of variables with a coefficient.
         """
@@ -460,13 +469,16 @@ class Variable:
 
     @overload
     def __add__(
-        self, other: ConstantLike | Variable | ScalarLinearExpression | LinearExpression
+        self, other: ConstantLike | Variable | ScalarLinearExpression
     ) -> LinearExpression: ...
 
     @overload
-    def __add__(self, other: QuadraticExpression) -> QuadraticExpression: ...
+    def __add__(self, other: GenericExpression) -> GenericExpression: ...
 
-    def __add__(self, other: SideLike) -> LinearExpression | QuadraticExpression:
+    def __add__(
+        self,
+        other: ConstantLike | Variable | ScalarLinearExpression | GenericExpression,
+    ) -> LinearExpression | GenericExpression:
         """
         Add variables to linear expressions or other variables.
         """
@@ -483,13 +495,16 @@ class Variable:
 
     @overload
     def __sub__(
-        self, other: ConstantLike | Variable | ScalarLinearExpression | LinearExpression
+        self, other: ConstantLike | Variable | ScalarLinearExpression
     ) -> LinearExpression: ...
 
     @overload
-    def __sub__(self, other: QuadraticExpression) -> QuadraticExpression: ...
+    def __sub__(self, other: GenericExpression) -> GenericExpression: ...
 
-    def __sub__(self, other: SideLike) -> LinearExpression | QuadraticExpression:
+    def __sub__(
+        self,
+        other: ConstantLike | Variable | ScalarLinearExpression | GenericExpression,
+    ) -> LinearExpression | GenericExpression:
         """
         Subtract linear expressions or other variables from the variables.
         """

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -411,7 +411,10 @@ class Variable:
         """
         Right-multiply variables by a constant
         """
-        return self * other
+        try:
+            return self * other
+        except TypeError:
+            return NotImplemented
 
     def __pow__(self, other: int) -> QuadraticExpression:
         """
@@ -475,7 +478,7 @@ class Variable:
     def __radd__(self, other: ConstantLike) -> LinearExpression:
         try:
             return self.__add__(other)
-        except ValueError:
+        except TypeError:
             return NotImplemented
 
     @overload

--- a/test/test_compatible_arithmetrics.py
+++ b/test/test_compatible_arithmetrics.py
@@ -6,8 +6,8 @@ import pytest
 import xarray as xr
 
 from linopy import LESS_EQUAL, Model, Variable
-from linopy.testing import assert_linequal
-
+from linopy.testing import assert_linequal, assert_quadequal
+from xarray.testing import assert_equal
 
 class SomeOtherDatatype:
     """
@@ -127,9 +127,9 @@ def test_arithmetric_operations_vars_and_expr(m: Model) -> None:
     x = m.variables["x"]
     x_expr = x * 1.0
 
-    assert_linequal(x**2, x_expr**2)
-    assert_linequal(x**2 + x, x + x**2)
-    assert_linequal(x**2 * 2, x**2 * 2)
+    assert_quadequal(x**2, x_expr**2)
+    assert_quadequal(x**2 + x, x + x**2)
+    assert_quadequal(x**2 * 2, x**2 * 2)
     with pytest.raises(TypeError):
         _ = x**2 * x
 
@@ -144,7 +144,8 @@ def test_arithmetric_operations_con(m: Model) -> None:
     assert_linequal(c.lhs - data, c.lhs - other_datatype)
     assert_linequal(c.lhs * data, c.lhs * other_datatype)
     assert_linequal(c.lhs / data, c.lhs / other_datatype)
-    assert_linequal(c.rhs + data, c.rhs + other_datatype)  # type: ignore
-    assert_linequal(c.rhs - data, c.rhs - other_datatype)  # type: ignore
-    assert_linequal(c.rhs * data, c.rhs * other_datatype)  # type: ignore
-    assert_linequal(c.rhs / data, c.rhs / other_datatype)  # type: ignore
+
+    assert_equal(c.rhs + data, c.rhs + other_datatype)
+    assert_equal(c.rhs - data, c.rhs - other_datatype)
+    assert_equal(c.rhs * data, c.rhs * other_datatype)
+    assert_equal(c.rhs / data, c.rhs / other_datatype)

--- a/test/test_compatible_arithmetrics.py
+++ b/test/test_compatible_arithmetrics.py
@@ -105,7 +105,8 @@ def test_arithmetric_operations_variable(m: Model) -> None:
     assert x.__mul__(object()) is NotImplemented
     assert x.__truediv__(object()) is NotImplemented  # type: ignore
     assert x.__pow__(object()) is NotImplemented  # type: ignore
-    assert x.__pow__(3) is NotImplemented
+    with pytest.raises(ValueError):
+        x.__pow__(3)
 
 
 def test_arithmetric_operations_expr(m: Model) -> None:

--- a/test/test_compatible_arithmetrics.py
+++ b/test/test_compatible_arithmetrics.py
@@ -4,10 +4,11 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
+from xarray.testing import assert_equal
 
 from linopy import LESS_EQUAL, Model, Variable
 from linopy.testing import assert_linequal, assert_quadequal
-from xarray.testing import assert_equal
+
 
 class SomeOtherDatatype:
     """

--- a/test/test_compatible_arithmetrics.py
+++ b/test/test_compatible_arithmetrics.py
@@ -97,7 +97,7 @@ def test_arithmetric_operations_variable(m: Model) -> None:
     assert_linequal(x + data, x + other_datatype)
     assert_linequal(x - data, x - other_datatype)
     assert_linequal(x * data, x * other_datatype)
-    assert_linequal(x / data, x / other_datatype)
+    assert_linequal(x / data, x / other_datatype)  # type: ignore
     assert_linequal(data * x, other_datatype * x)  # type: ignore
     assert x.__add__(object()) is NotImplemented
     assert x.__sub__(object()) is NotImplemented
@@ -131,7 +131,7 @@ def test_arithmetric_operations_vars_and_expr(m: Model) -> None:
     assert_linequal(x**2 + x, x + x**2)
     assert_linequal(x**2 * 2, x**2 * 2)
     with pytest.raises(TypeError):
-        _ = x**2 * x  # type: ignore
+        _ = x**2 * x
 
 
 def test_arithmetric_operations_con(m: Model) -> None:

--- a/test/test_compatible_arithmetrics.py
+++ b/test/test_compatible_arithmetrics.py
@@ -94,14 +94,14 @@ def test_arithmetric_operations_variable(m: Model) -> None:
     rng = np.random.default_rng()
     data = xr.DataArray(rng.random(x.shape), coords=x.coords)
     other_datatype = SomeOtherDatatype(data.copy())
-    assert_linequal(x + data, x + other_datatype)  # type: ignore
-    assert_linequal(x - data, x - other_datatype)  # type: ignore
-    assert_linequal(x * data, x * other_datatype)  # type: ignore
-    assert_linequal(x / data, x / other_datatype)  # type: ignore
+    assert_linequal(x + data, x + other_datatype)
+    assert_linequal(x - data, x - other_datatype)
+    assert_linequal(x * data, x * other_datatype)
+    assert_linequal(x / data, x / other_datatype)
     assert_linequal(data * x, other_datatype * x)  # type: ignore
-    assert x.__add__(object()) is NotImplemented  # type: ignore
-    assert x.__sub__(object()) is NotImplemented  # type: ignore
-    assert x.__mul__(object()) is NotImplemented  # type: ignore
+    assert x.__add__(object()) is NotImplemented
+    assert x.__sub__(object()) is NotImplemented
+    assert x.__mul__(object()) is NotImplemented
     assert x.__truediv__(object()) is NotImplemented  # type: ignore
     assert x.__pow__(object()) is NotImplemented  # type: ignore
     assert x.__pow__(3) is NotImplemented
@@ -121,6 +121,17 @@ def test_arithmetric_operations_expr(m: Model) -> None:
     assert expr.__sub__(object()) is NotImplemented
     assert expr.__mul__(object()) is NotImplemented
     assert expr.__truediv__(object()) is NotImplemented
+
+
+def test_arithmetric_operations_vars_and_expr(m: Model) -> None:
+    x = m.variables["x"]
+    x_expr = x * 1.0
+
+    assert_linequal(x**2, x_expr**2)
+    assert_linequal(x**2 + x, x + x**2)
+    assert_linequal(x**2 * 2, x**2 * 2)
+    with pytest.raises(TypeError):
+        _ = x**2 * x  # type: ignore
 
 
 def test_arithmetric_operations_con(m: Model) -> None:

--- a/test/test_linear_expression.py
+++ b/test/test_linear_expression.py
@@ -14,7 +14,7 @@ import pytest
 import xarray as xr
 from xarray.testing import assert_equal
 
-from linopy import LinearExpression, Model, Variable, merge
+from linopy import LinearExpression, Model, QuadraticExpression, Variable, merge
 from linopy.constants import HELPER_DIMS, TERM_DIM
 from linopy.expressions import ScalarLinearExpression
 from linopy.testing import assert_linequal
@@ -208,6 +208,9 @@ def test_linear_expression_with_multiplication(x: Variable) -> None:
     expr = pd.Series([1, 2], index=pd.RangeIndex(2, name="dim_0")) * x
     assert isinstance(expr, LinearExpression)
 
+    assert expr.__mul__(object()) is NotImplemented
+    assert expr.__rmul__(object()) is NotImplemented  # type: ignore
+
 
 def test_linear_expression_with_addition(m: Model, x: Variable, y: Variable) -> None:
     expr = 10 * x + y
@@ -224,6 +227,9 @@ def test_linear_expression_with_addition(m: Model, x: Variable, y: Variable) -> 
 
     expr2 = x.add(y)
     assert_linequal(expr, expr2)
+
+    expr3 = x + (x * x)
+    assert isinstance(expr3, QuadraticExpression)
 
 
 def test_linear_expression_with_raddition(m: Model, x: Variable):

--- a/test/test_linear_expression.py
+++ b/test/test_linear_expression.py
@@ -331,6 +331,9 @@ def test_linear_expression_with_errors(m: Model, x: Variable) -> None:
     with pytest.raises(TypeError):
         m.linexpr((10, x.labels), (1, "y"))
 
+    with pytest.raises(TypeError):
+        m.linexpr(a=2)  # type: ignore
+
 
 def test_linear_expression_from_rule(m: Model, x: Variable, y: Variable) -> None:
     def bound(m: Model, i: int) -> ScalarLinearExpression:

--- a/test/test_linear_expression.py
+++ b/test/test_linear_expression.py
@@ -1074,7 +1074,8 @@ def test_linear_expression_from_tuples(x: Variable, y: Variable) -> None:
     expr = LinearExpression.from_tuples((10, x), (1, y))
     assert isinstance(expr, LinearExpression)
 
-    expr2 = LinearExpression.from_tuples((10, x), (1,))
+    with pytest.warns(DeprecationWarning):
+        expr2 = LinearExpression.from_tuples((10, x), (1,))
     assert isinstance(expr2, LinearExpression)
     assert (expr2.const == 1).all()
 

--- a/test/test_linear_expression.py
+++ b/test/test_linear_expression.py
@@ -226,6 +226,14 @@ def test_linear_expression_with_addition(m: Model, x: Variable, y: Variable) -> 
     assert_linequal(expr, expr2)
 
 
+def test_linear_expression_with_raddition(m: Model, x: Variable):
+    expr = x * 1.0
+    expr_2: LinearExpression = 10.0 + expr  # type: ignore
+    assert isinstance(expr, LinearExpression)
+    expr_3: LinearExpression = expr + 10.0  # type: ignore
+    assert_linequal(expr_2, expr_3)
+
+
 def test_linear_expression_with_subtraction(m: Model, x: Variable, y: Variable) -> None:
     expr = x - y
     assert isinstance(expr, LinearExpression)

--- a/test/test_linear_expression.py
+++ b/test/test_linear_expression.py
@@ -209,7 +209,7 @@ def test_linear_expression_with_multiplication(x: Variable) -> None:
     assert isinstance(expr, LinearExpression)
 
     assert expr.__mul__(object()) is NotImplemented
-    assert expr.__rmul__(object()) is NotImplemented  # type: ignore
+    assert expr.__rmul__(object()) is NotImplemented
 
 
 def test_linear_expression_with_addition(m: Model, x: Variable, y: Variable) -> None:
@@ -232,11 +232,11 @@ def test_linear_expression_with_addition(m: Model, x: Variable, y: Variable) -> 
     assert isinstance(expr3, QuadraticExpression)
 
 
-def test_linear_expression_with_raddition(m: Model, x: Variable):
+def test_linear_expression_with_raddition(m: Model, x: Variable) -> None:
     expr = x * 1.0
-    expr_2: LinearExpression = 10.0 + expr  # type: ignore
+    expr_2: LinearExpression = 10.0 + expr
     assert isinstance(expr, LinearExpression)
-    expr_3: LinearExpression = expr + 10.0  # type: ignore
+    expr_3: LinearExpression = expr + 10.0
     assert_linequal(expr_2, expr_3)
 
 
@@ -1031,24 +1031,25 @@ def test_merge(x: Variable, y: Variable, z: Variable) -> None:
     expr1 = (10 * x + y).sum("dim_0")
     expr2 = z.sum("dim_0")
 
-    res = merge([expr1, expr2])
+    res = merge([expr1, expr2], cls=LinearExpression)
     assert res.nterm == 6
 
-    res = merge([expr1, expr2])
-    assert res.nterm == 6
+    with pytest.warns(DeprecationWarning):
+        res: LinearExpression = merge([expr1, expr2])  # type: ignore
+        assert res.nterm == 6
 
     # now concat with same length of terms
     expr1 = z.sel(dim_0=0).sum("dim_1")
     expr2 = z.sel(dim_0=1).sum("dim_1")
 
-    res = merge([expr1, expr2], dim="dim_1")
+    res = merge([expr1, expr2], dim="dim_1", cls=LinearExpression)
     assert res.nterm == 3
 
     # now with different length of terms
     expr1 = z.sel(dim_0=0, dim_1=slice(0, 1)).sum("dim_1")
     expr2 = z.sel(dim_0=1).sum("dim_1")
 
-    res = merge([expr1, expr2], dim="dim_1")
+    res = merge([expr1, expr2], dim="dim_1", cls=LinearExpression)
     assert res.nterm == 3
     assert res.sel(dim_1=0).vars[2].item() == -1
 

--- a/test/test_optimization.py
+++ b/test/test_optimization.py
@@ -386,7 +386,7 @@ def test_default_setting_expression_sol_accessor(
     qexpr = 4 * x**2
     assert_equal(qexpr.solution, 4 * x.solution**2)
 
-    qexpr = 4 * x * y
+    qexpr = 4 * (x * y)  # type: ignore
     assert_equal(qexpr.solution, 4 * x.solution * y.solution)
 
 

--- a/test/test_quadratic_expression.py
+++ b/test/test_quadratic_expression.py
@@ -45,6 +45,7 @@ def test_adding_quadratic_expressions(x: Variable) -> None:
     quad_expr = x * x
     double_quad = quad_expr + quad_expr
     assert isinstance(double_quad, QuadraticExpression)
+    assert double_quad.__add__(object()) is NotImplemented
 
 
 def test_quadratic_expression_from_variables_power(x: Variable) -> None:
@@ -123,6 +124,12 @@ def test_matmul_expr_and_expr(x: Variable, y: Variable, z: Variable) -> None:
     assert_quadequal(expr, target)
 
 
+def test_matmul_with_const(x: Variable) -> None:
+    expr = x * x
+    const = 2.0
+    assert_quadequal(expr @ const, (x * const).sum())
+
+
 def test_quadratic_expression_dot_and_matmul(x: Variable, y: Variable) -> None:
     matmul_expr: QuadraticExpression = 10 * x @ y  # type: ignore
     dot_expr: QuadraticExpression = 10 * x.dot(y)  # type: ignore
@@ -163,6 +170,7 @@ def test_quadratic_expression_subtraction(x: Variable, y: Variable) -> None:
     assert isinstance(expr, QuadraticExpression)
     assert (expr.const == -5).all()
     assert expr.nterm == 2
+    assert expr.__sub__(object()) is NotImplemented
 
 
 def test_quadratic_expression_rsubtraction(x: Variable, y: Variable) -> None:
@@ -170,6 +178,11 @@ def test_quadratic_expression_rsubtraction(x: Variable, y: Variable) -> None:
     assert isinstance(expr, QuadraticExpression)
     assert (expr.const == -5).all()
     assert expr.nterm == 2
+
+    expr2 = 5 - x * y
+    assert isinstance(expr2, QuadraticExpression)
+    assert (expr2.const == 5).all()
+    assert expr2.nterm == 1
 
 
 def test_quadratic_expression_sum(x: Variable, y: Variable) -> None:
@@ -314,7 +327,7 @@ def test_power_of_three(x: Variable) -> None:
         (x * 1) * (x * x)
     with pytest.raises(TypeError):
         (x * x) * (x * 1)
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         x**3
     with pytest.raises(TypeError):
         (x * x) * (x * x)

--- a/test/test_quadratic_expression.py
+++ b/test/test_quadratic_expression.py
@@ -214,6 +214,10 @@ def test_quadratic_expression_wrong_multiplication(x: Variable, y: Variable) -> 
     with pytest.raises(TypeError):
         x * x * y
 
+    quad = x * x
+    with pytest.raises(TypeError):
+        quad * quad
+
 
 def merge_raise_deprecation_warning(x: Variable, y: Variable) -> None:
     expr: QuadraticExpression = x * y  # type: ignore

--- a/test/test_quadratic_expression.py
+++ b/test/test_quadratic_expression.py
@@ -133,7 +133,6 @@ def test_matmul_with_const(x: Variable) -> None:
     assert expr2.data.sizes[FACTOR_DIM] == 2
 
 
-
 def test_quadratic_expression_dot_and_matmul(x: Variable, y: Variable) -> None:
     matmul_expr: QuadraticExpression = 10 * x @ y  # type: ignore
     dot_expr: QuadraticExpression = 10 * x.dot(y)  # type: ignore

--- a/test/test_quadratic_expression.py
+++ b/test/test_quadratic_expression.py
@@ -144,8 +144,12 @@ def test_quadratic_expression_raddition(x: Variable, y: Variable) -> None:
     assert (expr.const == 5).all()
     assert expr.nterm == 2
 
-    with pytest.raises(TypeError):
-        5 + x * y + x
+    expr_2 = 5 + x * y + x
+    assert isinstance(expr_2, QuadraticExpression)
+    assert (expr_2.const == 5).all()
+    assert expr_2.nterm == 2
+
+    assert_quadequal(expr, expr_2)
 
 
 def test_quadratic_expression_subtraction(x: Variable, y: Variable) -> None:

--- a/test/test_quadratic_expression.py
+++ b/test/test_quadratic_expression.py
@@ -126,8 +126,12 @@ def test_matmul_expr_and_expr(x: Variable, y: Variable, z: Variable) -> None:
 
 def test_matmul_with_const(x: Variable) -> None:
     expr = x * x
-    const = 2.0
-    assert_quadequal(expr @ const, (x * const).sum())
+    const = DataArray([2.0, 1.0], dims=["dim_0"])
+    expr2 = expr @ const
+    assert isinstance(expr2, QuadraticExpression)
+    assert expr2.nterm == 2
+    assert expr2.data.sizes[FACTOR_DIM] == 2
+
 
 
 def test_quadratic_expression_dot_and_matmul(x: Variable, y: Variable) -> None:

--- a/test/test_quadratic_expression.py
+++ b/test/test_quadratic_expression.py
@@ -291,3 +291,16 @@ def test_matrices_matrix_mixed_linear_and_quadratic(
 def test_quadratic_to_constraint(x: Variable, y: Variable) -> None:
     with pytest.raises(NotImplementedError):
         x * y <= 10
+
+
+def test_power_of_three(x: Variable) -> None:
+    with pytest.raises(TypeError):
+        x * x * x
+    with pytest.raises(TypeError):
+        (x * 1) * (x * x)
+    with pytest.raises(TypeError):
+        (x * x) * (x * 1)
+    with pytest.raises(TypeError):
+        x**3
+    with pytest.raises(TypeError):
+        (x * x) * (x * x)

--- a/test/test_quadratic_expression.py
+++ b/test/test_quadratic_expression.py
@@ -123,6 +123,9 @@ def test_matmul_expr_and_expr(x: Variable, y: Variable, z: Variable) -> None:
     assert expr.nterm == 6
     assert_quadequal(expr, target)
 
+    with pytest.raises(TypeError):
+        (x**2) @ (y**2)
+
 
 def test_matmul_with_const(x: Variable) -> None:
     expr = x * x

--- a/test/test_typing.py
+++ b/test/test_typing.py
@@ -1,0 +1,32 @@
+import xarray as xr
+from mypy import api
+
+import linopy
+
+
+def test_operations_with_data_arrays_are_typed_correctly() -> None:
+    m = linopy.Model()
+
+    a: xr.DataArray = xr.DataArray([1, 2, 3])
+
+    v: linopy.Variable = m.add_variables(lower=0.0, name="v")
+    e: linopy.LinearExpression = v * 1.0
+    q = v * v
+    assert isinstance(q, linopy.QuadraticExpression)
+
+    _ = a * v
+    _ = v * a
+    _ = v + a
+
+    _ = a * e
+    _ = e * a
+    _ = e + a
+
+    _ = a * q
+    _ = q * a
+    _ = q + a
+
+    # Get the path of this file
+    file_path = __file__
+    result = api.run([file_path])
+    assert result[2] == 0, "Mypy returned issues: " + result[0]

--- a/test/test_typing.py
+++ b/test/test_typing.py
@@ -5,6 +5,11 @@ import linopy
 
 
 def test_operations_with_data_arrays_are_typed_correctly() -> None:
+    # Get the path of this file
+    file_path = __file__
+    result = api.run([file_path])
+    assert result[2] == 0, "Mypy returned issues: " + result[0]
+
     m = linopy.Model()
 
     a: xr.DataArray = xr.DataArray([1, 2, 3])
@@ -12,7 +17,6 @@ def test_operations_with_data_arrays_are_typed_correctly() -> None:
     v: linopy.Variable = m.add_variables(lower=0.0, name="v")
     e: linopy.LinearExpression = v * 1.0
     q = v * v
-    assert isinstance(q, linopy.QuadraticExpression)
 
     _ = a * v
     _ = v * a
@@ -25,8 +29,3 @@ def test_operations_with_data_arrays_are_typed_correctly() -> None:
     _ = a * q
     _ = q * a
     _ = q + a
-
-    # Get the path of this file
-    file_path = __file__
-    result = api.run([file_path])
-    assert result[2] == 0, "Mypy returned issues: " + result[0]

--- a/test/test_typing.py
+++ b/test/test_typing.py
@@ -1,15 +1,9 @@
 import xarray as xr
-from mypy import api
 
 import linopy
 
 
 def test_operations_with_data_arrays_are_typed_correctly() -> None:
-    # Get the path of this file
-    file_path = __file__
-    result = api.run([file_path])
-    assert result[2] == 0, "Mypy returned issues: " + result[0]
-
     m = linopy.Model()
 
     a: xr.DataArray = xr.DataArray([1, 2, 3])

--- a/test/test_variable.py
+++ b/test/test_variable.py
@@ -17,6 +17,7 @@ from xarray.testing import assert_equal
 import linopy
 import linopy.variables
 from linopy import Model
+from linopy.testing import assert_linequal
 
 
 @pytest.fixture
@@ -305,3 +306,39 @@ def test_variable_iterate_slices(x: linopy.Variable) -> None:
     for s in slices:
         assert isinstance(s, linopy.variables.Variable)
         assert s.size <= 2
+
+
+def test_variable_addition(x: linopy.Variable) -> None:
+    expr1 = x + 1
+    assert isinstance(expr1, linopy.expressions.LinearExpression)
+    expr2 = 1 + x
+    assert isinstance(expr2, linopy.expressions.LinearExpression)
+    assert_linequal(expr1, expr2)
+
+    assert x.__radd__(object()) is NotImplemented
+    assert x.__add__(object()) is NotImplemented
+
+
+def test_variable_subtraction(x: linopy.Variable) -> None:
+    expr1 = -x + 1
+    assert isinstance(expr1, linopy.expressions.LinearExpression)
+    expr2 = 1 - x
+    assert isinstance(expr2, linopy.expressions.LinearExpression)
+    assert_linequal(expr1, expr2)
+
+    assert x.__rsub__(object()) is NotImplemented
+    assert x.__sub__(object()) is NotImplemented
+
+
+def test_variable_multiplication(x: linopy.Variable) -> None:
+    expr1 = x * 2
+    assert isinstance(expr1, linopy.expressions.LinearExpression)
+    expr2 = 2 * x
+    assert isinstance(expr2, linopy.expressions.LinearExpression)
+    assert_linequal(expr1, expr2)
+
+    expr3 = x * x
+    assert isinstance(expr3, linopy.expressions.QuadraticExpression)
+
+    assert x.__rmul__(object()) is NotImplemented
+    assert x.__mul__(object()) is NotImplemented

--- a/test/test_variables.py
+++ b/test/test_variables.py
@@ -13,6 +13,7 @@ import xarray.core.utils
 import linopy
 from linopy import Model
 from linopy.testing import assert_varequal
+from linopy.variables import ScalarVariable
 
 
 @pytest.fixture
@@ -115,3 +116,9 @@ def test_variables_get_name_by_label(m: Model) -> None:
 
     with pytest.raises(ValueError):
         m.variables.get_name_by_label("anystring")  # type: ignore
+
+
+def test_scalar_variable(m: Model) -> None:
+    x = ScalarVariable(label=0, model=m)
+    assert isinstance(x, ScalarVariable)
+    assert x.__rmul__(x) is NotImplemented  # type: ignore


### PR DESCRIPTION
Closes #435.

## Changes proposed in this Pull Request
Arithmetic methods now understand that data array is a valid type for addition/multiplication

## Checklist

- [X] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [X] Unit tests for new features were added (if applicable).
- [X] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [X] I consent to the release of this PR's code under the MIT license.
