### PR TITLE
fix: Allow COPT solution parsing for IMPRECISE status

### DIFF
--- a/linopy/constants.py
+++ b/linopy/constants.py
@@ -106,7 +106,6 @@ class TerminationCondition(Enum):
     iteration_limit = "iteration_limit"
     terminated_by_limit = "terminated_by_limit"
     suboptimal = "suboptimal"
-    numerical = "numerical"
     imprecise = "imprecise"
 
     # WARNING
@@ -143,7 +142,6 @@ STATUS_TO_TERMINATION_CONDITION_MAP: dict[SolverStatus, list[TerminationConditio
         TerminationCondition.time_limit,
         TerminationCondition.terminated_by_limit,
         TerminationCondition.suboptimal,
-        TerminationCondition.numerical,
         TerminationCondition.imprecise,
     ],
     SolverStatus.warning: [

--- a/linopy/constants.py
+++ b/linopy/constants.py
@@ -106,6 +106,8 @@ class TerminationCondition(Enum):
     iteration_limit = "iteration_limit"
     terminated_by_limit = "terminated_by_limit"
     suboptimal = "suboptimal"
+    numerical = "numerical"
+    imprecise = "imprecise"
 
     # WARNING
     unbounded = "unbounded"
@@ -141,6 +143,8 @@ STATUS_TO_TERMINATION_CONDITION_MAP: dict[SolverStatus, list[TerminationConditio
         TerminationCondition.time_limit,
         TerminationCondition.terminated_by_limit,
         TerminationCondition.suboptimal,
+        TerminationCondition.numerical,
+        TerminationCondition.imprecise,
     ],
     SolverStatus.warning: [
         TerminationCondition.unbounded,


### PR DESCRIPTION
Add 'numerical' and 'imprecise' as proper TerminationCondition enum values and map them to SolverStatus.ok to enable solution extraction for both COPT solver statuses.

This fixes issue #460 where COPT solutions with IMPRECISE status were not being parsed, even though COPT developers confirmed solutions should be available for OK, NUMERICAL, and IMPRECISE statuses.

Generated with [Claude Code](https://claude.ai/code)