### PR TITLE
fix(solvers): add forgotten xpress getDual fallback

### DIFF
--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -1702,7 +1702,11 @@ class Xpress(Solver[None]):
             sol = pd.Series(m.getSolution(), index=var, dtype=float)
 
             try:
-                _dual = m.getDuals()
+                try:  # Try new API first
+                    _dual = m.getDuals()
+                except AttributeError:  # Fallback to old API
+                    _dual = m.getDual()
+
                 try:  # Try new API first
                     constraints = m.getNameList(
                         xpress_Namespaces.ROW, 0, m.attributes.rows - 1


### PR DESCRIPTION
Follow up to #542 .

## Changes proposed in this Pull Request

m.getDual() → m.getDuals()

With this in place, everything runs fine even on xpress 9.4

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
