### PR TITLE
fix polars dep lb

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "numexpr",
     "xarray>=2024.2.0",
     "dask>=0.18.0",
-    "polars>=1.31",
+    "polars>=1.31.1",
     "tqdm",
     "deprecation",
     "packaging",


### PR DESCRIPTION
Fix polars lb for streaming engine being set too low. The new streaming engine was introduced in 1.31.1


## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
