### PR TITLE
Solver: Added additional keys and values within condition map of cplex solver

### DIFF
--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -1221,6 +1221,17 @@ class Cplex(Solver):
         CONDITION_MAP = {
             "integer optimal solution": "optimal",
             "integer optimal, tolerance": "optimal",
+            "integer infeasible": "infeasible",
+            "time limit exceeded": "time_limit",
+            "time limit exceeded, no integer solution": "infeasible",
+            "error termination": "error",
+            "error termination, no integer solution": "error",
+            "memory limit exceeded": "internal_solver_error",
+            "memory limit exceeded, no integer solution": "internal_solver_error",
+            "aborted": "user_interrupt",
+            "integer unbounded": "unbounded",
+            "integer infeasible or unbounded": "infeasible_or_unbounded",
+            "Unknown status value": "unknown",
         }
         io_api = read_io_api_from_problem_file(problem_fn)
         sense = read_sense_from_problem_file(problem_fn)


### PR DESCRIPTION
## Changes proposed in this Pull Request
This PR adds some keys and values within the condition map of the solver CPLEX. I've manually extracted the string value of the code values of the solution status. 

I haven't added a release notes within doc/release_notes.rst but I can do it if necessary.

## Checklist

- [X] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [X] Unit tests for new features were added (if applicable).
- [] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [X] I consent to the release of this PR's code under the MIT license.
