### PR TITLE
fix: make assert_linequal term-order invariant

### DIFF
--- a/linopy/testing.py
+++ b/linopy/testing.py
@@ -1,11 +1,27 @@
 from __future__ import annotations
 
+import numpy as np
 from xarray.testing import assert_equal
 
+from linopy.constants import TERM_DIM
 from linopy.constraints import ConstraintBase, _con_unwrap
 from linopy.expressions import LinearExpression, QuadraticExpression, _expr_unwrap
 from linopy.model import Model
 from linopy.variables import Variable, _var_unwrap
+
+
+def _sort_by_vars_along_term(expr: LinearExpression) -> LinearExpression:
+    """Sort a linear expression's terms by variable labels along _term."""
+    ds = expr.data
+    if TERM_DIM not in ds.dims:
+        return expr
+    order = np.argsort(ds["vars"].values, axis=-1, kind="stable")
+    sorted_vars = np.take_along_axis(ds["vars"].values, order, axis=-1)
+    sorted_coeffs = np.take_along_axis(ds["coeffs"].values, order, axis=-1)
+    new_ds = ds.copy()
+    new_ds["vars"] = (ds["vars"].dims, sorted_vars)
+    new_ds["coeffs"] = (ds["coeffs"].dims, sorted_coeffs)
+    return LinearExpression(new_ds, expr.model)
 
 
 def assert_varequal(a: Variable, b: Variable) -> None:
@@ -16,10 +32,18 @@ def assert_varequal(a: Variable, b: Variable) -> None:
 def assert_linequal(
     a: LinearExpression | QuadraticExpression, b: LinearExpression | QuadraticExpression
 ) -> None:
-    """Assert that two linear expressions are equal."""
+    """
+    Assert that two linear expressions are semantically equal.
+
+    Terms are sorted by variable labels along _term before comparing,
+    so expressions with different term orderings but identical mathematical
+    meaning are considered equal.
+    """
     assert isinstance(a, LinearExpression)
     assert isinstance(b, LinearExpression)
-    return assert_equal(_expr_unwrap(a), _expr_unwrap(b))
+    a_sorted = _sort_by_vars_along_term(a)
+    b_sorted = _sort_by_vars_along_term(b)
+    return assert_equal(_expr_unwrap(a_sorted), _expr_unwrap(b_sorted))
 
 
 def assert_quadequal(


### PR DESCRIPTION
## Summary
- `assert_linequal` now sorts both sides by variable labels along `_term` before comparing, so expressions with different term orderings are correctly recognized as semantically equal.
- Fixes false failures when comparing constraints that went through the CSR round-trip (`freeze_constraints=True`) against freshly built expressions, since `csr.sum_duplicates()` sorts terms by variable label.

## Reproducer (from #630 comment)
```python
from linopy import Model
from linopy.testing import assert_linequal
import pandas as pd

m = Model(freeze_constraints=True)
coords = pd.RangeIndex(3, name="time")
x = m.add_variables(coords=[coords], name="x")
y = m.add_variables(coords=[coords], name="y")

m.add_constraints(y - x == 0, name="con")

desired = y == x
assert_linequal(m.constraints["con"].lhs, desired.lhs)  # was failing, now passes
```

## Test plan
- [x] Reproducer passes
- [x] All 2665 existing tests pass
- [x] Linter and pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)