### PR TITLE
Add Xpress 9.8+ API support with backward compatibility

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -44,7 +44,7 @@ flexible data-handling features:
    - `HiGHS <https://www.maths.ed.ac.uk/hall/HiGHS/>`__
    - `MindOpt <https://solver.damo.alibaba.com/doc/en/html/index.html>`__
    - `Gurobi <https://www.gurobi.com/>`__
-   - `Xpress <https://www.fico.com/en/products/fico-xpress-solver>`__
+   - `Xpress <https://www.fico.com/en/fico-xpress-trial-and-licensing-options>`__
    - `Cplex <https://www.ibm.com/de-de/analytics/cplex-optimizer>`__
    - `MOSEK <https://www.mosek.com/>`__
    - `COPT <https://www.shanshu.ai/copt>`__

--- a/doc/prerequisites.rst
+++ b/doc/prerequisites.rst
@@ -34,7 +34,7 @@ Linopy won't work without a solver. Currently, the following solvers are support
 -  `GLPK <https://www.gnu.org/software/glpk/>`__ - open source, free, not very fast
 -  `HiGHS <https://www.maths.ed.ac.uk/hall/HiGHS/>`__ - open source, free, fast
 -  `Gurobi <https://www.gurobi.com/>`__  - closed source, commercial, very fast
--  `Xpress <https://www.fico.com/en/products/fico-xpress-solver>`__ - closed source, commercial, very fast
+-  `Xpress <https://www.fico.com/en/fico-xpress-trial-and-licensing-options>`__ - closed source, commercial, very fast
 -  `Cplex <https://www.ibm.com/de-de/analytics/cplex-optimizer>`__ - closed source, commercial, very fast
 -  `MOSEK <https://www.mosek.com/>`__
 -  `MindOpt <https://solver.damo.alibaba.com/doc/en/html/index.html>`__ -

--- a/linopy/constraints.py
+++ b/linopy/constraints.py
@@ -1015,7 +1015,14 @@ class Constraints:
             if display_max_terms is not None:
                 opts.set_value(display_max_terms=display_max_terms)
             res = [print_single_constraint(self.model, v) for v in values]
-        print("\n".join(res))
+
+        output = "\n".join(res)
+        try:
+            print(output)
+        except UnicodeEncodeError:
+            # Replace Unicode math symbols with ASCII equivalents for Windows console
+            output = output.replace("≤", "<=").replace("≥", ">=").replace("≠", "!=")
+            print(output)
 
     def set_blocks(self, block_map: np.ndarray) -> None:
         """

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -1458,7 +1458,10 @@ class Model:
     def _compute_infeasibilities_xpress(self, solver_model: Any) -> list[int]:
         """Compute infeasibilities for Xpress solver."""
         # Compute all IIS
-        solver_model.iisall()
+        try:  # Try new API first
+            solver_model.IISAll()
+        except AttributeError:  # Fallback to old API
+            solver_model.iisall()
 
         # Get the number of IIS found
         num_iis = solver_model.attributes.numiis
@@ -1502,28 +1505,55 @@ class Model:
         list[Any]
             List of xpress.constraint objects in the IIS
         """
-        # Prepare lists to receive IIS data
-        miisrow: list[Any] = []  # xpress.constraint objects in the IIS
-        miiscol: list[Any] = []  # xpress.variable objects in the IIS
-        constrainttype: list[str] = []  # Constraint types ('L', 'G', 'E')
-        colbndtype: list[str] = []  # Column bound types
-        duals: list[float] = []  # Dual values
-        rdcs: list[float] = []  # Reduced costs
-        isolationrows: list[str] = []  # Row isolation info
-        isolationcols: list[str] = []  # Column isolation info
+        # Declare variables before try/except to avoid mypy redefinition errors
+        miisrow: list[Any]
+        miiscol: list[Any]
+        constrainttype: list[str]
+        colbndtype: list[str]
+        duals: list[float]
+        rdcs: list[float]
+        isolationrows: list[str]
+        isolationcols: list[str]
 
-        # Get IIS data from Xpress
-        solver_model.getiisdata(
-            iis_num,
-            miisrow,
-            miiscol,
-            constrainttype,
-            colbndtype,
-            duals,
-            rdcs,
-            isolationrows,
-            isolationcols,
-        )
+        try:  # Try new API first
+            (
+                miisrow,
+                miiscol,
+                constrainttype,
+                colbndtype,
+                duals,
+                rdcs,
+                isolationrows,
+                isolationcols,
+            ) = solver_model.getIISData(iis_num)
+
+            # Transform list of indices to list of constraint objects
+            for i in range(len(miisrow)):
+                miisrow[i] = solver_model.getConstraint(miisrow[i])
+
+        except AttributeError:  # Fallback to old API
+            # Prepare lists to receive IIS data
+            miisrow = []  # xpress.constraint objects in the IIS
+            miiscol = []  # xpress.variable objects in the IIS
+            constrainttype = []  # Constraint types ('L', 'G', 'E')
+            colbndtype = []  # Column bound types
+            duals = []  # Dual values
+            rdcs = []  # Reduced costs
+            isolationrows = []  # Row isolation info
+            isolationcols = []  # Column isolation info
+
+            # Get IIS data from Xpress
+            solver_model.getiisdata(
+                iis_num,
+                miisrow,
+                miiscol,
+                constrainttype,
+                colbndtype,
+                duals,
+                rdcs,
+                isolationrows,
+                isolationcols,
+            )
 
         return miisrow
 


### PR DESCRIPTION
## Summary

This PR updates the linopy Xpress solver integration to support the new Python API introduced in Xpress 9.8+, while maintaining full backward compatibility with Xpress 9.6+ through fallback mechanisms.

## Changes

### 1. API Method Migration (`linopy/solvers.py`)
All method calls updated with try/except blocks for backward compatibility:
- `m.read()` → `m.readProb()`
- `m.setlogfile()` → `m.setLogFile()`
- `m.readbasis()` → `m.readBasis()`
- `m.writebasis()` → `m.writeBasis()`
- `m.writebinsol()` → `m.writeBinSol()`
- `m.postsolve()` → `m.postSolve()`
- `m.getnamelist()` → `m.getNameList()`
- `m.getDual()` → `m.getDuals()`

### 2. Status Handling Improvements (`linopy/solvers.py`)
- Replaced numeric status codes with `xpress.SolStatus` enum constants
- Updated solver status checks to use `xpress.enums.SolveStatus.STOPPED`
- Improved code readability and maintainability

### 3. Exception Handling (`linopy/solvers.py`)
- Replaced broad `Exception` catching with specific `xpress.SolverError` and `xpress.ModelError`
- Prevents masking of unrelated errors while catching only solver-specific issues

### 4. IIS (Irreducible Infeasible Subset) Detection (`linopy/model.py`)
- `solver_model.iisall()` → `solver_model.IISAll()` with fallback
- `solver_model.getiisdata()` → `solver_model.getIISData()` with fallback
- Fixed mypy type checking errors by declaring variables before try/except blocks

### 5. Unicode Handling (`linopy/constraints.py`)
- Added Windows console encoding fix for Unicode characters (≤, ≥) in constraint display

### 6. Documentation Updates
- Updated Xpress documentation URLs in `doc/index.rst` and `doc/prerequisites.rst`

## Testing

### Test Environment
- **Xpress 9.8.0**: Primary development version
- **Xpress 9.6.0**: Backward compatibility validation

### Test Results

- ✅ All 414 Xpress-specific tests **PASSED**
- ✅ All infeasibility detection tests **PASSED** (IIS functionality verified)
- ✅ Pre-commit hooks (Black, Ruff): **All passed**
- ✅ Backward compatibility confirmed through fallback mechanisms
