### PR TITLE
perf: use xpress c interface, xpress solution order of operations improvement, remove writing of redundant solution files

### DIFF
--- a/linopy/model.py
+++ b/linopy/model.py
@@ -59,7 +59,12 @@ from linopy.io import (
 from linopy.matrices import MatrixAccessor
 from linopy.objective import Objective
 from linopy.remote import OetcHandler, RemoteHandler
-from linopy.solvers import IO_APIS, available_solvers, quadratic_solvers
+from linopy.solvers import (
+    IO_APIS,
+    NO_SOLUTION_FILE_SOLVERS,
+    available_solvers,
+    quadratic_solvers,
+)
 from linopy.types import (
     ConstantLike,
     ConstraintLike,
@@ -1190,11 +1195,7 @@ class Model:
         if problem_fn is None:
             problem_fn = self.get_problem_file(io_api=io_api)
         if solution_fn is None:
-            if (
-                solver_name
-                in ["xpress", "gurobi", "highs", "mosek", "scip", "copt", "mindopt"]
-                and not keep_files
-            ):
+            if solver_name in NO_SOLUTION_FILE_SOLVERS and not keep_files:
                 # these (solver, keep_files=False) combos do not need a solution file
                 solution_fn = None
             else:

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -50,6 +50,17 @@ QUADRATIC_SOLVERS = [
     "mindopt",
 ]
 
+# Solvers that don't need a solution file when keep_files=False
+NO_SOLUTION_FILE_SOLVERS = [
+    "xpress",
+    "gurobi",
+    "highs",
+    "mosek",
+    "scip",
+    "copt",
+    "mindopt",
+]
+
 FILE_IO_APIS = ["lp", "lp-polars", "mps"]
 IO_APIS = FILE_IO_APIS + ["direct"]
 


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request
- performance improvements to `Xpress._solve_problem_from_file`
- use the solver's C interface directly to extract constraint and variable names rather than list comprehension
  - casting to string the xpress objects returned by `problem.getConstraints()` etc. is expensive and so is accessing the names via `.name`.
  - this gives small performance improvement on larger models
- improve order of operations when extracting dual
  - for MILPs, let code hit the exception on `getDuals` before doing the expensive constraint name extraction
- use `writebinsol` for a c. 10x improvement from `writesol`
  - @FabianHofmann it would be nice to not write the solution at all for xpress if `keep_files=False`

## Checklist

- [X] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [X] Unit tests for new features were added (if applicable).
- [X] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [X] I consent to the release of this PR's code under the MIT license.
