### PR TITLE
fix: relaxed upcasting in pl.concat

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -8,6 +8,7 @@ Upcoming Version
 * Reduced memory usage and faster file I/O operations when exporting models to LP format
 * Improved constraint equality check in `linopy.testing.assert_conequal` to less strict optionally
 * Minor bugfix for multiplying variables with numpy type constants
+* Harmonize dtypes before concatenation in lp file writing to avoid dtype mismatch errors. This error occurred when creating and storing models in netcdf format using windows machines and loading and solving them on linux machines.
 
 Version 0.5.6
 --------------

--- a/linopy/constraints.py
+++ b/linopy/constraints.py
@@ -631,7 +631,7 @@ class Constraint:
         short = filter_nulls_polars(short)
         check_has_nulls_polars(short, name=f"{self.type} {self.name}")
 
-        df = pl.concat([short, long], how="diagonal").sort(["labels", "rhs"])
+        df = pl.concat([short, long], how="diagonal_relaxed").sort(["labels", "rhs"])
         # delete subsequent non-null rhs (happens is all vars per label are -1)
         is_non_null = df["rhs"].is_not_null()
         prev_non_is_null = is_non_null.shift(1).fill_null(False)


### PR DESCRIPTION
Add fallback to upcast incompatible dtypes in overlapping columns when concatenating, preventing dtype mismatch errors on some systems.

## Changes proposed in this Pull Request

Use "diagonal_relaxed" as argument in pl.concat function. 

## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [ ] I consent to the release of this PR's code under the MIT license.
