### PR TITLE
Make LinearExpression multiplication with constant containing subset of dimensions consistent with Variable behaviour

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -4,6 +4,7 @@ Release Notes
 Upcoming Version
 ----------------
 
+* Fix the handling of multiplication between ``LinearExpression`` and constants with a subset of dimensions. Align with ``Variable`` behaviour
 * Fix docs (pick highs solver)
 * Add the `sphinx-copybutton` to the documentation
 * Add ``auto_mask`` parameter to ``Model`` class that automatically masks variables and constraints where bounds, coefficients, or RHS values contain NaN. This eliminates the need to manually create mask arrays when working with sparse or incomplete data.

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -538,7 +538,6 @@ class BaseExpression(ABC):
     ) -> GenericExpression:
         multiplier = as_dataarray(other, coords=self.coords, dims=self.coord_dims)
         coeffs = self.coeffs * multiplier
-        assert all(coeffs.sizes[d] == s for d, s in self.coeffs.sizes.items())
         const = self.const * multiplier
         return self.assign(coeffs=coeffs, const=const)
 

--- a/linopy/testing.py
+++ b/linopy/testing.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
+
+import numpy as np
 from xarray.testing import assert_equal
 
 from linopy.constraints import Constraint, _con_unwrap
@@ -72,3 +75,13 @@ def assert_model_equal(a: Model, b: Model) -> None:
     assert a.termination_condition == b.termination_condition
 
     assert a.type == b.type
+
+
+def assert_lists_equal(x: Iterable[float], b: Iterable[float]) -> None:
+    x = list(x)
+    b = list(b)
+    assert len(x) == len(b)
+    for xi, bi in zip(x, b):
+        if np.isnan(xi) and np.isnan(bi):
+            continue
+        assert xi == bi


### PR DESCRIPTION
Closes #569 #570 

## Changes proposed in this Pull Request
Now LinearExpression behaves the same way as Variable when multiplying with a constant containing a susbet of dimensions. Still it is not consistent with addition.

| Action  | Coords | Missing coord behaviour  |
| ------------- | ------------- |------------- |
| Addition | Same coords  | add 0 |
| Variable Multiplication | Same coords   | nan  |
| Expression Multiplication | Same coords   | nan  |

For addition, when a coord is mising we just add 0 (I.e do nothing at that coord)
Perhaps the equivalent for multiplication would be to multiply by 1 (also do nothing) rather than fill with nan?

## Checklist
- [X] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [X] Unit tests for new features were added (if applicable).
- [X] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [X] I consent to the release of this PR's code under the MIT license.
