### PR TITLE
Fix xpress

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -2,7 +2,7 @@ Release Notes
 =============
 
 .. Upcoming Version
-
+* xpress: Fixed for xpress v9.5 (broken since linopy v0.5.8), upgraded deprecated xpress methods
 * Add support for SOS1 and SOS2 (Special Ordered Sets) constraints via ``Model.add_sos_constraints()`` and ``Model.remove_sos_constraints()``
 * Add simplify method to LinearExpression to combine duplicate terms
 * Add convenience function to create LinearExpression from constant


### PR DESCRIPTION
Closes #533

## Changes proposed in this Pull Request
Fixed for xpress 9.5 (broken since linopy v0.5.8)
Removed deprecated xpress methods

## Checklist

- [X] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [X] Unit tests for new features were added (if applicable).
- [X] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [X] I consent to the release of this PR's code under the MIT license.
