### PR TITLE
remove python 3.9 deps

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -5,7 +5,12 @@ Release Notes
 .. ----------------
 
 
+
 * Improved variable/expression arithmetic methods so that they correctly handle types
+
+**Breaking Changes**
+
+* With this release, the package support for python 3.9 was dropped. It now requires python 3.10 or higher.
 
 Version 0.5.5
 --------------

--- a/linopy/common.py
+++ b/linopy/common.py
@@ -117,7 +117,7 @@ def get_from_iterable(lst: DimsLike | None, index: int) -> Any | None:
     """
     if lst is None:
         return None
-    if isinstance(lst, (Sequence, Iterable)):
+    if isinstance(lst, Sequence | Iterable):
         lst = list(lst)
     else:
         lst = [lst]
@@ -210,7 +210,7 @@ def numpy_to_dataarray(
         return DataArray(arr.item(), coords=coords, dims=dims, **kwargs)
 
     ndim = max(arr.ndim, 0 if coords is None else len(coords))
-    if isinstance(dims, (Iterable, Sequence)):
+    if isinstance(dims, Iterable | Sequence):
         dims = list(dims)
     elif dims is not None:
         dims = [dims]
@@ -250,11 +250,11 @@ def as_dataarray(
         DataArray:
             The converted DataArray.
     """
-    if isinstance(arr, (pd.Series, pd.DataFrame)):
+    if isinstance(arr, pd.Series | pd.DataFrame):
         arr = pandas_to_dataarray(arr, coords=coords, dims=dims, **kwargs)
     elif isinstance(arr, np.ndarray):
         arr = numpy_to_dataarray(arr, coords=coords, dims=dims, **kwargs)
-    elif isinstance(arr, (np.number, int, float, str, bool, list)):
+    elif isinstance(arr, np.number | int | float | str | bool | list):
         arr = DataArray(arr, coords=coords, dims=dims, **kwargs)
 
     elif not isinstance(arr, DataArray):
@@ -493,7 +493,7 @@ def fill_missing_coords(
 
     """
     ds = ds.copy()
-    if not isinstance(ds, (Dataset, DataArray)):
+    if not isinstance(ds, Dataset | DataArray):
         raise TypeError(f"Expected xarray.DataArray or xarray.Dataset, got {type(ds)}.")
 
     skip_dims = [] if fill_helper_dims else HELPER_DIMS
@@ -807,7 +807,7 @@ def print_coord(coord: dict[str, Any] | Iterable[Any]) -> str:
     # Convert each coordinate component to string
     formatted = []
     for value in values:
-        if isinstance(value, (list, tuple)):
+        if isinstance(value, list | tuple):
             formatted.append(f"({', '.join(str(x) for x in value)})")
         else:
             formatted.append(str(value))
@@ -946,11 +946,9 @@ def is_constant(func: Callable[..., Any]) -> Callable[..., Any]:
     def wrapper(self: Any, arg: Any) -> Any:
         if isinstance(
             arg,
-            (
-                variables.Variable,
-                variables.ScalarVariable,
-                expressions.LinearExpression,
-            ),
+            variables.Variable
+            | variables.ScalarVariable
+            | expressions.LinearExpression,
         ):
             raise TypeError(f"Assigned rhs must be a constant, got {type(arg)}).")
         return func(self, arg)
@@ -1061,7 +1059,7 @@ def align(
     finisher: list[partial[Any] | Callable[[Any], Any]] = []
     das: list[Any] = []
     for obj in objects:
-        if isinstance(obj, (LinearExpression, QuadraticExpression)):
+        if isinstance(obj, LinearExpression | QuadraticExpression):
             finisher.append(partial(obj.__class__, model=obj.model))
             das.append(obj.data)
         elif isinstance(obj, Variable):

--- a/linopy/common.py
+++ b/linopy/common.py
@@ -9,10 +9,10 @@ from __future__ import annotations
 
 import operator
 import os
-from collections.abc import Generator, Hashable, Iterable, Sequence
+from collections.abc import Callable, Generator, Hashable, Iterable, Sequence
 from functools import partial, reduce, wraps
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, overload
 from warnings import warn
 
 import numpy as np

--- a/linopy/constants.py
+++ b/linopy/constants.py
@@ -169,7 +169,7 @@ class Status:
 
     status: SolverStatus
     termination_condition: TerminationCondition
-    legacy_status: Union[tuple[str, str], str] = ""
+    legacy_status: tuple[str, str] | str = ""
 
     @classmethod
     def process(cls, status: str, termination_condition: str) -> "Status":
@@ -214,7 +214,7 @@ class Result:
     """
 
     status: Status
-    solution: Union[Solution, None] = None
+    solution: Solution | None = None
     solver_model: Any = None
 
     def __repr__(self) -> str:

--- a/linopy/constraints.py
+++ b/linopy/constraints.py
@@ -940,7 +940,7 @@ class Constraints:
         name : str
             Name of the containing constraint.
         """
-        if not isinstance(label, (float, int)) or label < 0:
+        if not isinstance(label, float | int) or label < 0:
             raise ValueError("Label must be a positive number.")
         for name, ds in self.items():
             if label in ds.labels:
@@ -1084,7 +1084,7 @@ class AnonymousScalarConstraint:
         """
         Initialize a anonymous scalar constraint.
         """
-        if not isinstance(rhs, (int, float, np.floating, np.integer)):
+        if not isinstance(rhs, int | float | np.floating | np.integer):
             raise TypeError(f"Assigned rhs must be a constant, got {type(rhs)}).")
         self._lhs = lhs
         self._sign = sign

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -39,6 +39,8 @@ except ImportError:
     import xarray.core.rolling
     from xarray.core.rolling import DatasetRolling  # type: ignore
 
+from types import EllipsisType, NotImplementedType
+
 from linopy import constraints, variables
 from linopy.common import (
     EmptyDeprecationWrapper,
@@ -77,9 +79,7 @@ from linopy.constants import (
 from linopy.types import (
     ConstantLike,
     DimsLike,
-    EllipsisType,
     ExpressionLike,
-    NotImplementedType,
     SideLike,
     SignLike,
     VariableLike,

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -129,7 +129,7 @@ def exprwrap(
 def _expr_unwrap(
     maybe_expr: Any | LinearExpression | QuadraticExpression,
 ) -> Any:
-    if isinstance(maybe_expr, (LinearExpression, QuadraticExpression)):
+    if isinstance(maybe_expr, LinearExpression | QuadraticExpression):
         return maybe_expr.data
 
     return maybe_expr
@@ -249,6 +249,8 @@ class LinearExpressionGroupby:
                 orig_group = group
                 group = group.apply(tuple, axis=1).map(int_map)
 
+            # At this point, group is always a pandas Series
+            assert isinstance(group, pd.Series)
             group_dim = group.index.name
 
             arrays = [group, group.groupby(group).cumcount()]
@@ -529,13 +531,11 @@ class BaseExpression(ABC):
         try:
             if isinstance(
                 other,
-                (
-                    variables.Variable,
-                    variables.ScalarVariable,
-                    LinearExpression,
-                    ScalarLinearExpression,
-                    QuadraticExpression,
-                ),
+                variables.Variable
+                | variables.ScalarVariable
+                | LinearExpression
+                | ScalarLinearExpression
+                | QuadraticExpression,
             ):
                 raise TypeError(
                     "unsupported operand type(s) for /: "
@@ -930,7 +930,7 @@ class BaseExpression(ABC):
                 _other = FILL_VALUE
             else:
                 _other = None
-        elif isinstance(other, (int, float, DataArray)):
+        elif isinstance(other, int | float | DataArray):
             _other = {**self._fill_value, "const": other}
         else:
             _other = _expr_unwrap(other)
@@ -970,7 +970,7 @@ class BaseExpression(ABC):
             A new object with missing values filled with the given value.
         """
         value = _expr_unwrap(value)
-        if isinstance(value, (DataArray, np.floating, np.integer, int, float)):
+        if isinstance(value, DataArray | np.floating | np.integer | int | float):
             value = {"const": value}
         return self.__class__(self.data.fillna(value), self.model)
 
@@ -1362,10 +1362,10 @@ class LinearExpression(BaseExpression):
             return other.__rmul__(self)
 
         try:
-            if isinstance(other, (variables.Variable, variables.ScalarVariable)):
+            if isinstance(other, variables.Variable | variables.ScalarVariable):
                 other = other.to_linexpr()
 
-            if isinstance(other, (LinearExpression, ScalarLinearExpression)):
+            if isinstance(other, LinearExpression | ScalarLinearExpression):
                 return self._multiply_by_linear_expression(other)
             else:
                 return self._multiply_by_constant(other)
@@ -1403,7 +1403,7 @@ class LinearExpression(BaseExpression):
         """
         Matrix multiplication with other, similar to xarray dot.
         """
-        if not isinstance(other, (LinearExpression, variables.Variable)):
+        if not isinstance(other, LinearExpression | variables.Variable):
             other = as_dataarray(other, coords=self.coords, dims=self.coord_dims)
 
         common_dims = list(set(self.coord_dims).intersection(other.dims))
@@ -1620,7 +1620,7 @@ class LinearExpression(BaseExpression):
                 # assume first element is coefficient and second is variable
                 c, v = t
                 if isinstance(v, variables.ScalarVariable):
-                    if not isinstance(c, (int, float)):
+                    if not isinstance(c, int | float):
                         raise TypeError(
                             "Expected int or float as coefficient of scalar variable (first element of tuple)."
                         )
@@ -1703,12 +1703,10 @@ class QuadraticExpression(BaseExpression):
         """
         if isinstance(
             other,
-            (
-                BaseExpression,
-                ScalarLinearExpression,
-                variables.Variable,
-                variables.ScalarVariable,
-            ),
+            BaseExpression
+            | ScalarLinearExpression
+            | variables.Variable
+            | variables.ScalarVariable,
         ):
             raise TypeError(
                 "unsupported operand type(s) for *: "
@@ -1787,12 +1785,10 @@ class QuadraticExpression(BaseExpression):
         """
         if isinstance(
             other,
-            (
-                BaseExpression,
-                ScalarLinearExpression,
-                variables.Variable,
-                variables.ScalarVariable,
-            ),
+            BaseExpression
+            | ScalarLinearExpression
+            | variables.Variable
+            | variables.ScalarVariable,
         ):
             raise TypeError(
                 "Higher order non-linear expressions are not yet supported."
@@ -1915,9 +1911,9 @@ def as_expression(
     ValueError
         If object cannot be converted to LinearExpression.
     """
-    if isinstance(obj, (LinearExpression, QuadraticExpression)):
+    if isinstance(obj, LinearExpression | QuadraticExpression):
         return obj
-    elif isinstance(obj, (variables.Variable, variables.ScalarVariable)):
+    elif isinstance(obj, variables.Variable | variables.ScalarVariable):
         return obj.to_linexpr()
     else:
         try:
@@ -2134,7 +2130,7 @@ class ScalarLinearExpression:
         )
 
     def __mul__(self, other: float | int) -> ScalarLinearExpression:
-        if not isinstance(other, (int, float, np.number)):
+        if not isinstance(other, int | float | np.number):
             raise TypeError(
                 f"unsupported operand type(s) for *: {type(self)} and {type(other)}"
             )
@@ -2147,7 +2143,7 @@ class ScalarLinearExpression:
         return self.__mul__(other)
 
     def __div__(self, other: float | int) -> ScalarLinearExpression:
-        if not isinstance(other, (int, float, np.number)):
+        if not isinstance(other, int | float | np.number):
             raise TypeError(
                 f"unsupported operand type(s) for /: {type(self)} and {type(other)}"
             )
@@ -2157,7 +2153,7 @@ class ScalarLinearExpression:
         return self.__div__(other)
 
     def __le__(self, other: int | float) -> AnonymousScalarConstraint:
-        if not isinstance(other, (int, float, np.number)):
+        if not isinstance(other, int | float | np.number):
             raise TypeError(
                 f"unsupported operand type(s) for <=: {type(self)} and {type(other)}"
             )
@@ -2165,7 +2161,7 @@ class ScalarLinearExpression:
         return constraints.AnonymousScalarConstraint(self, LESS_EQUAL, other)
 
     def __ge__(self, other: int | float) -> AnonymousScalarConstraint:
-        if not isinstance(other, (int, float, np.number)):
+        if not isinstance(other, int | float | np.number):
             raise TypeError(
                 f"unsupported operand type(s) for >=: {type(self)} and {type(other)}"
             )
@@ -2173,7 +2169,7 @@ class ScalarLinearExpression:
         return constraints.AnonymousScalarConstraint(self, GREATER_EQUAL, other)
 
     def __eq__(self, other: int | float) -> AnonymousScalarConstraint:  # type: ignore
-        if not isinstance(other, (int, float, np.number)):
+        if not isinstance(other, int | float | np.number):
             raise TypeError(
                 f"unsupported operand type(s) for ==: {type(self)} and {type(other)}"
             )

--- a/linopy/io.py
+++ b/linopy/io.py
@@ -8,11 +8,11 @@ from __future__ import annotations
 import logging
 import shutil
 import time
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from io import BufferedWriter, TextIOWrapper
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pandas as pd

--- a/linopy/matrices.py
+++ b/linopy/matrices.py
@@ -32,7 +32,7 @@ def create_vector(
     """Create a vector of a size equal to the maximum index plus one."""
     if shape is None:
         max_value = indices.max()
-        if not isinstance(max_value, (np.integer, int)):
+        if not isinstance(max_value, np.integer | int):
             raise ValueError("Indices must be integers.")
         shape = max_value + 1
     vector = np.full(shape, fill_value)

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -710,7 +710,7 @@ class Model:
                 "Objective already defined."
                 " Set `overwrite` to True to force overwriting."
             )
-        self.objective.expression = expr  # type: ignore[assignment]
+        self.objective.expression = expr
         self.objective.sense = sense
 
     def remove_variables(self, name: str) -> None:

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -317,7 +317,7 @@ class Model:
 
     @solver_dir.setter
     def solver_dir(self, value: str | Path) -> None:
-        if not isinstance(value, (str, Path)):
+        if not isinstance(value, str | Path):
             raise TypeError("'solver_dir' must path-like.")
         self._solver_dir = Path(value)
 
@@ -614,7 +614,7 @@ class Model:
             if sign is None or rhs is None:
                 raise ValueError(msg_sign_rhs_not_none)
             data = lhs.to_constraint(sign, rhs).data
-        elif isinstance(lhs, (list, tuple)):
+        elif isinstance(lhs, list | tuple):
             if sign is None or rhs is None:
                 raise ValueError(msg_sign_rhs_none)
             data = self.linexpr(*lhs).to_constraint(sign, rhs).data
@@ -633,7 +633,7 @@ class Model:
             if sign is not None or rhs is not None:
                 raise ValueError(msg_sign_rhs_none)
             data = lhs.data
-        elif isinstance(lhs, (Variable, ScalarVariable, ScalarLinearExpression)):
+        elif isinstance(lhs, Variable | ScalarVariable | ScalarLinearExpression):
             if sign is None or rhs is None:
                 raise ValueError(msg_sign_rhs_not_none)
             data = lhs.to_linexpr().to_constraint(sign, rhs).data

--- a/linopy/monkey_patch_xarray.py
+++ b/linopy/monkey_patch_xarray.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from functools import partialmethod, update_wrapper
-from typing import Any, Callable
+from typing import Any
 
 from xarray import DataArray
 

--- a/linopy/monkey_patch_xarray.py
+++ b/linopy/monkey_patch_xarray.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from functools import partialmethod, update_wrapper
+from types import NotImplementedType
 from typing import Any
 
 from xarray import DataArray
 
 from linopy import expressions, variables
-from linopy.types import NotImplementedType
 
 
 def monkey_patch(cls: type[DataArray], pass_unpatched_method: bool = False) -> Callable:
@@ -29,11 +29,9 @@ def __mul__(
 ) -> DataArray | NotImplementedType:
     if isinstance(
         other,
-        (
-            variables.Variable,
-            expressions.LinearExpression,
-            expressions.QuadraticExpression,
-        ),
+        variables.Variable
+        | expressions.LinearExpression
+        | expressions.QuadraticExpression,
     ):
         return NotImplemented
     return unpatched_method(da, other)

--- a/linopy/objective.py
+++ b/linopy/objective.py
@@ -175,11 +175,11 @@ class Objective:
         """
         Sets the expression of the objective.
         """
-        if isinstance(expr, (list, tuple)):
+        if isinstance(expr, list | tuple):
             expr = self.model.linexpr(*expr)
 
         if not isinstance(
-            expr, (expressions.LinearExpression, expressions.QuadraticExpression)
+            expr, expressions.LinearExpression | expressions.QuadraticExpression
         ):
             raise ValueError(
                 f"Invalid type of `expr` ({type(expr)})."
@@ -263,7 +263,7 @@ class Objective:
 
     def __mul__(self, expr: ConstantLike) -> Objective:
         # only allow scalar multiplication
-        if not isinstance(expr, (int, float, np.floating, np.integer)):
+        if not isinstance(expr, int | float | np.floating | np.integer):
             raise ValueError("Invalid type for multiplication.")
         return Objective(self.expression * expr, self.model, self.sense)
 
@@ -272,6 +272,6 @@ class Objective:
 
     def __truediv__(self, expr: ConstantLike) -> Objective:
         # only allow scalar division
-        if not isinstance(expr, (int, float, np.floating, np.integer)):
+        if not isinstance(expr, int | float | np.floating | np.integer):
             raise ValueError("Invalid type for division.")
         return Objective(self.expression / expr, self.model, self.sense)

--- a/linopy/objective.py
+++ b/linopy/objective.py
@@ -8,8 +8,8 @@ This module contains definition related to objective expressions.
 from __future__ import annotations
 
 import functools
-from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Callable
+from collections.abc import Callable, Sequence
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import polars as pl

--- a/linopy/remote.py
+++ b/linopy/remote.py
@@ -7,8 +7,9 @@ Created on Sun Feb 13 21:34:55 2022.
 
 import logging
 import tempfile
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable, Union
+from typing import TYPE_CHECKING, Any, Union
 
 from linopy.io import read_netcdf
 
@@ -116,8 +117,8 @@ class RemoteHandler:
 
     hostname: str
     port: int = 22
-    username: Union[str, None] = None
-    password: Union[str, None] = None
+    username: str | None = None
+    password: str | None = None
     client: Union["paramiko.SSHClient", None] = None
 
     python_script: Callable = command.format

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -2041,9 +2041,9 @@ class COPT(Solver):
 
         # TODO: check if this suffices
         condition = m.MipStatus if m.ismip else m.LpStatus
-        termination_condition = CONDITION_MAP.get(condition, condition)
+        termination_condition = CONDITION_MAP.get(condition, str(condition))
         status = Status.from_termination_condition(termination_condition)
-        status.legacy_status = condition
+        status.legacy_status = str(condition)
 
         def get_solver_solution() -> Solution:
             # TODO: check if this suffices

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -15,9 +15,9 @@ import subprocess as sub
 import sys
 from abc import ABC, abstractmethod
 from collections import namedtuple
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pandas as pd

--- a/linopy/types.py
+++ b/linopy/types.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 
 # Type aliases using Union for Python 3.9 compatibility
 CoordsLike = Union[
-    Sequence[Union[Sequence, Index, DataArray]],
+    Sequence[Sequence | Index | DataArray],
     Mapping,
     DataArrayCoordinates,
     DatasetCoordinates,

--- a/linopy/types.py
+++ b/linopy/types.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 from collections.abc import Hashable, Iterable, Mapping, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Union
@@ -10,12 +9,6 @@ import numpy.typing
 from pandas import DataFrame, Index, Series
 from xarray import DataArray
 from xarray.core.coordinates import DataArrayCoordinates, DatasetCoordinates
-
-if sys.version_info >= (3, 10):
-    from types import EllipsisType, NotImplementedType
-else:
-    EllipsisType = type(Ellipsis)
-    NotImplementedType = type(NotImplemented)
 
 if TYPE_CHECKING:
     from linopy.constraints import AnonymousScalarConstraint, Constraint
@@ -27,15 +20,15 @@ if TYPE_CHECKING:
     from linopy.variables import ScalarVariable, Variable
 
 # Type aliases using Union for Python 3.9 compatibility
-CoordsLike = Union[
+CoordsLike = Union[  # noqa: UP007
     Sequence[Sequence | Index | DataArray],
     Mapping,
     DataArrayCoordinates,
     DatasetCoordinates,
 ]
-DimsLike = Union[str, Iterable[Hashable]]
+DimsLike = Union[str, Iterable[Hashable]]  # noqa: UP007
 
-ConstantLike = Union[
+ConstantLike = Union[  # noqa: UP007
     int,
     float,
     numpy.floating,
@@ -45,7 +38,7 @@ ConstantLike = Union[
     Series,
     DataFrame,
 ]
-SignLike = Union[str, numpy.ndarray, DataArray, Series, DataFrame]
+SignLike = Union[str, numpy.ndarray, DataArray, Series, DataFrame]  # noqa: UP007
 VariableLike = Union["ScalarVariable", "Variable"]
 ExpressionLike = Union[
     "ScalarLinearExpression",
@@ -53,6 +46,6 @@ ExpressionLike = Union[
     "QuadraticExpression",
 ]
 ConstraintLike = Union["Constraint", "AnonymousScalarConstraint"]
-MaskLike = Union[numpy.ndarray, DataArray, Series, DataFrame]
-SideLike = Union[ConstantLike, VariableLike, ExpressionLike]
-PathLike = Union[str, Path]
+MaskLike = Union[numpy.ndarray, DataArray, Series, DataFrame]  # noqa: UP007
+SideLike = Union[ConstantLike, VariableLike, ExpressionLike]  # noqa: UP007
+PathLike = Union[str, Path]  # noqa: UP007

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -10,6 +10,7 @@ import functools
 import logging
 from collections.abc import Callable, Hashable, ItemsView, Iterator, Mapping
 from dataclasses import dataclass
+from types import NotImplementedType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -55,7 +56,6 @@ from linopy.types import (
     ConstantLike,
     DimsLike,
     ExpressionLike,
-    NotImplementedType,
     SideLike,
     VariableLike,
 )
@@ -400,7 +400,7 @@ class Variable:
         Multiply variables with a coefficient, variable, or expression.
         """
         try:
-            if isinstance(other, (Variable, ScalarVariable)):
+            if isinstance(other, Variable | ScalarVariable):
                 return self.to_linexpr() * other
 
             return self.to_linexpr(other)
@@ -449,7 +449,7 @@ class Variable:
         """
         Divide variables with a coefficient.
         """
-        if isinstance(other, (expressions.LinearExpression, Variable)):
+        if isinstance(other, expressions.LinearExpression | Variable):
             raise TypeError(
                 "unsupported operand type(s) for /: "
                 f"{type(self)} and {type(other)}. "
@@ -1028,7 +1028,7 @@ class Variable:
             _other = other.data
         elif isinstance(other, ScalarVariable):
             _other = {"labels": other.label, "lower": other.lower, "upper": other.upper}
-        elif isinstance(other, (dict, Dataset)):
+        elif isinstance(other, dict | Dataset):
             _other = other
         else:
             raise ValueError(
@@ -1432,7 +1432,7 @@ class Variables:
         name : str
             Name of the containing variable.
         """
-        if not isinstance(label, (float, int, np.integer)) or label < 0:
+        if not isinstance(label, float | int | np.integer) or label < 0:
             raise ValueError("Label must be a positive number.")
         for name, labels in self.labels.items():
             if label in labels:
@@ -1564,7 +1564,7 @@ class ScalarVariable:
         return self._model
 
     def to_scalar_linexpr(self, coeff: int | float = 1) -> ScalarLinearExpression:
-        if not isinstance(coeff, (int, np.integer, float)):
+        if not isinstance(coeff, int | np.integer | float):
             raise TypeError(f"Coefficient must be a numeric value, got {type(coeff)}.")
         return expressions.ScalarLinearExpression((coeff,), (self.label,), self.model)
 
@@ -1588,7 +1588,7 @@ class ScalarVariable:
         return self.to_scalar_linexpr(coeff)
 
     def __rmul__(self, coeff: int | float) -> ScalarLinearExpression:
-        if isinstance(coeff, (Variable, ScalarVariable)):
+        if isinstance(coeff, Variable | ScalarVariable):
             return NotImplemented
         return self.to_scalar_linexpr(coeff)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ readme = "README.md"
 authors = [{ name = "Fabian Hofmann", email = "fabianmarikhofmann@gmail.com" }]
 license = { file = "LICENSE" }
 classifiers = [
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "numpy; python_version > '3.10'",
     "numpy<2; python_version <= '3.10'",

--- a/test/test_constraint.py
+++ b/test/test_constraint.py
@@ -310,7 +310,7 @@ def test_constraint_rhs_getter(c: linopy.constraints.Constraint) -> None:
 def test_constraint_vars_setter(
     c: linopy.constraints.Constraint, x: linopy.Variable
 ) -> None:
-    c.vars = x  # type: ignore
+    c.vars = x  # type: ignore[assignment]
     assert_equal(c.vars, x.labels)
 
 
@@ -329,7 +329,7 @@ def test_constraint_vars_setter_invalid(
 
 
 def test_constraint_coeffs_setter(c: linopy.constraints.Constraint) -> None:
-    c.coeffs = 3  # type: ignore
+    c.coeffs = 3  # type: ignore[assignment]
     assert (c.coeffs == 3).all()
 
 
@@ -345,32 +345,32 @@ def test_constraint_lhs_setter(
 def test_constraint_lhs_setter_with_variable(
     c: linopy.constraints.Constraint, x: linopy.Variable
 ) -> None:
-    c.lhs = x  # type: ignore
+    c.lhs = x  # type: ignore[assignment]
     assert c.lhs.nterm == 1
 
 
 def test_constraint_lhs_setter_with_constant(c: linopy.constraints.Constraint) -> None:
     sizes = c.sizes
-    c.lhs = 10  # type: ignore
+    c.lhs = 10  # type: ignore[assignment]
     assert (c.rhs == -10).all()
     assert c.lhs.nterm == 0
     assert c.sizes["first"] == sizes["first"]
 
 
 def test_constraint_sign_setter(c: linopy.constraints.Constraint) -> None:
-    c.sign = EQUAL  # type: ignore
+    c.sign = EQUAL  # type: ignore[assignment]
     assert (c.sign == EQUAL).all()
 
 
 def test_constraint_sign_setter_alternative(c: linopy.constraints.Constraint) -> None:
-    c.sign = long_EQUAL  # type: ignore
+    c.sign = long_EQUAL  # type: ignore[assignment]
     assert (c.sign == EQUAL).all()
 
 
 def test_constraint_sign_setter_invalid(c: linopy.constraints.Constraint) -> None:
     # Test that assigning lhs with other type that LinearExpression raises TypeError
     with pytest.raises(ValueError):
-        c.sign = "asd"  # type: ignore
+        c.sign = "asd"  # type: ignore[assignment]
 
 
 def test_constraint_rhs_setter(c: linopy.constraints.Constraint) -> None:
@@ -392,7 +392,7 @@ def test_constraint_rhs_setter_with_variable(
 def test_constraint_rhs_setter_with_expression(
     c: linopy.constraints.Constraint, x: linopy.Variable, y: linopy.Variable
 ) -> None:
-    c.rhs = x + y  # type: ignore
+    c.rhs = x + y  # type: ignore[assignment]
     assert (c.rhs == 0).all()
     assert (c.coeffs.isel({c.term_dim: -1}) == -1).all()
     assert c.lhs.nterm == 3
@@ -401,7 +401,7 @@ def test_constraint_rhs_setter_with_expression(
 def test_constraint_rhs_setter_with_expression_and_constant(
     c: linopy.constraints.Constraint, x: linopy.Variable
 ) -> None:
-    c.rhs = x + 1  # type: ignore
+    c.rhs = x + 1  # type: ignore[assignment]
     assert (c.rhs == 1).all()
     assert (c.coeffs.sum(c.term_dim) == 0).all()
     assert c.lhs.nterm == 2

--- a/test/test_constraint.py
+++ b/test/test_constraint.py
@@ -310,7 +310,7 @@ def test_constraint_rhs_getter(c: linopy.constraints.Constraint) -> None:
 def test_constraint_vars_setter(
     c: linopy.constraints.Constraint, x: linopy.Variable
 ) -> None:
-    c.vars = x  # type: ignore[assignment]
+    c.vars = x
     assert_equal(c.vars, x.labels)
 
 
@@ -329,7 +329,7 @@ def test_constraint_vars_setter_invalid(
 
 
 def test_constraint_coeffs_setter(c: linopy.constraints.Constraint) -> None:
-    c.coeffs = 3  # type: ignore[assignment]
+    c.coeffs = 3
     assert (c.coeffs == 3).all()
 
 
@@ -345,32 +345,32 @@ def test_constraint_lhs_setter(
 def test_constraint_lhs_setter_with_variable(
     c: linopy.constraints.Constraint, x: linopy.Variable
 ) -> None:
-    c.lhs = x  # type: ignore[assignment]
+    c.lhs = x
     assert c.lhs.nterm == 1
 
 
 def test_constraint_lhs_setter_with_constant(c: linopy.constraints.Constraint) -> None:
     sizes = c.sizes
-    c.lhs = 10  # type: ignore[assignment]
+    c.lhs = 10
     assert (c.rhs == -10).all()
     assert c.lhs.nterm == 0
     assert c.sizes["first"] == sizes["first"]
 
 
 def test_constraint_sign_setter(c: linopy.constraints.Constraint) -> None:
-    c.sign = EQUAL  # type: ignore[assignment]
+    c.sign = EQUAL
     assert (c.sign == EQUAL).all()
 
 
 def test_constraint_sign_setter_alternative(c: linopy.constraints.Constraint) -> None:
-    c.sign = long_EQUAL  # type: ignore[assignment]
+    c.sign = long_EQUAL
     assert (c.sign == EQUAL).all()
 
 
 def test_constraint_sign_setter_invalid(c: linopy.constraints.Constraint) -> None:
     # Test that assigning lhs with other type that LinearExpression raises TypeError
     with pytest.raises(ValueError):
-        c.sign = "asd"  # type: ignore[assignment]
+        c.sign = "asd"
 
 
 def test_constraint_rhs_setter(c: linopy.constraints.Constraint) -> None:
@@ -392,7 +392,7 @@ def test_constraint_rhs_setter_with_variable(
 def test_constraint_rhs_setter_with_expression(
     c: linopy.constraints.Constraint, x: linopy.Variable, y: linopy.Variable
 ) -> None:
-    c.rhs = x + y  # type: ignore[assignment]
+    c.rhs = x + y
     assert (c.rhs == 0).all()
     assert (c.coeffs.isel({c.term_dim: -1}) == -1).all()
     assert c.lhs.nterm == 3
@@ -401,7 +401,7 @@ def test_constraint_rhs_setter_with_expression(
 def test_constraint_rhs_setter_with_expression_and_constant(
     c: linopy.constraints.Constraint, x: linopy.Variable
 ) -> None:
-    c.rhs = x + 1  # type: ignore[assignment]
+    c.rhs = x + 1
     assert (c.rhs == 1).all()
     assert (c.coeffs.sum(c.term_dim) == 0).all()
     assert c.lhs.nterm == 2

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -7,7 +7,6 @@ Created on Thu Mar 18 09:03:35 2021.
 
 import pickle
 from pathlib import Path
-from typing import Union
 
 import pandas as pd
 import pytest
@@ -165,7 +164,7 @@ def test_to_file_lp_explicit_coordinate_names(model: Model, tmp_path: Path) -> N
 def test_to_file_lp_None(model: Model) -> None:
     import gurobipy
 
-    fn: Union[str, None] = None
+    fn: str | None = None
     model.to_file(fn)
 
     fn_path = model.get_problem_file()

--- a/test/test_linear_expression.py
+++ b/test/test_linear_expression.py
@@ -1151,7 +1151,7 @@ def test_merge(x: Variable, y: Variable, z: Variable) -> None:
     assert res.sel(dim_1=0).vars[2].item() == -1
 
     with pytest.warns(DeprecationWarning):
-        merge(expr1, expr2)  # type: ignore[arg-type]
+        merge(expr1, expr2)
 
 
 def test_linear_expression_outer_sum(x: Variable, y: Variable) -> None:

--- a/test/test_linear_expression.py
+++ b/test/test_linear_expression.py
@@ -1151,7 +1151,7 @@ def test_merge(x: Variable, y: Variable, z: Variable) -> None:
     assert res.sel(dim_1=0).vars[2].item() == -1
 
     with pytest.warns(DeprecationWarning):
-        merge(expr1, expr2)  # type: ignore
+        merge(expr1, expr2)  # type: ignore[arg-type]
 
 
 def test_linear_expression_outer_sum(x: Variable, y: Variable) -> None:

--- a/test/test_linear_expression.py
+++ b/test/test_linear_expression.py
@@ -955,7 +955,7 @@ def test_linear_expression_groupby_with_dataarray(
 
     # this should not be the case, see https://github.com/PyPSA/linopy/issues/351
     if use_fallback:
-        with pytest.raises(KeyError):
+        with pytest.raises((KeyError, IndexError)):
             expr.groupby(groups).sum(use_fallback=use_fallback)
         return
 

--- a/test/test_optimization.py
+++ b/test/test_optimization.py
@@ -129,7 +129,7 @@ def model_with_inf() -> Model:
     m.add_constraints(x + y, GREATER_EQUAL, 10)
     m.add_constraints(1 * x, "<=", np.inf)
 
-    m.objective = 2 * x + y  # type: ignore[assignment]
+    m.objective = 2 * x + y
 
     return m
 
@@ -142,7 +142,7 @@ def model_with_duplicated_variables() -> Model:
     x = m.add_variables(coords=[lower.index], name="x")
 
     m.add_constraints(x + x, GREATER_EQUAL, 10)
-    m.objective = 1 * x  # type: ignore[assignment]
+    m.objective = 1 * x
 
     return m
 
@@ -157,7 +157,7 @@ def model_with_non_aligned_variables() -> Model:
     y = m.add_variables(lower=lower, coords=[lower.index], name="y")
 
     m.add_constraints(x + y, GREATER_EQUAL, 10.5)
-    m.objective = 1 * x + 0.5 * y  # type: ignore[assignment]
+    m.objective = 1 * x + 0.5 * y
 
     return m
 
@@ -270,9 +270,9 @@ def modified_model() -> Model:
 
     c = m.add_constraints(x + y, GREATER_EQUAL, 10)
 
-    y.lower = 9  # type: ignore[assignment]
+    y.lower = 9
     c.lhs = 2 * x + y
-    m.objective = 2 * x + y  # type: ignore[assignment]
+    m.objective = 2 * x + y
 
     return m
 

--- a/test/test_optimization.py
+++ b/test/test_optimization.py
@@ -129,7 +129,7 @@ def model_with_inf() -> Model:
     m.add_constraints(x + y, GREATER_EQUAL, 10)
     m.add_constraints(1 * x, "<=", np.inf)
 
-    m.objective = 2 * x + y  # type: ignore
+    m.objective = 2 * x + y  # type: ignore[assignment]
 
     return m
 
@@ -142,7 +142,7 @@ def model_with_duplicated_variables() -> Model:
     x = m.add_variables(coords=[lower.index], name="x")
 
     m.add_constraints(x + x, GREATER_EQUAL, 10)
-    m.objective = 1 * x  # type: ignore
+    m.objective = 1 * x  # type: ignore[assignment]
 
     return m
 
@@ -157,7 +157,7 @@ def model_with_non_aligned_variables() -> Model:
     y = m.add_variables(lower=lower, coords=[lower.index], name="y")
 
     m.add_constraints(x + y, GREATER_EQUAL, 10.5)
-    m.objective = 1 * x + 0.5 * y  # type: ignore
+    m.objective = 1 * x + 0.5 * y  # type: ignore[assignment]
 
     return m
 
@@ -270,9 +270,9 @@ def modified_model() -> Model:
 
     c = m.add_constraints(x + y, GREATER_EQUAL, 10)
 
-    y.lower = 9  # type: ignore
+    y.lower = 9  # type: ignore[assignment]
     c.lhs = 2 * x + y
-    m.objective = 2 * x + y  # type: ignore
+    m.objective = 2 * x + y  # type: ignore[assignment]
 
     return m
 

--- a/test/test_quadratic_expression.py
+++ b/test/test_quadratic_expression.py
@@ -303,7 +303,7 @@ def test_quadratic_expression_to_matrix(model: Model, x: Variable, y: Variable) 
 
 def test_matrices_matrix(model: Model, x: Variable, y: Variable) -> None:
     expr = 10 * x * y
-    model.objective = expr  # type: ignore
+    model.objective = expr  # type: ignore[assignment]
 
     Q = model.matrices.Q
     assert isinstance(Q, csc_matrix)
@@ -314,7 +314,7 @@ def test_matrices_matrix_mixed_linear_and_quadratic(
     model: Model, x: Variable, y: Variable
 ) -> None:
     quad_expr = x * y + x
-    model.objective = quad_expr + x  # type: ignore
+    model.objective = quad_expr + x  # type: ignore[assignment]
 
     Q = model.matrices.Q
     assert isinstance(Q, csc_matrix)

--- a/test/test_quadratic_expression.py
+++ b/test/test_quadratic_expression.py
@@ -303,7 +303,7 @@ def test_quadratic_expression_to_matrix(model: Model, x: Variable, y: Variable) 
 
 def test_matrices_matrix(model: Model, x: Variable, y: Variable) -> None:
     expr = 10 * x * y
-    model.objective = expr  # type: ignore[assignment]
+    model.objective = expr
 
     Q = model.matrices.Q
     assert isinstance(Q, csc_matrix)
@@ -314,7 +314,7 @@ def test_matrices_matrix_mixed_linear_and_quadratic(
     model: Model, x: Variable, y: Variable
 ) -> None:
     quad_expr = x * y + x
-    model.objective = quad_expr + x  # type: ignore[assignment]
+    model.objective = quad_expr + x
 
     Q = model.matrices.Q
     assert isinstance(Q, csc_matrix)

--- a/test/test_variable.py
+++ b/test/test_variable.py
@@ -128,12 +128,12 @@ def test_variable_lower_getter(z: linopy.Variable) -> None:
 
 
 def test_variable_upper_setter(z: linopy.Variable) -> None:
-    z.upper = 20  # type: ignore
+    z.upper = 20  # type: ignore[assignment]
     assert z.upper.item() == 20
 
 
 def test_variable_lower_setter(z: linopy.Variable) -> None:
-    z.lower = 8  # type: ignore
+    z.lower = 8  # type: ignore[assignment]
     assert z.lower == 8
 
 

--- a/test/test_variable.py
+++ b/test/test_variable.py
@@ -128,12 +128,12 @@ def test_variable_lower_getter(z: linopy.Variable) -> None:
 
 
 def test_variable_upper_setter(z: linopy.Variable) -> None:
-    z.upper = 20  # type: ignore[assignment]
+    z.upper = 20
     assert z.upper.item() == 20
 
 
 def test_variable_lower_setter(z: linopy.Variable) -> None:
-    z.lower = 8  # type: ignore[assignment]
+    z.lower = 8
     assert z.lower == 8
 
 


### PR DESCRIPTION
I am facing issues in command like `uv sync`  due to the Python 3.9 deps colliding with extras from the "doc" dependency.  EOL for Python 3.9 is in October this year and PyPSA already removed its support, so this should not be a problem.  

## Changes proposed in this Pull Request


## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
