### PR TITLE
fix: exclude highspy 1.14.0 due to suboptimal MIP solutions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ docs = [
     "gurobipy>=13.0.0",
     "ipykernel==6.29.5",
     "matplotlib==3.9.1",
-    "highspy>=1.7.1",
+    "highspy>=1.7.1,!=1.14.0",
 ]
 dev = [
     "pytest",
@@ -74,7 +74,7 @@ dev = [
     "types-paramiko",
     "types-requests",
     "gurobipy",
-    "highspy",
+    "highspy!=1.14.0",
 ]
 benchmarks = [
     "pytest-benchmark",
@@ -82,8 +82,8 @@ benchmarks = [
 ]
 solvers = [
     "gurobipy",
-    "highspy>=1.5.0; python_version < '3.12'",
-    "highspy>=1.7.1; python_version >= '3.12'",
+    "highspy>=1.5.0,!=1.14.0; python_version < '3.12'",
+    "highspy>=1.7.1,!=1.14.0; python_version >= '3.12'",
     "cplex; platform_system != 'Darwin' and python_version < '3.12'",
     "mosek",
     "mindoptpy; python_version < '3.12'",


### PR DESCRIPTION
## Summary

Closes #651

- highspy 1.14.0 returns suboptimal solutions for modified MIP models (`x=1, y=9` instead of optimal `x=0, y=10`)
- Exclude `!=1.14.0` from all dependency groups: docs, dev, and solvers
- Affects `test_modified_model[highs-*]` across all platforms and Python versions on CI

## Test plan

- [ ] CI passes with highspy != 1.14.0
- [ ] Re-evaluate when highspy 1.15.0+ is released

🤖 Generated with [Claude Code](https://claude.com/claude-code)