### PR TITLE
fix: correct regex to capture negative objective values when using CBC

### DIFF
--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -482,7 +482,7 @@ class CBC(Solver[None]):
         variables = {v.name for v in h.getVariables()}
 
         def get_solver_solution() -> Solution:
-            m = re.match(r"Optimal.* - objective value (\d+\.?\d*)$", first_line)
+            m = re.match(r"Optimal.* - objective value (-?\d+\.?\d*)$", first_line)
             if m and len(m.groups()) == 1:
                 objective = float(m.group(1))
             else:


### PR DESCRIPTION
Currently returns np.nan if objective function value solved by CBC is negative

Closes # (if applicable).

## Changes proposed in this Pull Request


## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
