### PR TITLE
fix: harmonize polars dtypes before concat in Constraint.to_polars

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -8,6 +8,7 @@ Upcoming Version
 * Reduced memory usage and faster file I/O operations when exporting models to LP format
 * Improved constraint equality check in `linopy.testing.assert_conequal` to less strict optionally
 * Minor bugfix for multiplying variables with numpy type constants
+* Harmonize dtypes before concatenation in lp file writing to avoid dtype mismatch errors. This error occurred when creating and storing models in netcdf format using windows machines and loading and solving them on linux machines.
 
 Version 0.5.6
 --------------

--- a/linopy/constraints.py
+++ b/linopy/constraints.py
@@ -40,6 +40,7 @@ from linopy.common import (
     get_dims_with_index_levels,
     get_label_position,
     group_terms_polars,
+    harmonize_polars_dtypes,
     has_optimized_model,
     infer_schema_polars,
     is_constant,
@@ -630,6 +631,9 @@ class Constraint:
         short = to_polars(short_ds, schema=schema)
         short = filter_nulls_polars(short)
         check_has_nulls_polars(short, name=f"{self.type} {self.name}")
+
+        # Harmonize dtypes before concatenation to avoid dtype mismatch errors
+        short, long = harmonize_polars_dtypes(short, long)
 
         df = pl.concat([short, long], how="diagonal").sort(["labels", "rhs"])
         # delete subsequent non-null rhs (happens is all vars per label are -1)


### PR DESCRIPTION
Add harmonize_polars_dtypes() function to upcast incompatible dtypes in overlapping columns before concatenation, preventing dtype mismatch errors on some systems. Also remove breakpoint from to_polars method.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
