### PR TITLE
fix: compatibility with xarray 2026.4.0

### DIFF
--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -284,7 +284,7 @@ class LinearExpressionGroupby:
                 index.names = [str(col) for col in orig_group.columns]
                 index.name = GROUP_DIM
                 new_coords = Coordinates.from_pandas_multiindex(index, GROUP_DIM)
-                ds = xr.Dataset(ds.assign_coords(new_coords))
+                ds = ds.assign_coords(new_coords)
 
             ds = ds.rename({GROUP_DIM: final_group_name})
             return LinearExpression(ds, self.model)
@@ -392,7 +392,7 @@ class BaseExpression(ABC):
         data = assign_multiindex_safe(data, **coeffs_vars_dict)
 
         # transpose with new Dataset to really ensure correct order
-        data = Dataset(data.transpose(..., TERM_DIM))
+        data = data.transpose(..., TERM_DIM)
 
         # ensure helper dimensions are not set as coordinates
         if drop_dims := set(HELPER_DIMS).intersection(data.coords):
@@ -2098,7 +2098,7 @@ class QuadraticExpression(BaseExpression):
             raise ValueError(f"Size of dimension {FACTOR_DIM} must be 2.")
 
         # transpose data to have _term as last dimension and _factor as second last
-        data = xr.Dataset(data.transpose(..., FACTOR_DIM, TERM_DIM))
+        data = data.transpose(..., FACTOR_DIM, TERM_DIM)
         self._data = data
 
     @property

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -2340,7 +2340,7 @@ def merge(
         LinearExpression | QuadraticExpression | variables.Variable | Dataset
     ],
     dim: str = TERM_DIM,
-    cls: type[GenericExpression] = None,  # type: ignore
+    cls: type[GenericExpression] | None = None,
     join: str | None = None,
     **kwargs: Any,
 ) -> GenericExpression:
@@ -2384,7 +2384,7 @@ def merge(
     has_quad_expression = any(type(e) is QuadraticExpression for e in exprs)
     has_linear_expression = any(type(e) is LinearExpression for e in exprs)
     if cls is None:
-        cls = QuadraticExpression if has_quad_expression else LinearExpression
+        cls = QuadraticExpression if has_quad_expression else LinearExpression  # type: ignore[assignment]
 
     if cls is QuadraticExpression and dim == TERM_DIM and has_linear_expression:
         raise ValueError(
@@ -2445,6 +2445,7 @@ def merge(
     for d in set(HELPER_DIMS) & set(ds.coords):
         ds = ds.reset_index(d, drop=True)
 
+    assert cls is not None
     return cls(ds, model)
 
 

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -359,7 +359,7 @@ class Model:
         """
         Set the parameters of the model.
         """
-        self._parameters = Dataset(value)
+        self._parameters = value if isinstance(value, Dataset) else Dataset(value)
 
     @property
     def solution(self) -> Dataset:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ docs = [
     "gurobipy>=13.0.0",
     "ipykernel==6.29.5",
     "matplotlib==3.9.1",
-    "highspy>=1.7.1,!=1.14.0",
+    "highspy>=1.7.1",
 ]
 dev = [
     "pytest",
@@ -74,7 +74,7 @@ dev = [
     "types-paramiko",
     "types-requests",
     "gurobipy",
-    "highspy!=1.14.0",
+    "highspy",
 ]
 benchmarks = [
     "pytest-benchmark",
@@ -82,8 +82,8 @@ benchmarks = [
 ]
 solvers = [
     "gurobipy",
-    "highspy>=1.5.0,!=1.14.0; python_version < '3.12'",
-    "highspy>=1.7.1,!=1.14.0; python_version >= '3.12'",
+    "highspy>=1.5.0; python_version < '3.12'",
+    "highspy>=1.7.1; python_version >= '3.12'",
     "cplex; platform_system != 'Darwin' and python_version < '3.12'",
     "mosek",
     "mindoptpy; python_version < '3.12'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ docs = [
     "gurobipy>=13.0.0",
     "ipykernel==6.29.5",
     "matplotlib==3.9.1",
-    "highspy>=1.7.1",
+    "highspy>=1.7.1,!=1.14.0",
 ]
 dev = [
     "pytest",
@@ -74,7 +74,7 @@ dev = [
     "types-paramiko",
     "types-requests",
     "gurobipy",
-    "highspy",
+    "highspy!=1.14.0",
 ]
 benchmarks = [
     "pytest-benchmark",
@@ -82,8 +82,8 @@ benchmarks = [
 ]
 solvers = [
     "gurobipy",
-    "highspy>=1.5.0; python_version < '3.12'",
-    "highspy>=1.7.1; python_version >= '3.12'",
+    "highspy>=1.5.0,!=1.14.0; python_version < '3.12'",
+    "highspy>=1.7.1,!=1.14.0; python_version >= '3.12'",
     "cplex; platform_system != 'Darwin' and python_version < '3.12'",
     "mosek",
     "mindoptpy; python_version < '3.12'",


### PR DESCRIPTION
## Summary

Closes #650

- xarray 2026.4.0 no longer allows passing a `Dataset` to the `Dataset()` constructor ([xarray GH11095](https://github.com/pydata/xarray/pull/11095))
- Remove redundant `Dataset()` wrappers around `transpose()` and `assign_coords()` calls that already return a `Dataset`
- Add `isinstance` check in `Model.parameters` setter where input may be either a `Dataset` or a `Mapping`

**Note:** Pre-existing CI failures unrelated to this change:
- mypy type error: #652
- HiGHS test failure: #651 (fixed in #653)

## Test plan

- [x] Full test suite passes with xarray 2026.4.0 (2689 passed, 236 skipped)
- [ ] CI confirms compatibility across supported Python/xarray versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)