### PR TITLE
fix: make gurobipy dependency optional in generic type parameter

### DIFF
--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -923,7 +923,7 @@ class Highs(Solver[None]):
         return Result(status, solution, h)
 
 
-class Gurobi(Solver[gurobipy.Env | dict[str, Any] | None]):
+class Gurobi(Solver["gurobipy.Env | dict[str, Any] | None"]):
     """
     Solver subclass for the gurobi solver.
 


### PR DESCRIPTION
Follow up on #469
Closes issue described [here](https://github.com/PyPSA/linopy/pull/469#issuecomment-3044131115)

## Changes proposed in this Pull Request
Make `gurobipy` dependency optional also in generic type parameter using deferred evaluation