### PR TITLE
fix: filter nulls in polars df to align with subsequent check of coeffs

### DIFF
--- a/linopy/common.py
+++ b/linopy/common.py
@@ -415,6 +415,7 @@ def filter_nulls_polars(df: pl.DataFrame) -> pl.DataFrame:
         cond.append(reduce(operator.or_, [pl.col(c).ne(-1) for c in varcols]))
     if "coeffs" in df.columns:
         cond.append(pl.col("coeffs").ne(0))
+        cond.append(pl.col("coeffs").is_not_null())
     if "labels" in df.columns:
         cond.append(pl.col("labels").ne(-1))
 


### PR DESCRIPTION
@lkstrp would that resolve the issues to encountered with pypsa multi horizon. you can also point me out the example and I can check


## Changes proposed in this Pull Request

- also filter null coeffs in polars dataframe filtering

## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [ ] I consent to the release of this PR's code under the MIT license.
