### PR TITLE
feat: allow passing a parameter dict to gurobi's env creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .coverage
 .eggs
 .DS_Store
+.mypy_cache
 linopy/__pycache__
 test/__pycache__
 linopy.egg-info

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -7,6 +7,7 @@ Release Notes
 
 
 * Improved variable/expression arithmetic methods so that they correctly handle types
+* Gurobi: Pass dictionary as env argument `env={...}` through to gurobi env creation
 
 **Breaking Changes**
 

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -32,6 +32,8 @@ from linopy.constants import (
 )
 
 if TYPE_CHECKING:
+    import gurobipy
+
     from linopy.model import Model
 
 QUADRATIC_SOLVERS = [
@@ -942,7 +944,7 @@ class Gurobi(Solver):
         log_fn: Path | None = None,
         warmstart_fn: Path | None = None,
         basis_fn: Path | None = None,
-        env: None = None,
+        env: gurobipy.Env | dict[str, Any] | None = None,
         explicit_coordinate_names: bool = False,
     ) -> Result:
         """
@@ -962,9 +964,8 @@ class Gurobi(Solver):
             Path to the warmstart file.
         basis_fn : Path, optional
             Path to the basis file.
-        env : None, optional
-            Gurobi environment for the solver, a dictionary is used as parameters for
-            environment creation.
+        env : gurobipy.Env or dict, optional
+            Gurobi environment for the solver, pass env directly or kwargs for creation.
         explicit_coordinate_names : bool, optional
             Transfer variable and constraint names to the solver (default: False)
 
@@ -1001,7 +1002,7 @@ class Gurobi(Solver):
         log_fn: Path | None = None,
         warmstart_fn: Path | None = None,
         basis_fn: Path | None = None,
-        env: None = None,
+        env: gurobipy.Env | dict[str, Any] | None = None,
     ) -> Result:
         """
         Solve a linear problem from a problem file using the Gurobi solver.
@@ -1020,8 +1021,8 @@ class Gurobi(Solver):
             Path to the warmstart file.
         basis_fn : Path, optional
             Path to the basis file.
-        env : None, optional
-            Gurobi environment for the solver
+        env : gurobipy.Env or dict, optional
+            Gurobi environment for the solver, pass env directly or kwargs for creation.
 
         Returns
         -------

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -963,7 +963,8 @@ class Gurobi(Solver):
         basis_fn : Path, optional
             Path to the basis file.
         env : None, optional
-            Gurobi environment for the solver
+            Gurobi environment for the solver, a dictionary is used as parameters for
+            environment creation.
         explicit_coordinate_names : bool, optional
             Transfer variable and constraint names to the solver (default: False)
 
@@ -974,6 +975,8 @@ class Gurobi(Solver):
         with contextlib.ExitStack() as stack:
             if env is None:
                 env_ = stack.enter_context(gurobipy.Env())
+            elif isinstance(env, dict):
+                env_ = stack.enter_context(gurobipy.Env(params=env))
             else:
                 env_ = env
 
@@ -1031,6 +1034,8 @@ class Gurobi(Solver):
         with contextlib.ExitStack() as stack:
             if env is None:
                 env_ = stack.enter_context(gurobipy.Env())
+            elif isinstance(env, dict):
+                env_ = stack.enter_context(gurobipy.Env(params=env))
             else:
                 env_ = env
 

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -17,7 +17,7 @@ from abc import ABC, abstractmethod
 from collections import namedtuple
 from collections.abc import Callable, Generator
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 import numpy as np
 import pandas as pd
@@ -35,6 +35,8 @@ if TYPE_CHECKING:
     import gurobipy
 
     from linopy.model import Model
+
+EnvType = TypeVar("EnvType")
 
 QUADRATIC_SOLVERS = [
     "gurobi",
@@ -197,7 +199,7 @@ def maybe_adjust_objective_sign(
     return solution
 
 
-class Solver(ABC):
+class Solver(ABC, Generic[EnvType]):
     """
     Abstract base class for solving a given linear problem.
 
@@ -244,7 +246,7 @@ class Solver(ABC):
         log_fn: Path | None = None,
         warmstart_fn: Path | None = None,
         basis_fn: Path | None = None,
-        env: None = None,
+        env: EnvType | None = None,
         explicit_coordinate_names: bool = False,
     ) -> Result:
         """
@@ -264,7 +266,7 @@ class Solver(ABC):
         log_fn: Path | None = None,
         warmstart_fn: Path | None = None,
         basis_fn: Path | None = None,
-        env: None = None,
+        env: EnvType | None = None,
     ) -> Result:
         """
         Abstract method to solve a linear problem from a problem file.
@@ -283,7 +285,7 @@ class Solver(ABC):
         log_fn: Path | None = None,
         warmstart_fn: Path | None = None,
         basis_fn: Path | None = None,
-        env: None = None,
+        env: EnvType | None = None,
         explicit_coordinate_names: bool = False,
     ) -> Result:
         """
@@ -324,7 +326,7 @@ class Solver(ABC):
         return SolverName[self.__class__.__name__]
 
 
-class CBC(Solver):
+class CBC(Solver[None]):
     """
     Solver subclass for the CBC solver.
 
@@ -505,7 +507,7 @@ class CBC(Solver):
         return Result(status, solution, CbcModel(mip_gap, runtime))
 
 
-class GLPK(Solver):
+class GLPK(Solver[None]):
     """
     Solver subclass for the GLPK solver.
 
@@ -675,7 +677,7 @@ class GLPK(Solver):
         return Result(status, solution)
 
 
-class Highs(Solver):
+class Highs(Solver[None]):
     """
     Solver subclass for the Highs solver. Highs must be installed
     for usage. Find the documentation at https://www.maths.ed.ac.uk/hall/HiGHS/.
@@ -921,7 +923,7 @@ class Highs(Solver):
         return Result(status, solution, h)
 
 
-class Gurobi(Solver):
+class Gurobi(Solver[gurobipy.Env | dict[str, Any] | None]):
     """
     Solver subclass for the gurobi solver.
 
@@ -1156,7 +1158,7 @@ class Gurobi(Solver):
         return Result(status, solution, m)
 
 
-class Cplex(Solver):
+class Cplex(Solver[None]):
     """
     Solver subclass for the Cplex solver.
 
@@ -1312,7 +1314,7 @@ class Cplex(Solver):
         return Result(status, solution, m)
 
 
-class SCIP(Solver):
+class SCIP(Solver[None]):
     """
     Solver subclass for the SCIP solver.
 
@@ -1465,7 +1467,7 @@ class SCIP(Solver):
         return Result(status, solution, m)
 
 
-class Xpress(Solver):
+class Xpress(Solver[None]):
     """
     Solver subclass for the xpress solver.
 
@@ -1602,7 +1604,7 @@ class Xpress(Solver):
 mosek_bas_re = re.compile(r" (XL|XU)\s+([^ \t]+)\s+([^ \t]+)| (LL|UL|BS)\s+([^ \t]+)")
 
 
-class Mosek(Solver):
+class Mosek(Solver[None]):
     """
     Solver subclass for the Mosek solver.
 
@@ -1932,7 +1934,7 @@ class Mosek(Solver):
         return Result(status, solution)
 
 
-class COPT(Solver):
+class COPT(Solver[None]):
     """
     Solver subclass for the COPT solver.
 
@@ -2073,7 +2075,7 @@ class COPT(Solver):
         return Result(status, solution, m)
 
 
-class MindOpt(Solver):
+class MindOpt(Solver[None]):
     """
     Solver subclass for the MindOpt solver.
 
@@ -2216,7 +2218,7 @@ class MindOpt(Solver):
         return Result(status, solution, m)
 
 
-class PIPS(Solver):
+class PIPS(Solver[None]):
     """
     Solver subclass for the PIPS solver.
     """

--- a/test/test_solvers.py
+++ b/test/test_solvers.py
@@ -7,11 +7,10 @@ Created on Tue Jan 28 09:03:35 2025.
 
 from pathlib import Path
 
-import pandas as pd
 import pytest
-import xarray as xr
+from test_io import model  # noqa: F401
 
-from linopy import LESS_EQUAL, Model, solvers
+from linopy import Model, solvers
 
 free_mps_problem = """NAME               sample_mip
 ROWS
@@ -46,22 +45,6 @@ ENDATA
 """
 
 
-@pytest.fixture
-def model() -> Model:
-    m = Model()
-
-    x = m.add_variables(4, pd.Series([8, 10]), name="x")
-    y = m.add_variables(0, pd.DataFrame([[1, 2], [3, 4]]), name="y")
-
-    m.add_constraints(x + y, LESS_EQUAL, 10)
-
-    m.add_objective(2 * x + 3 * y)
-
-    m.parameters["param"] = xr.DataArray([1, 2, 3, 4], dims=["x"])
-
-    return m
-
-
 @pytest.mark.parametrize("solver", set(solvers.available_solvers))
 def test_free_mps_solution_parsing(solver: str, tmp_path: Path) -> None:
     try:
@@ -87,7 +70,7 @@ def test_free_mps_solution_parsing(solver: str, tmp_path: Path) -> None:
 @pytest.mark.skipif(
     "gurobi" not in set(solvers.available_solvers), reason="Gurobi is not installed"
 )
-def test_gurobi_environment_with_dict(model: Model, tmp_path: Path) -> None:
+def test_gurobi_environment_with_dict(model: Model, tmp_path: Path) -> None:  # noqa: F811
     gurobi = solvers.Gurobi()
 
     mps_file = tmp_path / "problem.mps"
@@ -113,7 +96,7 @@ def test_gurobi_environment_with_dict(model: Model, tmp_path: Path) -> None:
 @pytest.mark.skipif(
     "gurobi" not in set(solvers.available_solvers), reason="Gurobi is not installed"
 )
-def test_gurobi_environment_with_gurobi_env(model: Model, tmp_path: Path) -> None:
+def test_gurobi_environment_with_gurobi_env(model: Model, tmp_path: Path) -> None:  # noqa: F811
     import gurobipy as gp
 
     gurobi = solvers.Gurobi()


### PR DESCRIPTION
## Changes proposed in this Pull Request

Enable passing parameters to gurobi's environment creation by supplying a dictionary
as the `env` parameter.

This allows to provide license information to gurobi like:

```
env_params = {
    "WLSACCESSID": "203dec48-e3f8-46ac-0184-92d7d6ded944",
    "WLSSECRET": "a080cce8-4e01-4e36-955e-61592c5630db",
    "LICENSEID": 12127,
}
m.solve(solver_name="gurobi", env=env_params)
```

This enables implicitly to add license information to `pypsa-eur`/`pypsa-earth` `solver_options` like:

```
solver_options:
  gurobi-default:
    env:
      WLSACCESSID: "203dec48-e3f8-46ac-0184-92d7d6ded944",
      WLSSECRET: "a080cce8-4e01-4e36-955e-61592c5630db",
      LICENSEID: 12127,
```

@FabianHofmann @lkstrp Would this be an acceptable addition or is this too magic?

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
