### PR TITLE
fix: as_dataarray treating multi-index levels as extra dims

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -29,6 +29,7 @@ Upcoming Version
 * Add ``fix()``, ``unfix()``, and ``fixed`` to ``Variable`` and ``Variables`` for fixing variables to values via equality constraints. Supports automatic rounding for integer/binary variables.
 * Add ``relax()``, ``unrelax()``, and ``relaxed`` to ``Variable`` and ``Variables`` for LP relaxation of integer/binary variables. Supports partial relaxation via filtered views (e.g. ``m.variables.integers.relax()``). Semi-continuous variables raise ``NotImplementedError``.
 * Add compatibility to latest xarray version.
+* Fix ``as_dataarray`` treating multi-index level names as extra dimensions when broadcasting a scalar against ``xarray.Coordinates``.
 
 
 Version 0.6.6

--- a/linopy/common.py
+++ b/linopy/common.py
@@ -19,7 +19,7 @@ import numpy as np
 import pandas as pd
 import polars as pl
 from numpy import arange, nan, signedinteger
-from xarray import DataArray, Dataset, apply_ufunc, broadcast
+from xarray import Coordinates, DataArray, Dataset, apply_ufunc, broadcast
 from xarray import align as xr_align
 from xarray.core import dtypes, indexing
 from xarray.core.types import JoinOptions, T_Alignable
@@ -243,13 +243,14 @@ def as_dataarray(
         arr = numpy_to_dataarray(arr, coords=coords, dims=dims, **kwargs)
     elif isinstance(arr, pl.Series):
         arr = numpy_to_dataarray(arr.to_numpy(), coords=coords, dims=dims, **kwargs)
-    elif isinstance(arr, np.number):
-        if dims is None and is_dict_like(coords) and np.ndim(arr) == 0:
-            dims = list(coords.keys())
-        arr = DataArray(float(arr), coords=coords, dims=dims, **kwargs)
-    elif isinstance(arr, int | float | str | bool | list):
-        if dims is None and is_dict_like(coords) and np.ndim(arr) == 0:
-            dims = list(coords.keys())
+    elif isinstance(arr, np.number | int | float | str | bool | list):
+        if isinstance(arr, np.number):
+            arr = float(arr)
+        if dims is None:
+            if isinstance(coords, Coordinates):
+                dims = coords.dims
+            elif is_dict_like(coords) and np.ndim(arr) == 0:
+                dims = list(coords.keys())
         arr = DataArray(arr, coords=coords, dims=dims, **kwargs)
 
     elif not isinstance(arr, DataArray):

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -383,6 +383,16 @@ def test_as_dataarray_with_number_and_coords() -> None:
     assert list(da.coords["a"].values) == list(range(10))
 
 
+def test_as_dataarray_with_np_number_and_multiindex_coords() -> None:
+    """Level names in multi-index coords must not be treated as extra dims."""
+    mi = pd.MultiIndex.from_tuples([("a", 1), ("b", 2)], names=["letter", "num"])
+    source = DataArray([1.0, 2.0], coords={"station": mi}, dims="station")
+    da = as_dataarray(np.float64(3.0), coords=source.coords)
+    assert da.dims == ("station",)
+    assert da.shape == (2,)
+    assert (da.values == 3.0).all()
+
+
 def test_as_dataarray_with_dataarray() -> None:
     da_in = DataArray(
         data=[[1, 2], [3, 4]],

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -383,14 +383,66 @@ def test_as_dataarray_with_number_and_coords() -> None:
     assert list(da.coords["a"].values) == list(range(10))
 
 
-def test_as_dataarray_with_np_number_and_multiindex_coords() -> None:
+@pytest.mark.parametrize(
+    ("arr", "expected_values"),
+    [
+        (np.float64(3.0), [3.0, 3.0]),
+        (3, [3, 3]),
+        (3.0, [3.0, 3.0]),
+        (np.array([10.0, 20.0]), [10.0, 20.0]),
+    ],
+    ids=["np_number", "python_int", "python_float", "numpy_array"],
+)
+def test_as_dataarray_with_multiindex_coords(arr, expected_values) -> None:
     """Level names in multi-index coords must not be treated as extra dims."""
     mi = pd.MultiIndex.from_tuples([("a", 1), ("b", 2)], names=["letter", "num"])
     source = DataArray([1.0, 2.0], coords={"station": mi}, dims="station")
-    da = as_dataarray(np.float64(3.0), coords=source.coords)
+
+    da = as_dataarray(arr, coords=source.coords)
+
     assert da.dims == ("station",)
     assert da.shape == (2,)
+    assert set(da.coords.keys()) == {"station", "letter", "num"}
+    assert list(da.coords["letter"].values) == ["a", "b"]
+    assert list(da.coords["num"].values) == [1, 2]
+    assert da.coords["letter"].dims == ("station",)
+    assert da.coords["num"].dims == ("station",)
+    assert list(da.values) == expected_values
+
+
+@pytest.mark.parametrize(
+    "coords_factory",
+    [
+        lambda mi: xr.Coordinates.from_pandas_multiindex(mi, "station"),
+        lambda mi: {"station": mi},
+        lambda mi: DataArray([1.0, 2.0], coords={"station": mi}, dims="station").coords,
+    ],
+    ids=["xarray_Coordinates", "plain_dict", "dataarray_coords"],
+)
+def test_as_dataarray_with_various_multiindex_coord_inputs(coords_factory) -> None:
+    """Users may pass a MultiIndex via Coordinates, a dict, or another DataArray's coords."""
+    mi = pd.MultiIndex.from_tuples([("a", 1), ("b", 2)], names=["letter", "num"])
+    coords = coords_factory(mi)
+
+    da = as_dataarray(3.0, coords=coords)
+
+    assert da.dims == ("station",)
+    assert da.shape == (2,)
+    assert set(da.coords.keys()) == {"station", "letter", "num"}
+    assert da.coords["letter"].dims == ("station",)
+    assert da.coords["num"].dims == ("station",)
     assert (da.values == 3.0).all()
+
+
+def test_as_dataarray_with_scalar_and_explicit_dims_over_multiindex_coords() -> None:
+    """Explicit dims must win over any inference from Coordinates."""
+    mi = pd.MultiIndex.from_tuples([("a", 1), ("b", 2)], names=["letter", "num"])
+    source = DataArray([1.0, 2.0], coords={"station": mi}, dims="station")
+
+    da = as_dataarray(3.0, coords=source.coords, dims=["station"])
+    assert da.dims == ("station",)
+    assert da.shape == (2,)
+    assert set(da.coords.keys()) == {"station", "letter", "num"}
 
 
 def test_as_dataarray_with_dataarray() -> None:

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -5,6 +5,8 @@ Created on Mon Jun 19 12:11:03 2023
 @author: fabian
 """
 
+from collections.abc import Callable
+
 import numpy as np
 import pandas as pd
 import polars as pl
@@ -25,6 +27,7 @@ from linopy.common import (
     maybe_group_terms_polars,
 )
 from linopy.testing import assert_linequal, assert_varequal
+from linopy.types import CoordsLike
 
 
 def test_as_dataarray_with_series_dims_default() -> None:
@@ -393,7 +396,9 @@ def test_as_dataarray_with_number_and_coords() -> None:
     ],
     ids=["np_number", "python_int", "python_float", "numpy_array"],
 )
-def test_as_dataarray_with_multiindex_coords(arr, expected_values) -> None:
+def test_as_dataarray_with_multiindex_coords(
+    arr: object, expected_values: list[float]
+) -> None:
     """Level names in multi-index coords must not be treated as extra dims."""
     mi = pd.MultiIndex.from_tuples([("a", 1), ("b", 2)], names=["letter", "num"])
     source = DataArray([1.0, 2.0], coords={"station": mi}, dims="station")
@@ -419,7 +424,9 @@ def test_as_dataarray_with_multiindex_coords(arr, expected_values) -> None:
     ],
     ids=["xarray_Coordinates", "plain_dict", "dataarray_coords"],
 )
-def test_as_dataarray_with_various_multiindex_coord_inputs(coords_factory) -> None:
+def test_as_dataarray_with_various_multiindex_coord_inputs(
+    coords_factory: Callable[[pd.MultiIndex], CoordsLike],
+) -> None:
     """Users may pass a MultiIndex via Coordinates, a dict, or another DataArray's coords."""
     mi = pd.MultiIndex.from_tuples([("a", 1), ("b", 2)], names=["letter", "num"])
     coords = coords_factory(mi)


### PR DESCRIPTION
## Changes proposed in this Pull Request

When `as_dataarray` is given a scalar (`np.number`, `int`, `float`, `bool`, `str`, or `list`) together with an `xarray.Coordinates` object whose underlying index is a pandas `MultiIndex`, it inferred dims from `coords.keys()`. That includes the level names, so a scalar with `station` coords containing levels `letter`/`num` was broadcast to shape `(2, 2, 2)` over `('station', 'letter', 'num')` instead of `(2,)` over `('station',)`.

- Use `coords.dims` when `coords` is an `xarray.Coordinates` instance so only real dimensions are used.
- Merge the `np.number` and `int | float | str | bool | list` branches of `as_dataarray` into one, now that both need the same dim resolution.
- Add a regression test in `test_common.py` covering the scalar + multi-index `Coordinates` case.
- Release note added.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.