### PR TITLE
Ise multiindex safe assignment where needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ doc/api
 Highs.log
 paper/
 monkeytype.sqlite3
+.github/copilot-instructions.md
+uv.lock
 
 # Environments
 .env

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -12,6 +12,9 @@ Upcoming Version
   gap tolerance.
 * Improve the mapping of termination conditions for the SCIP solver
 * Treat GLPK's `integer undefined` status as not-OK
+* Internally assign new data fields to `Variable` and `Constraint` with a multiindexed-safe routine. Before the
+  assignment when using multi-indexed coordinates, an deprecation warning was raised. This is fixed now.
+
 
 Version 0.5.3
 --------------

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -313,7 +313,7 @@ class LinearExpressionRolling:
             .rename({TERM_DIM: STACKED_TERM_DIM})
             .stack({TERM_DIM: [STACKED_TERM_DIM, "_rolling_term"]}, create_index=False)
         )
-        ds["const"] = data.const.sum("_rolling_term")
+        ds = assign_multiindex_safe(ds, const=data.const.sum("_rolling_term"))
         return LinearExpression(ds, self.model)
 
 
@@ -783,7 +783,7 @@ class LinearExpression:
 
     @vars.setter
     def vars(self, value: DataArray) -> None:
-        self.data["vars"] = value
+        self._data = assign_multiindex_safe(self.data, vars=value)
 
     @property
     def coeffs(self) -> DataArray:
@@ -791,7 +791,7 @@ class LinearExpression:
 
     @coeffs.setter
     def coeffs(self, value: DataArray) -> None:
-        self.data["coeffs"] = value
+        self._data = assign_multiindex_safe(self.data, coeffs=value)
 
     @property
     def const(self) -> DataArray:
@@ -799,7 +799,7 @@ class LinearExpression:
 
     @const.setter
     def const(self, value: DataArray) -> None:
-        self.data["const"] = value
+        self._data = assign_multiindex_safe(self.data, const=value)
 
     @property
     def has_constant(self) -> DataArray:
@@ -1458,7 +1458,7 @@ class LinearExpression:
         return df
 
     # Wrapped function which would convert variable to dataarray
-    assign = exprwrap(Dataset.assign)
+    assign = exprwrap(assign_multiindex_safe)
 
     assign_multiindex_safe = exprwrap(assign_multiindex_safe)
 

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -27,6 +27,7 @@ from xarray.core.types import T_Chunks
 from linopy import solvers
 from linopy.common import (
     as_dataarray,
+    assign_multiindex_safe,
     best_int,
     maybe_replace_signs,
     replace_by_map,
@@ -734,7 +735,9 @@ class Model:
         for k in list(self.constraints):
             vars = self.constraints[k].data["vars"]
             vars = vars.where(~vars.isin(labels), -1)
-            self.constraints[k].data["vars"] = vars
+            self.constraints[k]._data = assign_multiindex_safe(
+                self.constraints[k].data, vars=vars
+            )
 
         self.objective = self.objective.sel(
             {TERM_DIM: ~self.objective.vars.isin(labels)}

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -8,12 +8,11 @@ from __future__ import annotations
 
 import functools
 import logging
-from collections.abc import Hashable, ItemsView, Iterator, Mapping
+from collections.abc import Callable, Hashable, ItemsView, Iterator, Mapping
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
     overload,
 )
 from warnings import warn
@@ -755,7 +754,7 @@ class Variable:
         value = DataArray(value).broadcast_like(self.upper)
         if not set(value.dims).issubset(self.model.variables[self.name].dims):
             raise ValueError("Cannot assign new dimensions to existing variable.")
-        self.data["upper"] = value
+        self._data = assign_multiindex_safe(self.data, upper=value)
 
     @property
     def lower(self) -> DataArray:
@@ -779,7 +778,7 @@ class Variable:
         value = DataArray(value).broadcast_like(self.lower)
         if not set(value.dims).issubset(self.model.variables[self.name].dims):
             raise ValueError("Cannot assign new dimensions to existing variable.")
-        self.data["lower"] = value
+        self._data = assign_multiindex_safe(self.data, lower=value)
 
     @property
     @has_optimized_model
@@ -1059,8 +1058,7 @@ class Variable:
             .map(DataArray.bfill, dim=dim, limit=limit)
             .fillna(self._fill_value)
         )
-        data = data.assign(labels=data.labels.astype(int))
-        return self.__class__(data, self.model, self.name)
+        return self.assign(labels=data.labels.astype(int))
 
     def sanitize(self) -> Variable:
         """
@@ -1071,8 +1069,7 @@ class Variable:
         linopy.Variable
         """
         if issubdtype(self.labels.dtype, floating):
-            data = self.data.assign(labels=self.labels.fillna(-1).astype(int))
-            return self.__class__(data, self.model, self.name)
+            return self.assign(labels=self.labels.fillna(-1).astype(int))
         return self
 
     def equals(self, other: Variable) -> bool:
@@ -1082,6 +1079,8 @@ class Variable:
     assign_attrs = varwrap(Dataset.assign_attrs)
 
     assign_coords = varwrap(Dataset.assign_coords)
+
+    assign = varwrap(assign_multiindex_safe)
 
     assign_multiindex_safe = varwrap(assign_multiindex_safe)
 
@@ -1450,7 +1449,9 @@ class Variables:
 
         for name, variable in self.items():
             if dim in variable.dims:
-                variable.data["blocks"] = blocks.broadcast_like(variable.labels)
+                variable._data = assign_multiindex_safe(
+                    variable.data, blocks=blocks.broadcast_like(variable.labels)
+                )
 
     def get_blockmap(self, dtype: type = np.int8) -> ndarray:
         """


### PR DESCRIPTION
## Context

The issue being fixed relates to xarray's handling of multi-indexed coordinates. When using direct assignment with multi-indexed coordinates (e.g., self.data["vars"] = value), xarray would raise a deprecation warning because this approach doesn't properly handle the multi-indexed structure. The fix implemented here uses the assign_multiindex_safe() function which properly handles these cases, ensuring that assignments work correctly with multi-indexed coordinates without triggering deprecation warnings.


## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
