### PR TITLE
Determine time spent in solver for CPLEX

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -4,6 +4,7 @@ Release Notes
 Upcoming Version
 ----------------
 
+* Wrap the CPLEX model in a structured result that includes runtime measured via the solver API
 * Add ``Model.copy()`` (default deep copy) with ``deep`` and ``include_solution`` options; support Python ``copy.copy`` and ``copy.deepcopy`` protocols via ``__copy__`` and ``__deepcopy__``.
 * Harmonize coordinate alignment for operations with subset/superset objects:
   - Multiplication and division fill missing coords with 0 (variable doesn't participate)

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -1265,6 +1265,7 @@ class Gurobi(Solver["gurobipy.Env | dict[str, Any] | None"]):
 
         return Result(status, solution, m)
 
+CplexResult = namedtuple("CplexResult", ["model", "reported_runtime"])
 
 class Cplex(Solver[None]):
     """
@@ -1375,8 +1376,12 @@ class Cplex(Solver[None]):
 
         is_lp = m.problem_type[m.get_problem_type()] == "LP"
 
+        reported_runtime = None
+
         with contextlib.suppress(cplex.exceptions.errors.CplexSolverError):
+            start_time = m.get_time()
             m.solve()
+            reported_runtime = m.get_time() - start_time
 
         if solution_fn is not None:
             try:
@@ -1421,7 +1426,7 @@ class Cplex(Solver[None]):
         solution = self.safe_get_solution(status=status, func=get_solver_solution)
         solution = maybe_adjust_objective_sign(solution, io_api, sense)
 
-        return Result(status, solution, m)
+        return Result(status, solution, CplexResult(m, reported_runtime))
 
 
 class SCIP(Solver[None]):

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -1265,7 +1265,9 @@ class Gurobi(Solver["gurobipy.Env | dict[str, Any] | None"]):
 
         return Result(status, solution, m)
 
+
 CplexResult = namedtuple("CplexResult", ["model", "reported_runtime"])
+
 
 class Cplex(Solver[None]):
     """


### PR DESCRIPTION
## Changes proposed in this Pull Request
When calling CPLEX through linopy, the returned `Result` object contained only:
-  `status`
- `solution`
- `solver_model = m` (the raw `cplex.Cplex` object)
but it did NOT include the solver runtime.

This creates of course an issue for benchmarking cplex as we cannot reliably access the solve time from linopy,  and of course the profiler misses it completely

Other solvers in Linopy already expose structured metrics:

`Knitro`returns a KnitroResult with runtime + gaps + errors
`HiGHS` runtime accessible via solver info
`Gurobi / Xpress` can access runtime from API

So I'm proposing here to add a lightweight wrapper, similar to Knitro:

`CplexResult = namedtuple("CplexResult", ["model", "reported_runtime"])`
and modify the solve steps accordingly.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
