### PR TITLE
fix: update HiGHS URLs and naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Fri    0          4
 
 * [Cbc](https://projects.coin-or.org/Cbc)
 * [GLPK](https://www.gnu.org/software/glpk/)
-* [HiGHS](https://www.maths.ed.ac.uk/hall/HiGHS/)
+* [HiGHS](https://highs.dev/)
 * [Gurobi](https://www.gurobi.com/)
 * [Xpress](https://www.fico.com/en/products/fico-xpress-solver)
 * [Cplex](https://www.ibm.com/de-de/analytics/cplex-optimizer)

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -42,7 +42,7 @@ flexible data-handling features:
 -  Support of various solvers
    - `Cbc <https://projects.coin-or.org/Cbc>`__
    - `GLPK <https://www.gnu.org/software/glpk/>`__
-   - `HiGHS <https://www.maths.ed.ac.uk/hall/HiGHS/>`__
+   - `HiGHS <https://highs.dev/>`__
    - `MindOpt <https://solver.damo.alibaba.com/doc/en/html/index.html>`__
    - `Gurobi <https://www.gurobi.com/>`__
    - `Xpress <https://www.fico.com/en/fico-xpress-trial-and-licensing-options>`__

--- a/doc/prerequisites.rst
+++ b/doc/prerequisites.rst
@@ -35,7 +35,7 @@ CPU-based solvers
 
 -  `Cbc <https://projects.coin-or.org/Cbc>`__ - open source, free, fast
 -  `GLPK <https://www.gnu.org/software/glpk/>`__ - open source, free, not very fast
--  `HiGHS <https://www.maths.ed.ac.uk/hall/HiGHS/>`__ - open source, free, fast
+-  `HiGHS <https://highs.dev/>`__ - open source, free, fast
 -  `Gurobi <https://www.gurobi.com/>`__  - closed source, commercial, very fast
 -  `Xpress <https://www.fico.com/en/fico-xpress-trial-and-licensing-options>`__ - closed source, commercial, very fast (GPU acceleration available in v9.8+)
 -  `Cplex <https://www.ibm.com/de-de/analytics/cplex-optimizer>`__ - closed source, commercial, very fast

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -678,7 +678,7 @@ Version 0.0.5
 * The `Variable` class now has a `lower` and `upper` accessor, which allows to inspect and modify the lower and upper bounds of a assigned variable.
 * The `Constraint` class now has a `lhs`, `vars`, `coeffs`, `rhs` and `sign` accessor, which allows to inspect and modify the left-hand-side, the signs and right-hand-side of a assigned constraint.
 * Constraints can now be build combining linear expressions with right-hand-side via a `>=`, `<=` or a `==` operator. This creates an `AnonymousConstraint` which can be passed to `Model.add_constraints`.
-* Add support of the HiGHS open source solver https://www.maths.ed.ac.uk/hall/HiGHS/ (https://github.com/PyPSA/linopy/pull/8, https://github.com/PyPSA/linopy/pull/17).
+* Add support of the HiGHS open source solver https://highs.dev/ (https://github.com/PyPSA/linopy/pull/8, https://github.com/PyPSA/linopy/pull/17).
 
 
 **Breaking changes**

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -773,10 +773,10 @@ class GLPK(Solver[None]):
 
 class Highs(Solver[None]):
     """
-    Solver subclass for the Highs solver. Highs must be installed
-    for usage. Find the documentation at https://www.maths.ed.ac.uk/hall/HiGHS/.
+    Solver subclass for the HiGHS solver. HiGHS must be installed
+    for usage. Find the documentation at https://highs.dev/.
 
-    The full list of solver options is documented at https://www.maths.ed.ac.uk/hall/HiGHS/HighsOptions.set.
+    The full list of solver options is documented at https://ergo-code.github.io/HiGHS/stable/options/definitions/.
 
     Some exemplary options are:
 
@@ -808,8 +808,8 @@ class Highs(Solver[None]):
         explicit_coordinate_names: bool = False,
     ) -> Result:
         """
-        Solve a linear problem directly from a linopy model using the Highs solver.
-        Reads a linear problem file and passes it to the highs solver.
+        Solve a linear problem directly from a linopy model using the HiGHS solver.
+        Reads a linear problem file and passes it to the HiGHS solver.
         If the solution is feasible the function returns the
         objective, solution and dual constraint variables.
 
@@ -834,7 +834,7 @@ class Highs(Solver[None]):
         -------
         Result
         """
-        # check for Highs solver compatibility
+        # check for HiGHS solver compatibility
         if self.solver_options.get("solver") in [
             "simplex",
             "ipm",
@@ -871,8 +871,8 @@ class Highs(Solver[None]):
         env: None = None,
     ) -> Result:
         """
-        Solve a linear problem from a problem file using the Highs solver.
-        Reads a linear problem file and passes it to the highs solver.
+        Solve a linear problem from a problem file using the HiGHS solver.
+        Reads a linear problem file and passes it to the HiGHS solver.
         If the solution is feasible the function returns the
         objective, solution and dual constraint variables.
 
@@ -934,13 +934,13 @@ class Highs(Solver[None]):
         sense: str | None = None,
     ) -> Result:
         """
-        Solve a linear problem from a Highs object.
+        Solve a linear problem from a HiGHS object.
 
 
         Parameters
         ----------
         h : highspy.Highs
-            Highs object.
+            HiGHS object.
         solution_fn : Path, optional
             Path to the solution file.
         log_fn : Path, optional


### PR DESCRIPTION
## Changes proposed in this Pull Request

- Replace all dead `maths.ed.ac.uk/hall/HiGHS/` links with `https://highs.dev/`
- Fix dead options link (`HighsOptions.set`) → `https://ergo-code.github.io/HiGHS/stable/options/definitions/`
- Use "HiGHS" consistently in docstrings instead of "Highs" (code identifiers unchanged)

Files changed: `README.md`, `doc/index.rst`, `doc/prerequisites.rst`, `doc/release_notes.rst`, `linopy/solvers.py`

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.