### PR TITLE
fix: don't init gurobi on import

### DIFF
--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -129,11 +129,7 @@ def _run_highs_with_keyboard_interrupt(h: Any) -> None:
 with contextlib.suppress(ModuleNotFoundError):
     import gurobipy
 
-    try:
-        with contextlib.closing(gurobipy.Env()):
-            available_solvers.append("gurobi")
-    except gurobipy.GurobiError:
-        pass
+    available_solvers.append("gurobi")
 with contextlib.suppress(ModuleNotFoundError):
     _new_highspy_mps_layout = None
     import highspy


### PR DESCRIPTION
Closes https://github.com/PyPSA/PyPSA/pull/1532

Gurobi is now initialised and appears in the logs as soon as we import linopy, which is something we want to avoid. I think this was added to handle invalid licences, but we need to find a better way to do this