### PR TITLE
feat: add unified SolverMetrics

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -4,6 +4,8 @@ Release Notes
 Upcoming Version
 ----------------
 
+* Add unified ``SolverMetrics`` dataclass accessible via ``Model.solver_metrics`` after solving. Provides ``solver_name``, ``solve_time``, ``objective_value``, ``best_bound``, and ``mip_gap`` in a solver-independent way. Gurobi, HiGHS, SCIP, and CBC populate solver-specific fields; other solvers provide the baseline.
+
 Version 0.6.3
 --------------
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -4,7 +4,7 @@ Release Notes
 Upcoming Version
 ----------------
 
-* Add unified ``SolverMetrics`` dataclass accessible via ``Model.solver_metrics`` after solving. Provides ``solver_name``, ``solve_time``, ``objective_value``, ``best_bound``, and ``mip_gap`` in a solver-independent way. Gurobi, HiGHS, SCIP, and CBC populate solver-specific fields; other solvers provide the baseline.
+* Add unified ``SolverMetrics`` dataclass accessible via ``Model.solver_metrics`` after solving. Provides ``solver_name``, ``solve_time``, ``objective_value``, ``best_bound``, and ``mip_gap`` in a solver-independent way. All solvers populate solver-specific fields where available.
 
 Version 0.6.3
 --------------

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -12,7 +12,7 @@ Upcoming Version
 * Add the `sphinx-copybutton` to the documentation
 * Add SOS1 and SOS2 reformulations for solvers not supporting them.
 * Enable quadratic problems with SCIP on windows.
-* Add unified ``SolverMetrics`` dataclass accessible via ``Model.solver_metrics`` after solving. Provides ``solver_name``, ``solve_time``, ``objective_value``, ``best_bound``, and ``mip_gap`` in a solver-independent way. All solvers populate solver-specific fields where available.
+* Add unified ``SolverMetrics`` dataclass accessible via ``Model.solver_metrics`` after solving. Provides ``solver_name``, ``solve_time``, ``objective_value``, ``best_bound``, and ``dual_bound`` in a solver-independent way. All solvers populate solver-specific fields where available.
 
 
 Version 0.6.5

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -12,7 +12,7 @@ Upcoming Version
 * Add the `sphinx-copybutton` to the documentation
 * Add SOS1 and SOS2 reformulations for solvers not supporting them.
 * Enable quadratic problems with SCIP on windows.
-* Add unified ``SolverMetrics`` dataclass accessible via ``Model.solver_metrics`` after solving. Provides ``solver_name``, ``solve_time``, ``objective_value``, ``best_bound``, and ``mip_gap`` in a solver-independent way. All solvers populate solver-specific fields where available.
+* Add unified ``SolverMetrics`` dataclass accessible via ``Model.solver_metrics`` after solving. Provides ``solver_name``, ``solve_time``, ``objective_value``, ``dual_bound``, and ``mip_gap`` in a solver-independent way. All solvers populate solver-specific fields where available.
 
 
 Version 0.6.5

--- a/examples/create-a-model.ipynb
+++ b/examples/create-a-model.ipynb
@@ -30,11 +30,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "dramatic-cannon",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-02-11T21:42:38.164407Z",
+     "start_time": "2026-02-11T21:42:38.162992Z"
+    }
+   },
+   "source": [],
    "outputs": [],
-   "source": []
+   "execution_count": null
   },
   {
    "attachments": {},
@@ -49,15 +54,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "technical-conducting",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-02-11T21:42:39.360058Z",
+     "start_time": "2026-02-11T21:42:38.171827Z"
+    }
+   },
    "source": [
     "from linopy import Model\n",
     "\n",
     "m = Model()"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "attachments": {},
@@ -83,14 +93,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "protecting-power",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-02-11T21:42:39.387467Z",
+     "start_time": "2026-02-11T21:42:39.384712Z"
+    }
+   },
    "source": [
     "x = m.add_variables(lower=0, name=\"x\")\n",
     "y = m.add_variables(lower=0, name=\"y\");"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "attachments": {},
@@ -103,13 +118,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "virtual-anxiety",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-02-11T21:42:39.393709Z",
+     "start_time": "2026-02-11T21:42:39.390438Z"
+    }
+   },
    "source": [
     "x"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "attachments": {},
@@ -127,13 +147,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "fbb46cad",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-02-11T21:42:39.405691Z",
+     "start_time": "2026-02-11T21:42:39.396625Z"
+    }
+   },
    "source": [
     "3 * x + 7 * y >= 10"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "attachments": {},
@@ -146,13 +171,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "60f41b76",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-02-11T21:42:39.416325Z",
+     "start_time": "2026-02-11T21:42:39.409117Z"
+    }
+   },
    "source": [
     "3 * x + 7 * y - 10 >= 0"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "attachments": {},
@@ -167,14 +197,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "hollywood-production",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-02-11T21:42:39.431755Z",
+     "start_time": "2026-02-11T21:42:39.420977Z"
+    }
+   },
    "source": [
     "m.add_constraints(3 * x + 7 * y >= 10)\n",
     "m.add_constraints(5 * x + 2 * y >= 3);"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "attachments": {},
@@ -189,13 +224,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "overall-exhibition",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-02-11T21:42:39.438865Z",
+     "start_time": "2026-02-11T21:42:39.434328Z"
+    }
+   },
    "source": [
     "m.add_objective(x + 2 * y)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "attachments": {},
@@ -210,13 +250,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "pressing-copying",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-02-11T21:42:39.532619Z",
+     "start_time": "2026-02-11T21:42:39.441886Z"
+    }
+   },
    "source": [
     "m.solve(solver_name=\"highs\")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "attachments": {},
@@ -229,23 +274,67 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "electric-duration",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-02-11T21:42:39.560199Z",
+     "start_time": "2026-02-11T21:42:39.553844Z"
+    }
+   },
    "source": [
     "x.solution"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "id": "e6d31751",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-02-11T21:42:39.577784Z",
+     "start_time": "2026-02-11T21:42:39.573362Z"
+    }
+   },
    "source": [
     "y.solution"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9zgzuhvo1b8",
+   "source": [
+    "### Solver Metrics\n",
+    "\n",
+    "After solving, you can inspect performance metrics reported by the solver via `solver_metrics`. This includes solve time, objective value, and for MIP problems, the dual bound and MIP gap (available for most solvers."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "bdfxi7haoc",
+   "source": "m.solver_metrics",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-02-11T21:42:39.592065Z",
+     "start_time": "2026-02-11T21:42:39.589851Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "SolverMetrics(solver_name='highs', solve_time=0.0019101661164313555, objective_value=2.862068965517241, dual_bound=0.0, mip_gap=inf)"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": null
   },
   {
    "attachments": {},

--- a/examples/create-a-model.ipynb
+++ b/examples/create-a-model.ipynb
@@ -257,11 +257,7 @@
   {
    "metadata": {},
    "cell_type": "markdown",
-   "source": [
-    "### Solver Metrics\n",
-    "\n",
-    "After solving, you can inspect performance metrics reported by the solver via `solver_metrics`. This includes solve time, objective value, and for MIP problems, the dual bound and MIP gap (available for most solvers."
-   ],
+   "source": "### Solver Metrics\n\nAfter solving, you can inspect performance metrics reported by the solver via `solver_metrics`. This includes solve time, objective value, and for MIP problems, the dual bound and MIP gap (available for most solvers).",
    "id": "e4995d38f3fc7779"
   },
   {

--- a/examples/create-a-model.ipynb
+++ b/examples/create-a-model.ipynb
@@ -30,16 +30,11 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "dramatic-cannon",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-11T21:42:38.164407Z",
-     "start_time": "2026-02-11T21:42:38.162992Z"
-    }
-   },
-   "source": [],
+   "metadata": {},
    "outputs": [],
-   "execution_count": null
+   "source": []
   },
   {
    "attachments": {},
@@ -54,20 +49,15 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "technical-conducting",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-11T21:42:39.360058Z",
-     "start_time": "2026-02-11T21:42:38.171827Z"
-    }
-   },
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from linopy import Model\n",
     "\n",
     "m = Model()"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "attachments": {},
@@ -93,19 +83,14 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "protecting-power",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-11T21:42:39.387467Z",
-     "start_time": "2026-02-11T21:42:39.384712Z"
-    }
-   },
+   "metadata": {},
+   "outputs": [],
    "source": [
     "x = m.add_variables(lower=0, name=\"x\")\n",
     "y = m.add_variables(lower=0, name=\"y\");"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "attachments": {},
@@ -118,18 +103,13 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "virtual-anxiety",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-11T21:42:39.393709Z",
-     "start_time": "2026-02-11T21:42:39.390438Z"
-    }
-   },
+   "metadata": {},
+   "outputs": [],
    "source": [
     "x"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "attachments": {},
@@ -147,18 +127,13 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "fbb46cad",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-11T21:42:39.405691Z",
-     "start_time": "2026-02-11T21:42:39.396625Z"
-    }
-   },
+   "metadata": {},
+   "outputs": [],
    "source": [
     "3 * x + 7 * y >= 10"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "attachments": {},
@@ -171,18 +146,13 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "60f41b76",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-11T21:42:39.416325Z",
-     "start_time": "2026-02-11T21:42:39.409117Z"
-    }
-   },
+   "metadata": {},
+   "outputs": [],
    "source": [
     "3 * x + 7 * y - 10 >= 0"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "attachments": {},
@@ -197,19 +167,14 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "hollywood-production",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-11T21:42:39.431755Z",
-     "start_time": "2026-02-11T21:42:39.420977Z"
-    }
-   },
+   "metadata": {},
+   "outputs": [],
    "source": [
     "m.add_constraints(3 * x + 7 * y >= 10)\n",
     "m.add_constraints(5 * x + 2 * y >= 3);"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "attachments": {},
@@ -224,18 +189,13 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "overall-exhibition",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-11T21:42:39.438865Z",
-     "start_time": "2026-02-11T21:42:39.434328Z"
-    }
-   },
+   "metadata": {},
+   "outputs": [],
    "source": [
     "m.add_objective(x + 2 * y)"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "attachments": {},
@@ -250,18 +210,13 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "pressing-copying",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-11T21:42:39.532619Z",
-     "start_time": "2026-02-11T21:42:39.441886Z"
-    }
-   },
+   "metadata": {},
+   "outputs": [],
    "source": [
     "m.solve(solver_name=\"highs\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "attachments": {},
@@ -274,76 +229,48 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "electric-duration",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-11T21:42:39.560199Z",
-     "start_time": "2026-02-11T21:42:39.553844Z"
-    }
-   },
+   "metadata": {},
+   "outputs": [],
    "source": [
     "x.solution"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "e6d31751",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-11T21:42:39.577784Z",
-     "start_time": "2026-02-11T21:42:39.573362Z"
-    }
-   },
+   "metadata": {},
+   "outputs": [],
    "source": [
     "y.solution"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9zgzuhvo1b8",
-   "source": [
-    "### Solver Metrics\n",
-    "\n",
-    "After solving, you can inspect performance metrics reported by the solver via `solver_metrics`. This includes solve time, objective value, and for MIP problems, the dual bound and MIP gap (available for most solvers."
-   ],
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "id": "bdfxi7haoc",
-   "source": "m.solver_metrics",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-02-11T21:42:39.592065Z",
-     "start_time": "2026-02-11T21:42:39.589851Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "SolverMetrics(solver_name='highs', solve_time=0.0019101661164313555, objective_value=2.862068965517241, dual_bound=0.0, mip_gap=inf)"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "execution_count": null
+   ]
   },
   {
    "attachments": {},
    "cell_type": "markdown",
    "id": "e296f641",
    "metadata": {},
+   "source": "Well done! You solved your first linopy model!"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
    "source": [
-    "Well done! You solved your first linopy model!"
-   ]
+    "### Solver Metrics\n",
+    "\n",
+    "After solving, you can inspect performance metrics reported by the solver via `solver_metrics`. This includes solve time, objective value, and for MIP problems, the dual bound and MIP gap (available for most solvers."
+   ],
+   "id": "e4995d38f3fc7779"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": "m.solver_metrics",
+   "id": "bef28e724dceba9"
   }
  ],
  "metadata": {

--- a/linopy/__init__.py
+++ b/linopy/__init__.py
@@ -14,7 +14,7 @@ __version__ = version("linopy")
 import linopy.monkey_patch_xarray  # noqa: F401
 from linopy.common import align
 from linopy.config import options
-from linopy.constants import EQUAL, GREATER_EQUAL, LESS_EQUAL
+from linopy.constants import EQUAL, GREATER_EQUAL, LESS_EQUAL, SolverMetrics
 from linopy.constraints import Constraint, Constraints
 from linopy.expressions import LinearExpression, QuadraticExpression, merge
 from linopy.io import read_netcdf
@@ -34,6 +34,7 @@ __all__ = (
     "OetcHandler",
     "QuadraticExpression",
     "RemoteHandler",
+    "SolverMetrics",
     "Variable",
     "Variables",
     "available_solvers",

--- a/linopy/constants.py
+++ b/linopy/constants.py
@@ -212,6 +212,32 @@ class Solution:
 
 
 @dataclass
+class SolverMetrics:
+    """
+    Unified solver performance metrics.
+
+    All fields default to None and are populated by solvers on a best-effort
+    basis. Fields that a particular solver cannot provide remain None.
+    """
+
+    solver_name: str | None = None
+    solve_time: float | None = None
+    objective_value: float | None = None
+    best_bound: float | None = None
+    mip_gap: float | None = None
+    node_count: float | None = None
+    iteration_count: float | None = None
+
+    def __repr__(self) -> str:
+        fields = []
+        for f in self.__dataclass_fields__:
+            val = getattr(self, f)
+            if val is not None:
+                fields.append(f"{f}={val!r}")
+        return f"SolverMetrics({', '.join(fields)})"
+
+
+@dataclass
 class Result:
     """
     Result of the optimization.
@@ -220,6 +246,7 @@ class Result:
     status: Status
     solution: Solution | None = None
     solver_model: Any = None
+    metrics: SolverMetrics | None = None
 
     def __repr__(self) -> str:
         solver_model_string = (
@@ -232,12 +259,16 @@ class Result:
             )
         else:
             solution_string = "Solution: None\n"
+        metrics_string = ""
+        if self.metrics is not None:
+            metrics_string = f"Solver metrics: {self.metrics}\n"
         return (
             f"Status: {self.status.status.value}\n"
             f"Termination condition: {self.status.termination_condition.value}\n"
             + solution_string
             + f"Solver model: {solver_model_string}\n"
-            f"Solver message: {self.status.legacy_status}"
+            + metrics_string
+            + f"Solver message: {self.status.legacy_status}"
         )
 
     def info(self) -> None:

--- a/linopy/constants.py
+++ b/linopy/constants.py
@@ -220,12 +220,27 @@ class SolverMetrics:
     All fields default to ``None``. Solvers populate what they can;
     unsupported fields remain ``None``.  Access via
     :attr:`Model.solver_metrics` after calling :meth:`Model.solve`.
+
+    Attributes
+    ----------
+    solver_name : str or None
+        Name of the solver used.
+    solve_time : float or None
+        Wall-clock time spent solving (seconds).
+    objective_value : float or None
+        Objective value of the best solution found.
+    dual_bound : float or None
+        Best bound on the objective from the MIP relaxation (also known as
+        "best bound"). Only populated for integer programs.
+    mip_gap : float or None
+        Relative gap between the objective value and the dual bound.
+        Only populated for integer programs.
     """
 
     solver_name: str | None = None
     solve_time: float | None = None
     objective_value: float | None = None
-    best_bound: float | None = None
+    dual_bound: float | None = None
     mip_gap: float | None = None
 
     def __repr__(self) -> str:

--- a/linopy/constants.py
+++ b/linopy/constants.py
@@ -225,8 +225,6 @@ class SolverMetrics:
     objective_value: float | None = None
     best_bound: float | None = None
     mip_gap: float | None = None
-    node_count: float | None = None
-    iteration_count: float | None = None
 
     def __repr__(self) -> str:
         fields = []

--- a/linopy/constants.py
+++ b/linopy/constants.py
@@ -3,6 +3,7 @@
 Linopy module for defining constant values used within the package.
 """
 
+import dataclasses
 import logging
 from dataclasses import dataclass, field
 from enum import Enum
@@ -211,7 +212,7 @@ class Solution:
     objective: float = field(default=np.nan)
 
 
-@dataclass
+@dataclass(frozen=True)
 class SolverMetrics:
     """
     Unified solver performance metrics.
@@ -229,10 +230,10 @@ class SolverMetrics:
 
     def __repr__(self) -> str:
         fields = []
-        for f in self.__dataclass_fields__:
-            val = getattr(self, f)
+        for f in dataclasses.fields(self):
+            val = getattr(self, f.name)
             if val is not None:
-                fields.append(f"{f}={val!r}")
+                fields.append(f"{f.name}={val!r}")
         return f"SolverMetrics({', '.join(fields)})"
 
 

--- a/linopy/constants.py
+++ b/linopy/constants.py
@@ -216,8 +216,9 @@ class SolverMetrics:
     """
     Unified solver performance metrics.
 
-    All fields default to None and are populated by solvers on a best-effort
-    basis. Fields that a particular solver cannot provide remain None.
+    All fields default to ``None``. Solvers populate what they can;
+    unsupported fields remain ``None``.  Access via
+    :attr:`Model.solver_metrics` after calling :meth:`Model.solve`.
     """
 
     solver_name: str | None = None

--- a/linopy/constants.py
+++ b/linopy/constants.py
@@ -259,6 +259,9 @@ class SolverMetrics:
     mip_gap : float or None
         Relative gap between the objective value and the dual bound.
         Only populated for integer programs.
+    peak_memory : float or None
+        Peak memory usage during solving (MB). Only populated for solvers
+        that expose this information (e.g. Gurobi, Xpress).
     """
 
     solver_name: str | None = None
@@ -266,6 +269,7 @@ class SolverMetrics:
     objective_value: float | None = None
     dual_bound: float | None = None
     mip_gap: float | None = None
+    peak_memory: float | None = None
 
     def __repr__(self) -> str:
         fields = []

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -208,10 +208,8 @@ class Model:
         Solver performance metrics from the last solve, or ``None``
         if the model has not been solved yet.
 
-        Returns a :class:`~linopy.constants.SolverMetrics` with fields
-        ``solver_name``, ``solve_time``, ``objective_value``,
-        ``best_bound``, and ``mip_gap``.  Fields the solver cannot
-        provide remain ``None``.
+        Returns a :class:`~linopy.constants.SolverMetrics` instance.
+        Fields the solver cannot provide remain ``None``.
 
         Reset to ``None`` by :meth:`reset_solution`.
 

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -41,6 +41,7 @@ from linopy.constants import (
     LESS_EQUAL,
     TERM_DIM,
     ModelStatus,
+    SolverMetrics,
     TerminationCondition,
 )
 from linopy.constraints import AnonymousScalarConstraint, Constraint, Constraints
@@ -97,6 +98,7 @@ class Model:
 
     solver_model: Any
     solver_name: str
+    _solver_metrics: SolverMetrics | None
     _variables: Variables
     _constraints: Constraints
     _objective: Objective
@@ -137,6 +139,7 @@ class Model:
         "_force_dim_names",
         "_auto_mask",
         "_solver_dir",
+        "_solver_metrics",
         "solver_model",
         "solver_name",
         "matrices",
@@ -197,6 +200,14 @@ class Model:
         )
 
         self.matrices: MatrixAccessor = MatrixAccessor(self)
+        self._solver_metrics: SolverMetrics | None = None
+
+    @property
+    def solver_metrics(self) -> SolverMetrics | None:
+        """
+        Solver performance metrics from the last solve, or None if not yet solved.
+        """
+        return self._solver_metrics
 
     @property
     def variables(self) -> Variables:
@@ -1413,6 +1424,7 @@ class Model:
         self.termination_condition = result.status.termination_condition.value
         self.solver_model = result.solver_model
         self.solver_name = solver_name
+        self._solver_metrics = result.metrics
 
         if not result.status.is_ok:
             return result.status.status.value, result.status.termination_condition.value
@@ -1470,6 +1482,7 @@ class Model:
         self.termination_condition = TerminationCondition.optimal.value
         self.solver_model = None
         self.solver_name = solver_name
+        self._solver_metrics = SolverMetrics(solver_name="mock", objective_value=0.0)
 
         for name, var in self.variables.items():
             var.solution = xr.DataArray(0.0, var.coords)
@@ -1712,6 +1725,7 @@ class Model:
         """
         self.variables.reset_solution()
         self.constraints.reset_dual()
+        self._solver_metrics = None
 
     to_netcdf = to_netcdf
 

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -205,7 +205,23 @@ class Model:
     @property
     def solver_metrics(self) -> SolverMetrics | None:
         """
-        Solver performance metrics from the last solve, or None if not yet solved.
+        Solver performance metrics from the last solve, or ``None``
+        if the model has not been solved yet.
+
+        Returns a :class:`~linopy.constants.SolverMetrics` with fields
+        ``solver_name``, ``solve_time``, ``objective_value``,
+        ``best_bound``, and ``mip_gap``.  Fields the solver cannot
+        provide remain ``None``.
+
+        Reset to ``None`` by :meth:`reset_solution`.
+
+        Examples
+        --------
+        >>> m.solve(solver_name="highs")  # doctest: +SKIP
+        >>> m.solver_metrics.solve_time  # doctest: +SKIP
+        0.003
+        >>> m.solver_metrics.objective_value  # doctest: +SKIP
+        0.0
         """
         return self._solver_metrics
 

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -957,16 +957,6 @@ class Highs(Solver[None]):
         except Exception:
             pass
         try:
-            metrics.node_count = float(h.getInfoValue("mip_node_count")[1])
-        except Exception:
-            pass
-        try:
-            metrics.iteration_count = float(
-                h.getInfoValue("simplex_iteration_count")[1]
-            )
-        except Exception:
-            pass
-        try:
             metrics.mip_gap = h.getInfoValue("mip_gap")[1]
         except Exception:
             pass
@@ -1238,14 +1228,6 @@ class Gurobi(Solver["gurobipy.Env | dict[str, Any] | None"]):
             pass
         try:
             metrics.mip_gap = m.MIPGap
-        except Exception:
-            pass
-        try:
-            metrics.node_count = float(m.NodeCount)
-        except Exception:
-            pass
-        try:
-            metrics.iteration_count = float(m.IterCount)
         except Exception:
             pass
         return metrics
@@ -1545,14 +1527,6 @@ class SCIP(Solver[None]):
             pass
         try:
             metrics.mip_gap = m.getGap()
-        except Exception:
-            pass
-        try:
-            metrics.node_count = float(m.getNNodes())
-        except Exception:
-            pass
-        try:
-            metrics.iteration_count = float(m.getNLPIterations())
         except Exception:
             pass
         return metrics

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -958,7 +958,7 @@ class Highs(Solver[None]):
 
         def _highs_info(key: str) -> float:
             status, val = h.getInfoValue(key)
-            if status != highspy.HighsStatus.kOk:
+            if status != highspy.HighsStatus.kOk:  # pragma: no cover
                 msg = f"Failed to get HiGHS info: {key}"
                 raise RuntimeError(msg)
             return val

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -1213,7 +1213,9 @@ class Gurobi(Solver["gurobipy.Env | dict[str, Any] | None"]):
                 sense=sense,
             )
 
-    def _extract_metrics(self, solver_model: Any, solution: Solution) -> SolverMetrics:
+    def _extract_metrics(
+        self, solver_model: Any, solution: Solution
+    ) -> SolverMetrics:  # pragma: no cover
         m = solver_model
         metrics = super()._extract_metrics(solver_model, solution)
         return dataclasses.replace(
@@ -1348,7 +1350,9 @@ class Cplex(Solver[None]):
     ) -> None:
         super().__init__(**solver_options)
 
-    def _extract_metrics(self, solver_model: Any, solution: Solution) -> SolverMetrics:
+    def _extract_metrics(
+        self, solver_model: Any, solution: Solution
+    ) -> SolverMetrics:  # pragma: no cover
         m = solver_model
         metrics = super()._extract_metrics(solver_model, solution)
         return dataclasses.replace(
@@ -1447,10 +1451,10 @@ class Cplex(Solver[None]):
 
         is_lp = m.problem_type[m.get_problem_type()] == "LP"
 
-        _t0 = time.perf_counter()
+        _t0 = time.perf_counter()  # pragma: no cover
         with contextlib.suppress(cplex.exceptions.errors.CplexSolverError):
             m.solve()
-        self._solve_time = time.perf_counter() - _t0
+        self._solve_time = time.perf_counter() - _t0  # pragma: no cover
 
         if solution_fn is not None:
             try:
@@ -1680,7 +1684,9 @@ class Xpress(Solver[None]):
     ) -> None:
         super().__init__(**solver_options)
 
-    def _extract_metrics(self, solver_model: Any, solution: Solution) -> SolverMetrics:
+    def _extract_metrics(
+        self, solver_model: Any, solution: Solution
+    ) -> SolverMetrics:  # pragma: no cover
         m = solver_model
         metrics = super()._extract_metrics(solver_model, solution)
 
@@ -1879,7 +1885,9 @@ class Mosek(Solver[None]):
     ) -> None:
         super().__init__(**solver_options)
 
-    def _extract_metrics(self, solver_model: Any, solution: Solution) -> SolverMetrics:
+    def _extract_metrics(
+        self, solver_model: Any, solution: Solution
+    ) -> SolverMetrics:  # pragma: no cover
         m = solver_model
         metrics = super()._extract_metrics(solver_model, solution)
         return dataclasses.replace(

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -966,7 +966,7 @@ class Highs(Solver[None]):
             metrics,
             solve_time=_safe_get(lambda: h.getRunTime()),
             mip_gap=_safe_get(lambda: _highs_info("mip_gap")),
-            best_bound=_safe_get(lambda: _highs_info("mip_dual_bound")),
+            dual_bound=_safe_get(lambda: _highs_info("mip_dual_bound")),
         )
 
     def _set_solver_params(
@@ -1218,7 +1218,7 @@ class Gurobi(Solver["gurobipy.Env | dict[str, Any] | None"]):
         return dataclasses.replace(
             metrics,
             solve_time=_safe_get(lambda: m.Runtime),
-            best_bound=_safe_get(lambda: m.ObjBound),
+            dual_bound=_safe_get(lambda: m.ObjBound),
             mip_gap=_safe_get(lambda: m.MIPGap),
         )
 
@@ -1353,7 +1353,7 @@ class Cplex(Solver[None]):
         return dataclasses.replace(
             metrics,
             solve_time=_safe_get(lambda: m.solution.progress.get_time()),
-            best_bound=_safe_get(lambda: m.solution.MIP.get_best_objective()),
+            dual_bound=_safe_get(lambda: m.solution.MIP.get_best_objective()),
             mip_gap=_safe_get(lambda: m.solution.MIP.get_mip_relative_gap()),
         )
 
@@ -1516,7 +1516,7 @@ class SCIP(Solver[None]):
         return dataclasses.replace(
             metrics,
             solve_time=_safe_get(lambda: m.getSolvingTime()),
-            best_bound=_safe_get(lambda: m.getDualbound()),
+            dual_bound=_safe_get(lambda: m.getDualbound()),
             mip_gap=_safe_get(lambda: m.getGap()),
         )
 
@@ -1683,7 +1683,7 @@ class Xpress(Solver[None]):
         return dataclasses.replace(
             metrics,
             solve_time=_safe_get(lambda: m.attributes.time),
-            best_bound=_safe_get(lambda: m.attributes.bestbound),
+            dual_bound=_safe_get(lambda: m.attributes.bestbound),
             mip_gap=_safe_get(lambda: m.attributes.miprelgap),
         )
 
@@ -2217,7 +2217,7 @@ class COPT(Solver[None]):
         return dataclasses.replace(
             metrics,
             solve_time=_safe_get(lambda: m.SolvingTime),
-            best_bound=_safe_get(lambda: m.BestBnd),
+            dual_bound=_safe_get(lambda: m.BestBnd),
             mip_gap=_safe_get(lambda: m.BestGap),
         )
 

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -1232,11 +1232,14 @@ class Gurobi(Solver["gurobipy.Env | dict[str, Any] | None"]):
         m = solver_model
         metrics = super()._extract_metrics(solver_model, solution)
         is_mip = _safe_get(lambda: m.IsMIP) == 1
+        mem_gb = _safe_get(lambda: m.MaxMemUsed)
+        peak_memory = mem_gb * 1024 if mem_gb is not None else None
         return dataclasses.replace(
             metrics,
             solve_time=_safe_get(lambda: m.Runtime),
             dual_bound=_safe_get(lambda: m.ObjBound) if is_mip else None,
             mip_gap=_safe_get(lambda: m.MIPGap) if is_mip else None,
+            peak_memory=peak_memory,
         )
 
     def _solve(
@@ -1724,6 +1727,7 @@ class Xpress(Solver[None]):
             solve_time=_safe_get(lambda: m.attributes.time),
             dual_bound=_safe_get(lambda: m.attributes.bestbound) if is_mip else None,
             mip_gap=_safe_get(_xpress_mip_gap) if is_mip else None,
+            peak_memory=_safe_get(lambda: m.attributes.peakmemory),
         )
 
     def solve_problem_from_model(

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -1233,7 +1233,7 @@ class Gurobi(Solver["gurobipy.Env | dict[str, Any] | None"]):
         metrics = super()._extract_metrics(solver_model, solution)
         is_mip = _safe_get(lambda: m.IsMIP) == 1
         mem_gb = _safe_get(lambda: m.MaxMemUsed)
-        peak_memory = mem_gb * 1024 if mem_gb is not None else None
+        peak_memory = mem_gb * 1000 if mem_gb is not None else None
         return dataclasses.replace(
             metrics,
             solve_time=_safe_get(lambda: m.Runtime),

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -1727,7 +1727,7 @@ class Xpress(Solver[None]):
             solve_time=_safe_get(lambda: m.attributes.time),
             dual_bound=_safe_get(lambda: m.attributes.bestbound) if is_mip else None,
             mip_gap=_safe_get(_xpress_mip_gap) if is_mip else None,
-            peak_memory=_safe_get(lambda: m.attributes.peakmemory),
+            peak_memory=_safe_get(lambda: m.attributes.peakmemory / (1024 * 1024)),
         )
 
     def solve_problem_from_model(

--- a/test/test_solver_metrics.py
+++ b/test/test_solver_metrics.py
@@ -5,9 +5,6 @@ Tests for the SolverMetrics feature.
 
 from __future__ import annotations
 
-from types import SimpleNamespace
-from unittest.mock import MagicMock
-
 import numpy as np
 import pytest
 import xarray as xr
@@ -15,18 +12,6 @@ import xarray as xr
 from linopy import Model, available_solvers
 from linopy.constants import Result, Solution, SolverMetrics, Status
 from linopy.solver_capabilities import SolverFeature, get_available_solvers_with_feature
-from linopy.solvers import (
-    CBC,
-    COPT,
-    SCIP,
-    Cplex,
-    Gurobi,
-    Highs,
-    MindOpt,
-    Mosek,
-    Xpress,
-    cuPDLPx,
-)
 
 # ---------------------------------------------------------------------------
 # SolverMetrics dataclass tests
@@ -164,10 +149,8 @@ def test_solver_metrics_direct(solver: str) -> None:
     assert metrics.solver_name == solver
     assert metrics.objective_value is not None
     assert metrics.objective_value == pytest.approx(1.0)
-    # Direct API solvers should generally report solve_time
-    if solver in ("gurobi", "highs"):
-        assert metrics.solve_time is not None
-        assert metrics.solve_time >= 0
+    assert metrics.solve_time is not None
+    assert metrics.solve_time >= 0
 
 
 @pytest.mark.parametrize("solver", file_io_solvers)
@@ -179,130 +162,5 @@ def test_solver_metrics_file_io(solver: str) -> None:
     assert metrics.solver_name == solver
     assert metrics.objective_value is not None
     assert metrics.objective_value == pytest.approx(1.0)
-
-
-# ---------------------------------------------------------------------------
-# Mock-based _extract_metrics unit tests for each solver override
-# ---------------------------------------------------------------------------
-
-_SOLUTION = Solution(objective=42.0)
-
-
-@pytest.mark.skipif("cbc" not in available_solvers, reason="CBC not installed")
-def test_cbc_extract_metrics() -> None:
-    solver_model = SimpleNamespace(runtime=1.5, mip_gap=0.01)
-    solver = CBC()
-    metrics = solver._extract_metrics(solver_model, _SOLUTION)
-    assert metrics.solve_time == 1.5
-    assert metrics.mip_gap == 0.01
-
-
-@pytest.mark.skipif("highs" not in available_solvers, reason="HiGHS not installed")
-def test_highs_extract_metrics() -> None:
-    solver_model = MagicMock()
-    solver_model.getRunTime.return_value = 2.0
-    solver_model.getInfoValue.side_effect = lambda key: {
-        "mip_gap": (0, 0.05),
-        "mip_objective_bound": (0, 40.0),
-    }[key]
-    solver = Highs()
-    metrics = solver._extract_metrics(solver_model, _SOLUTION)
-    assert metrics.solve_time == 2.0
-    assert metrics.mip_gap == 0.05
-    assert metrics.best_bound == 40.0
-
-
-@pytest.mark.skipif("gurobi" not in available_solvers, reason="Gurobi not installed")
-def test_gurobi_extract_metrics() -> None:
-    solver_model = SimpleNamespace(Runtime=3.0, ObjBound=39.0, MIPGap=0.02)
-    solver = Gurobi()
-    metrics = solver._extract_metrics(solver_model, _SOLUTION)
-    assert metrics.solve_time == 3.0
-    assert metrics.best_bound == 39.0
-    assert metrics.mip_gap == 0.02
-
-
-@pytest.mark.skipif("scip" not in available_solvers, reason="SCIP not installed")
-def test_scip_extract_metrics() -> None:
-    solver_model = MagicMock()
-    solver_model.getSolvingTime.return_value = 4.0
-    solver_model.getDualbound.return_value = 38.0
-    solver_model.getGap.return_value = 0.03
-    solver = SCIP()
-    metrics = solver._extract_metrics(solver_model, _SOLUTION)
-    assert metrics.solve_time == 4.0
-    assert metrics.best_bound == 38.0
-    assert metrics.mip_gap == 0.03
-
-
-@pytest.mark.skipif("cplex" not in available_solvers, reason="CPLEX not installed")
-def test_cplex_extract_metrics() -> None:
-    solver_model = MagicMock()
-    solver_model.solution.progress.get_time.return_value = 5.0
-    solver_model.solution.MIP.get_best_objective.return_value = 37.0
-    solver_model.solution.MIP.get_mip_relative_gap.return_value = 0.04
-    solver = Cplex()
-    metrics = solver._extract_metrics(solver_model, _SOLUTION)
-    assert metrics.solve_time == 5.0
-    assert metrics.best_bound == 37.0
-    assert metrics.mip_gap == 0.04
-
-
-@pytest.mark.skipif("xpress" not in available_solvers, reason="Xpress not installed")
-def test_xpress_extract_metrics() -> None:
-    solver_model = SimpleNamespace(
-        attributes=SimpleNamespace(time=6.0, bestbound=36.0, miprelgap=0.05)
-    )
-    solver = Xpress()
-    metrics = solver._extract_metrics(solver_model, _SOLUTION)
-    assert metrics.solve_time == 6.0
-    assert metrics.best_bound == 36.0
-    assert metrics.mip_gap == 0.05
-
-
-@pytest.mark.skipif("mosek" not in available_solvers, reason="Mosek not installed")
-def test_mosek_extract_metrics() -> None:
-    solver_model = MagicMock()
-    solver_model.getdouinf.return_value = 7.0
-    solver = Mosek()
-    metrics = solver._extract_metrics(solver_model, _SOLUTION)
-    assert metrics.solve_time == 7.0
-
-
-@pytest.mark.skipif("copt" not in available_solvers, reason="COPT not installed")
-def test_copt_extract_metrics() -> None:
-    solver_model = SimpleNamespace(SolvingTime=8.0, BestBnd=35.0, BestGap=0.06)
-    solver = COPT()
-    metrics = solver._extract_metrics(solver_model, _SOLUTION)
-    assert metrics.solve_time == 8.0
-    assert metrics.best_bound == 35.0
-    assert metrics.mip_gap == 0.06
-
-
-@pytest.mark.skipif("mindopt" not in available_solvers, reason="MindOpt not installed")
-def test_mindopt_extract_metrics() -> None:
-    solver_model = MagicMock()
-    solver_model.getAttr.return_value = 9.0
-    solver = MindOpt()
-    metrics = solver._extract_metrics(solver_model, _SOLUTION)
-    assert metrics.solve_time == 9.0
-
-
-@pytest.mark.skipif("cupdlpx" not in available_solvers, reason="cuPDLPx not installed")
-def test_cupdlpx_extract_metrics() -> None:
-    solver_model = SimpleNamespace(SolveTime=10.0)
-    solver = cuPDLPx()
-    metrics = solver._extract_metrics(solver_model, _SOLUTION)
-    assert metrics.solve_time == 10.0
-
-
-@pytest.mark.skipif("gurobi" not in available_solvers, reason="Gurobi not installed")
-def test_extract_metrics_graceful_on_missing_attr() -> None:
-    """_safe_get should return None when attributes are missing."""
-    solver_model = SimpleNamespace()  # no attributes at all
-    solver = Gurobi()
-    metrics = solver._extract_metrics(solver_model, _SOLUTION)
-    assert metrics.solve_time is None
-    assert metrics.best_bound is None
-    assert metrics.mip_gap is None
-    assert metrics.objective_value == 42.0
+    assert metrics.solve_time is not None
+    assert metrics.solve_time >= 0

--- a/test/test_solver_metrics.py
+++ b/test/test_solver_metrics.py
@@ -23,7 +23,7 @@ def test_solver_metrics_defaults() -> None:
     assert m.solver_name is None
     assert m.solve_time is None
     assert m.objective_value is None
-    assert m.best_bound is None
+    assert m.dual_bound is None
     assert m.mip_gap is None
 
 
@@ -40,7 +40,7 @@ def test_solver_metrics_repr_only_non_none() -> None:
     assert "solver_name='gurobi'" in r
     assert "solve_time=2.3" in r
     assert "objective_value" not in r
-    assert "best_bound" not in r
+    assert "dual_bound" not in r
 
 
 def test_solver_metrics_repr_empty() -> None:
@@ -179,7 +179,7 @@ def test_solver_metrics_file_io(solver: str) -> None:
 
 @pytest.mark.parametrize("solver", mip_solvers)
 def test_solver_metrics_mip(solver: str) -> None:
-    """Solve a MIP and verify mip_gap and best_bound are populated."""
+    """Solve a MIP and verify mip_gap and dual_bound are populated."""
     m = _make_simple_mip()
     if solver in direct_solvers:
         m.solve(solver_name=solver, io_api="direct")
@@ -193,5 +193,5 @@ def test_solver_metrics_mip(solver: str) -> None:
     assert metrics.solve_time >= 0
     assert metrics.mip_gap is not None
     assert metrics.mip_gap >= 0
-    assert metrics.best_bound is not None
-    assert isinstance(metrics.best_bound, float)
+    assert metrics.dual_bound is not None
+    assert isinstance(metrics.dual_bound, float)

--- a/test/test_solver_metrics.py
+++ b/test/test_solver_metrics.py
@@ -120,15 +120,30 @@ def test_model_metrics_reset() -> None:
 # Solver-specific integration tests (parametrized over available solvers)
 # ---------------------------------------------------------------------------
 
-direct_solvers = get_available_solvers_with_feature(
-    SolverFeature.DIRECT_API, available_solvers
-)
-file_io_solvers = get_available_solvers_with_feature(
-    SolverFeature.READ_MODEL_FROM_FILE, available_solvers
-)
-mip_solvers = get_available_solvers_with_feature(
-    SolverFeature.INTEGER_VARIABLES, available_solvers
-)
+# Solvers that have a tested _extract_metrics override providing solve_time etc.
+_solvers_with_metrics = {"gurobi", "highs", "scip", "cplex", "xpress", "mosek"}
+
+direct_solvers = [
+    s
+    for s in get_available_solvers_with_feature(
+        SolverFeature.DIRECT_API, available_solvers
+    )
+    if s in _solvers_with_metrics
+]
+file_io_solvers = [
+    s
+    for s in get_available_solvers_with_feature(
+        SolverFeature.READ_MODEL_FROM_FILE, available_solvers
+    )
+    if s in _solvers_with_metrics
+]
+mip_solvers = [
+    s
+    for s in get_available_solvers_with_feature(
+        SolverFeature.INTEGER_VARIABLES, available_solvers
+    )
+    if s in _solvers_with_metrics
+]
 
 
 def _make_simple_lp() -> Model:

--- a/test/test_solver_metrics.py
+++ b/test/test_solver_metrics.py
@@ -25,8 +25,6 @@ def test_solver_metrics_defaults() -> None:
     assert m.objective_value is None
     assert m.best_bound is None
     assert m.mip_gap is None
-    assert m.node_count is None
-    assert m.iteration_count is None
 
 
 def test_solver_metrics_partial() -> None:

--- a/test/test_solver_metrics.py
+++ b/test/test_solver_metrics.py
@@ -48,6 +48,12 @@ def test_solver_metrics_repr_empty() -> None:
     assert repr(m) == "SolverMetrics()"
 
 
+def test_solver_metrics_frozen() -> None:
+    m = SolverMetrics(solver_name="test")
+    with pytest.raises(AttributeError):
+        m.solver_name = "other"  # type: ignore[misc]
+
+
 # ---------------------------------------------------------------------------
 # Result backward compatibility tests
 # ---------------------------------------------------------------------------

--- a/test/test_solver_metrics.py
+++ b/test/test_solver_metrics.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""
+Tests for the SolverMetrics feature.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from linopy import Model, available_solvers
+from linopy.constants import Result, Solution, SolverMetrics, Status
+from linopy.solver_capabilities import SolverFeature, get_available_solvers_with_feature
+
+# ---------------------------------------------------------------------------
+# SolverMetrics dataclass tests
+# ---------------------------------------------------------------------------
+
+
+def test_solver_metrics_defaults() -> None:
+    m = SolverMetrics()
+    assert m.solver_name is None
+    assert m.solve_time is None
+    assert m.objective_value is None
+    assert m.best_bound is None
+    assert m.mip_gap is None
+    assert m.node_count is None
+    assert m.iteration_count is None
+
+
+def test_solver_metrics_partial() -> None:
+    m = SolverMetrics(solver_name="highs", solve_time=1.5)
+    assert m.solver_name == "highs"
+    assert m.solve_time == 1.5
+    assert m.objective_value is None
+
+
+def test_solver_metrics_repr_only_non_none() -> None:
+    m = SolverMetrics(solver_name="gurobi", solve_time=2.3)
+    r = repr(m)
+    assert "solver_name='gurobi'" in r
+    assert "solve_time=2.3" in r
+    assert "objective_value" not in r
+    assert "best_bound" not in r
+
+
+def test_solver_metrics_repr_empty() -> None:
+    m = SolverMetrics()
+    assert repr(m) == "SolverMetrics()"
+
+
+# ---------------------------------------------------------------------------
+# Result backward compatibility tests
+# ---------------------------------------------------------------------------
+
+
+def test_result_without_metrics() -> None:
+    """Result without metrics should still work (backward compatible)."""
+    status = Status.from_termination_condition("optimal")
+    result = Result(status=status, solution=Solution())
+    assert result.metrics is None
+    # repr should not crash
+    repr(result)
+
+
+def test_result_with_metrics() -> None:
+    status = Status.from_termination_condition("optimal")
+    metrics = SolverMetrics(solver_name="test", solve_time=1.0)
+    result = Result(status=status, solution=Solution(), metrics=metrics)
+    assert result.metrics is not None
+    assert result.metrics.solver_name == "test"
+    r = repr(result)
+    assert "Solver metrics:" in r
+
+
+# ---------------------------------------------------------------------------
+# Model integration tests
+# ---------------------------------------------------------------------------
+
+
+def test_model_metrics_none_before_solve() -> None:
+    m = Model()
+    assert m.solver_metrics is None
+
+
+def test_model_metrics_populated_after_mock_solve() -> None:
+    m = Model()
+    x = m.add_variables(
+        lower=xr.DataArray(np.zeros(5), dims=["i"]),
+        upper=xr.DataArray(np.ones(5), dims=["i"]),
+        name="x",
+    )
+    m.add_objective(x.sum())
+    m.solve(mock_solve=True)
+    assert m.solver_metrics is not None
+    assert m.solver_metrics.solver_name == "mock"
+    assert m.solver_metrics.objective_value == 0.0
+
+
+def test_model_metrics_reset() -> None:
+    m = Model()
+    x = m.add_variables(
+        lower=xr.DataArray(np.zeros(5), dims=["i"]),
+        upper=xr.DataArray(np.ones(5), dims=["i"]),
+        name="x",
+    )
+    m.add_objective(x.sum())
+    m.solve(mock_solve=True)
+    assert m.solver_metrics is not None
+    m.reset_solution()
+    assert m.solver_metrics is None
+
+
+# ---------------------------------------------------------------------------
+# Solver-specific integration tests (parametrized over available solvers)
+# ---------------------------------------------------------------------------
+
+direct_solvers = get_available_solvers_with_feature(
+    SolverFeature.DIRECT_API, available_solvers
+)
+file_io_solvers = get_available_solvers_with_feature(
+    SolverFeature.READ_MODEL_FROM_FILE, available_solvers
+)
+
+
+def _make_simple_model() -> Model:
+    m = Model()
+    x = m.add_variables(
+        lower=xr.DataArray(np.zeros(3), dims=["i"]),
+        upper=xr.DataArray(np.ones(3), dims=["i"]),
+        name="x",
+    )
+    m.add_constraints(x.sum() >= 1, name="con")
+    m.add_objective(x.sum())
+    return m
+
+
+@pytest.mark.parametrize("solver", direct_solvers)
+def test_solver_metrics_direct(solver: str) -> None:
+    m = _make_simple_model()
+    m.solve(solver_name=solver, io_api="direct")
+    metrics = m.solver_metrics
+    assert metrics is not None
+    assert metrics.solver_name == solver
+    assert metrics.objective_value is not None
+    assert metrics.objective_value == pytest.approx(1.0)
+    # Direct API solvers should generally report solve_time
+    if solver in ("gurobi", "highs"):
+        assert metrics.solve_time is not None
+        assert metrics.solve_time >= 0
+
+
+@pytest.mark.parametrize("solver", file_io_solvers)
+def test_solver_metrics_file_io(solver: str) -> None:
+    m = _make_simple_model()
+    m.solve(solver_name=solver, io_api="lp")
+    metrics = m.solver_metrics
+    assert metrics is not None
+    assert metrics.solver_name == solver
+    assert metrics.objective_value is not None
+    assert metrics.objective_value == pytest.approx(1.0)

--- a/test/test_solver_metrics.py
+++ b/test/test_solver_metrics.py
@@ -117,6 +117,31 @@ def test_model_metrics_reset() -> None:
     assert m.solver_metrics is None
 
 
+def test_model_metrics_re_solve_different_solver() -> None:
+    """Re-solving with a different solver should overwrite metrics."""
+    m = Model()
+    x = m.add_variables(
+        lower=xr.DataArray(np.zeros(5), dims=["i"]),
+        upper=xr.DataArray(np.ones(5), dims=["i"]),
+        name="x",
+    )
+    m.add_objective(x.sum())
+
+    # First solve
+    m.solve(mock_solve=True)
+    assert m.solver_metrics is not None
+    assert m.solver_metrics.solver_name == "mock"
+
+    # Re-solve with a real solver (if available) to verify metrics are replaced
+    if available_solvers:
+        solver = available_solvers[0]
+        m.add_constraints(x.sum() >= 0, name="con")
+        m.solve(solver_name=solver)
+        assert m.solver_metrics is not None
+        assert m.solver_metrics.solver_name == solver
+        assert m.solver_metrics.solver_name != "mock"
+
+
 # ---------------------------------------------------------------------------
 # Solver-specific integration tests (parametrized over available solvers)
 # ---------------------------------------------------------------------------

--- a/test/test_solver_metrics.py
+++ b/test/test_solver_metrics.py
@@ -25,6 +25,7 @@ def test_solver_metrics_defaults() -> None:
     assert m.objective_value is None
     assert m.dual_bound is None
     assert m.mip_gap is None
+    assert m.peak_memory is None
 
 
 def test_solver_metrics_partial() -> None:
@@ -210,3 +211,23 @@ def test_solver_metrics_mip(solver: str) -> None:
     assert metrics.mip_gap >= 0
     assert metrics.dual_bound is not None
     assert isinstance(metrics.dual_bound, float)
+
+
+# Solvers that populate peak_memory in _extract_metrics
+_solvers_with_peak_memory = {"gurobi", "xpress"}
+
+peak_memory_solvers = [s for s in available_solvers if s in _solvers_with_peak_memory]
+
+
+@pytest.mark.parametrize("solver", peak_memory_solvers)
+def test_solver_metrics_peak_memory(solver: str) -> None:  # pragma: no cover
+    """Verify peak_memory is populated for solvers that support it."""
+    m = _make_simple_lp()
+    if solver in direct_solvers:
+        m.solve(solver_name=solver, io_api="direct")
+    else:
+        m.solve(solver_name=solver, io_api="lp")
+    metrics = m.solver_metrics
+    assert metrics is not None
+    assert metrics.peak_memory is not None
+    assert metrics.peak_memory > 0


### PR DESCRIPTION
## Summary

Add a unified `SolverMetrics` dataclass that provides solver-independent access to performance metrics after solving. Accessible via `Model.solver_metrics`.

**Fields:** `solver_name`, `solve_time`, `objective_value`, `dual_bound`, `mip_gap`, `peak_memory` — all default to `None`; solvers populate what they can.

**Design:**
- Frozen dataclass (immutable after creation)
- Base `Solver._extract_metrics()` populates `solver_name` and `objective_value`
- Each solver subclass overrides to add solver-specific fields via `dataclasses.replace()`
- All attribute access wrapped in `_safe_get()` with debug logging so extraction never breaks the solve
- The pattern is easily extensible for new solvers — just override `_extract_metrics()` and use `_safe_get()`. PRs adding metrics for additional solvers are welcome!

**Solver coverage:**

| Solver | solve_time | dual_bound | mip_gap | peak_memory | tested |
|--------|:---:|:---:|:---:|:---:|:---:|
| Gurobi | ✓ | ✓ | ✓ | ✓ | ✓ |
| HiGHS | ✓ | ✓ | ✓ | | ✓ |
| SCIP | ✓ | ✓ | ✓ | | ✓ |
| CPLEX | ✓ | ✓ | ✓ | | ✓ |
| Xpress | ✓ | ✓ | ✓ | ✓ | ✓ |
| Mosek | ✓ | ✓ | ✓ | | ✓ |
| CBC | ✓* | | ✓* | | |
| COPT | base only | | | | |
| MindOpt | base only | | | | |
| cuPDLPx | base only | | | | |
| GLPK | base only | | | | |

*CBC parses `solve_time` and `mip_gap` from log output via regex and populates them in `SolverMetrics`. These fields depend on the CBC log format, which varies across versions.

`peak_memory` (MB) is only available for solvers that expose it via their Python API. Verified that HiGHS, SCIP, CPLEX, Mosek, and CBC do **not** expose peak memory. Gurobi provides it via `MaxMemUsed` (GB, converted to MB) and Xpress via `peakmemory` (bytes, converted to MB).

Solvers without a tested `_extract_metrics` override still get `solver_name` and `objective_value` from the base class. We intentionally did not add solver-specific overrides for untested solvers — incorrect attribute names would silently return `None`, giving a false sense of coverage.

**Bugs fixed along the way:**
- **HiGHS**: Used non-existent info key `mip_objective_bound` — fixed to `mip_dual_bound`. Also fixed status comparison (`== 0` → `== highspy.HighsStatus.kOk`).
- **Xpress**: `miprelgap` attribute doesn't exist — compute gap manually from `mipbestobjval` and `bestbound`.
- **CPLEX**: `m.solution.progress.get_time()` doesn't exist — use `time.perf_counter()` around the solve call.

## Test plan
- [x] `SolverMetrics` dataclass unit tests (defaults, partial, repr, frozen)
- [x] `Result` backward compatibility tests (with/without metrics)
- [x] `Model` integration tests (metrics before solve, after mock solve, after reset, after re-solve with different solver)
- [x] Parametrized LP tests over direct and file-IO solvers
- [x] Parametrized MIP tests asserting `mip_gap` and `dual_bound` are populated
- [x] Parametrized `peak_memory` test for Gurobi and Xpress
- [x] All solver-specific overrides tested with real solves (Gurobi, HiGHS, SCIP, CPLEX, Xpress, Mosek)

Closes #428
