### PR TITLE
feat: add __weakref__ to Model.__slots__

### DIFF
--- a/linopy/model.py
+++ b/linopy/model.py
@@ -231,6 +231,9 @@ class Model:
         "solver_model",
         "solver_name",
         "matrices",
+        # allow weak references to Model instances so third-party extensions
+        # can attach per-instance state via WeakKeyDictionary
+        "__weakref__",
     )
 
     def __init__(

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -6,6 +6,7 @@ Test function defined in the Model class.
 from __future__ import annotations
 
 import copy as pycopy
+import weakref
 from pathlib import Path
 from tempfile import gettempdir
 
@@ -39,6 +40,25 @@ def test_model_solver_dir() -> None:
     d: str = gettempdir()
     m: Model = Model(solver_dir=d)
     assert m.solver_dir == Path(d)
+
+
+def test_model_is_weakrefable() -> None:
+    m: Model = Model()
+    ref = weakref.ref(m)
+    assert ref() is m
+
+
+def test_model_weakkeydict_use_case() -> None:
+    # third-party extensions rely on WeakKeyDictionary for per-instance storage
+    registry: weakref.WeakKeyDictionary[Model, str] = weakref.WeakKeyDictionary()
+    m: Model = Model()
+    registry[m] = "extension-state"
+    assert registry[m] == "extension-state"
+    del m
+    import gc
+
+    gc.collect()
+    assert len(registry) == 0
 
 
 def test_model_variable_getitem() -> None:


### PR DESCRIPTION
## Summary
- Add `__weakref__` to `Model.__slots__` so `weakref.ref(model)` and `WeakKeyDictionary` keyed by `Model` work.
- Enables third-party accessor-style extensions to attach per-instance state without forcing users to subclass `Model` or reintroduce `__dict__`.

Closes #655

## Test plan
- [x] `test_model_is_weakrefable` — `weakref.ref(Model())` returns a live reference.
- [x] `test_model_weakkeydict_use_case` — entries in a `WeakKeyDictionary[Model, ...]` are GC'd when the model is deleted.
- [x] Full `test/test_model.py` suite still passes (20 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)