### PR TITLE
fix: add coords and dims to as_dataarray

### DIFF
--- a/linopy/model.py
+++ b/linopy/model.py
@@ -746,7 +746,7 @@ class Model:
         (data,) = xr.broadcast(data, exclude=[TERM_DIM])
 
         if mask is not None:
-            mask = as_dataarray(mask).astype(bool)
+            mask = as_dataarray(mask, coords=data.coords, dims=data.dims).astype(bool)
             mask = broadcast_mask(mask, data.labels)
 
         # Auto-mask based on null expressions or NaN RHS (use numpy for speed)


### PR DESCRIPTION
Follow up to #580

Harmonize coords and dims for non-xarray mask objects. 

## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [ ] I consent to the release of this PR's code under the MIT license.
