### PR TITLE
fix: raise clear error when solving model without objective

### DIFF
--- a/examples/infeasible-model.ipynb
+++ b/examples/infeasible-model.ipynb
@@ -19,21 +19,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import pandas as pd\n",
-    "\n",
-    "import linopy\n",
-    "\n",
-    "m = linopy.Model()\n",
-    "\n",
-    "time = pd.RangeIndex(10, name=\"time\")\n",
-    "x = m.add_variables(lower=0, coords=[time], name=\"x\")\n",
-    "y = m.add_variables(lower=0, coords=[time], name=\"y\")\n",
-    "\n",
-    "m.add_constraints(x <= 5)\n",
-    "m.add_constraints(y <= 5)\n",
-    "m.add_constraints(x + y >= 12)"
-   ]
+   "source": "import pandas as pd\n\nimport linopy\n\nm = linopy.Model()\n\ntime = pd.RangeIndex(10, name=\"time\")\nx = m.add_variables(lower=0, coords=[time], name=\"x\")\ny = m.add_variables(lower=0, coords=[time], name=\"y\")\n\nm.add_constraints(x <= 5)\nm.add_constraints(y <= 5)\nm.add_constraints(x + y >= 12)\n\n# A trivial objective is required; the model is solved purely to check feasibility.\nm.add_objective(0 * x)"
   },
   {
    "attachments": {},

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -1484,6 +1484,12 @@ class Model:
                 sanitize_zeros=sanitize_zeros, sanitize_infinities=sanitize_infinities
             )
 
+        if self.objective.expression.empty:
+            raise ValueError(
+                "No objective has been set on the model. Use `m.add_objective(...)` "
+                "first (e.g. `m.add_objective(0 * x)` for a pure feasibility problem)."
+            )
+
         # clear cached matrix properties potentially present from previous solve commands
         self.matrices.clean_cached_properties()
 

--- a/test/test_infeasibility.py
+++ b/test/test_infeasibility.py
@@ -210,6 +210,7 @@ class TestInfeasibility:
         x = m.add_variables(name="x")
         m.add_constraints(x >= 0)
         m.add_constraints(x <= -1)  # Make it infeasible
+        m.add_objective(1 * x)
 
         # Use a solver that doesn't support IIS
         if "cbc" in available_solvers:

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -113,6 +113,14 @@ def test_objective() -> None:
         m.objective = m.objective + 3
 
 
+def test_solve_without_objective_raises() -> None:
+    # https://github.com/PyPSA/linopy/issues/668
+    m: Model = Model()
+    m.add_variables(lower=0, upper=10, name="myvar")
+    with pytest.raises(ValueError, match="No objective has been set"):
+        m.solve()
+
+
 def test_remove_variable() -> None:
     m: Model = Model()
 

--- a/test/test_oetc_settings.py
+++ b/test/test_oetc_settings.py
@@ -300,7 +300,8 @@ def test_model_solve_forwards_to_oetc() -> None:
     from linopy import Model
 
     m = Model()
-    m.add_variables(lower=0, name="x")
+    x = m.add_variables(lower=0, name="x")
+    m.add_objective(1 * x)
 
     handler = MagicMock(spec=OetcHandler)
     mock_solved = MagicMock()


### PR DESCRIPTION
## Summary
- `Model.solve()` now raises `ValueError` early when no objective has been set, instead of silently writing a malformed LP file with a phantom `x` variable that later crashes `set_int_index`.
- The error message points users to `m.add_objective(...)`, with `m.add_objective(0 * x)` suggested for the pure-feasibility use case.
- Updated `examples/infeasible-model.ipynb` to set `m.add_objective(0 * x)` before its feasibility-check solve.
- Added a regression test in `test/test_model.py`.

Fixes #668

## Alternatives considered
1. **Filter null `vars` rows out of the objective polars df in `objective_write_linear_terms`.** Smallest possible fix — the LP file would no longer contain a phantom `x`. Rejected because it leaves an empty `obj:` block whose acceptance varies across solvers/formats, and because silently solving a zero-objective hides what is almost always a user bug.
2. **Write a no-op `+0 x0` term when the objective is empty.** Avoids the empty-block fragility, but still treats "forgot to set objective" as valid input. Same hide-the-bug objection as (1).
3. **Raise the error (chosen).** Makes the omission explicit. Trivial escape hatch (`m.add_objective(0 * x)`) for users who genuinely want a feasibility solve, which is exactly what the updated example notebook now demonstrates.

## Test plan
- [x] `pytest test/test_model.py -k objective` passes locally
- [x] `pytest test/test_oetc_settings.py::test_model_solve_forwards_to_oetc` passes (test was updated to add an objective)
- [x] Manual repro from the issue now raises a clear `ValueError` instead of `invalid literal for int() with base 10: 'x'`
- [x] `examples/infeasible-model.ipynb` executes end-to-end after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)