### PR TITLE
MOSEK: Remove explicit use of mosek.Env

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -8,6 +8,7 @@ Release Notes
 
 * Improved variable/expression arithmetic methods so that they correctly handle types
 * Gurobi: Pass dictionary as env argument `env={...}` through to gurobi env creation
+* Mosek: Remove explicit use of Env, use global env instead
 
 **Breaking Changes**
 


### PR DESCRIPTION
Closes #474 

## Changes proposed in this Pull Request

- Remove explicit use of `mosek.Env`, use global environment instead. This avoids checking out new licenses for each new task created, and avoids creating and destroying environment object for each task.

## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
