### PR TITLE
fix: xarray 2026.4 Dataset-into-Dataset TypeError

### DIFF
--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -284,7 +284,7 @@ class LinearExpressionGroupby:
                 index.names = [str(col) for col in orig_group.columns]
                 index.name = GROUP_DIM
                 new_coords = Coordinates.from_pandas_multiindex(index, GROUP_DIM)
-                ds = xr.Dataset(ds.assign_coords(new_coords))
+                ds = ds.assign_coords(new_coords)
 
             ds = ds.rename({GROUP_DIM: final_group_name})
             return LinearExpression(ds, self.model)
@@ -391,8 +391,8 @@ class BaseExpression(ABC):
         coeffs_vars_dict = {str(k): v for k, v in coeffs_vars.items()}
         data = assign_multiindex_safe(data, **coeffs_vars_dict)
 
-        # transpose with new Dataset to really ensure correct order
-        data = Dataset(data.transpose(..., TERM_DIM))
+        # transpose to ensure correct dimension order
+        data = data.transpose(..., TERM_DIM)
 
         # ensure helper dimensions are not set as coordinates
         if drop_dims := set(HELPER_DIMS).intersection(data.coords):
@@ -2098,7 +2098,7 @@ class QuadraticExpression(BaseExpression):
             raise ValueError(f"Size of dimension {FACTOR_DIM} must be 2.")
 
         # transpose data to have _term as last dimension and _factor as second last
-        data = xr.Dataset(data.transpose(..., FACTOR_DIM, TERM_DIM))
+        data = data.transpose(..., FACTOR_DIM, TERM_DIM)
         self._data = data
 
     @property

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -359,7 +359,9 @@ class Model:
         """
         Set the parameters of the model.
         """
-        self._parameters = Dataset(value)
+        self._parameters = (
+            value.copy() if isinstance(value, Dataset) else Dataset(value)
+        )
 
     @property
     def solution(self) -> Dataset:


### PR DESCRIPTION
## Summary
xarray 2026.4.0 now raises `TypeError: Passing a Dataset as 'data_vars' to the Dataset constructor is not supported` when an existing `Dataset` is passed to `Dataset()`. This broke `linopy.Model()` construction and the RTD docs build (see #656).

Three call sites in `expressions.py` wrapped an already-Dataset return from `.transpose()` / `.assign_coords()` in a redundant `Dataset(...)`. The `Model.parameters` setter also wrapped a potential `Dataset` input — switched to `.copy()` in that branch.

## Changes
- `linopy/expressions.py:287` — drop `xr.Dataset(...)` wrap around `ds.assign_coords(new_coords)`
- `linopy/expressions.py:395` — drop `Dataset(...)` wrap around `data.transpose(..., TERM_DIM)`
- `linopy/expressions.py:2101` — drop `xr.Dataset(...)` wrap around `data.transpose(..., FACTOR_DIM, TERM_DIM)`
- `linopy/model.py:362` — `Model.parameters` setter now uses `.copy()` for Dataset inputs

## Test plan
- [x] `Model()` constructs under xarray 2026.4.0
- [x] Full non-solver test suite passes (1252 passed, 7 skipped) — exercises the previously-broken groupby-with-dataframe path
- [ ] RTD docs build succeeds on the PR preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)