### PR TITLE
fix: compute a single IIS in Xpress infeasibility path

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -24,6 +24,7 @@ Upcoming Version
 * Forward ``solver_name`` and ``**solver_options`` from ``Model.solve()`` to OETC handler. Call-level options override settings-level defaults.
 * Improve handling of CPLEX solver quality attributes to ensure metrics such are extracted correctly when available.
 * Fix Xpress IIS label mapping for masked constraints and add a regression test for matching infeasible coordinates.
+* Fix ``Model.compute_infeasibilities`` returning a flattened, deduplicated union of all IIS when Xpress found more than one. The Xpress path now computes a single IIS (via ``firstIIS``), matching the Gurobi path.
 * Enable quadratic problems with SCIP on windows.
 * Add ``format_labels()`` on ``Constraints``/``Variables`` and ``format_infeasibilities()`` on ``Model`` that return strings instead of printing to stdout, allowing usage with logging, storage, or custom output handling. Deprecate ``print_labels()`` and ``print_infeasibilities()``.
 * Add ``fix()``, ``unfix()``, and ``fixed`` to ``Variable`` and ``Variables`` for fixing variables to values via equality constraints. Supports automatic rounding for integer/binary variables.

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -1816,18 +1816,16 @@ class Model:
         be skipped (e.g., labels [0, 2, 4] with gaps instead of sequential
         [0, 1, 2]).
         """
-        # Compute all IIS
+        # Compute a single IIS (matches Gurobi behavior; multiple IIS would
+        # otherwise get flattened into an ambiguous union). Mode 2 prioritises
+        # a fast IIS search over minimality.
         try:  # Try new API first
-            solver_model.IISAll()
+            solver_model.firstIIS(2)
         except AttributeError:  # Fallback to old API
-            solver_model.iisall()
+            solver_model.iisfirst(2)
 
-        # Get the number of IIS found
-        num_iis = solver_model.attributes.numiis
-        if num_iis == 0:
+        if solver_model.attributes.numiis == 0:
             return []
-
-        labels = set()
 
         clabels = self.matrices.clabels
         constraint_position_map = {}
@@ -1837,17 +1835,12 @@ class Model:
                 if constraint_label >= 0:
                     constraint_position_map[constraint_obj] = constraint_label
 
-        # Retrieve each IIS
-        for iis_num in range(1, num_iis + 1):
-            iis_constraints = self._extract_iis_constraints(solver_model, iis_num)
+        labels = set()
+        for constraint_obj in self._extract_iis_constraints(solver_model, 1):
+            if constraint_obj in constraint_position_map:
+                labels.add(constraint_position_map[constraint_obj])
 
-            for constraint_obj in iis_constraints:
-                if constraint_obj in constraint_position_map:
-                    labels.add(constraint_position_map[constraint_obj])
-                # Note: Silently skip constraints not found in mapping
-                # This can happen if the model structure changed after solving
-
-        return sorted(list(labels))
+        return sorted(labels)
 
     def _extract_iis_constraints(self, solver_model: Any, iis_num: int) -> list[Any]:
         """


### PR DESCRIPTION
## Changes proposed in this Pull Request

- `Model._compute_infeasibilities_xpress` now computes a single IIS via `firstIIS(2)` (new Xpress API) with `iisfirst(2)` as deprecated-API fallback, instead of calling `iisall()` and iterating every IIS.
- The previous code merged constraints from all IIS into one deduplicated `set`, flattening per-IIS grouping and returning an ambiguous union. With only one IIS computed, the returned `list[int]` matches the Gurobi path's semantics.
- Mode `2` asks Xpress for a proper IIS optimised for a quick result (mode `0` would return a non-minimal infeasible subproblem; mode `1` optimises for minimality at higher cost).
- Release note added under `Upcoming Version`.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.