### PR TITLE
feat: add slopes_align to breakpoints()

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -17,7 +17,6 @@ Upcoming Version
 * Surface formulation metadata on the returned ``PiecewiseFormulation``: ``.method`` (resolved method name) and ``.convexity`` (``"convex"`` / ``"concave"`` / ``"linear"`` / ``"mixed"`` when well-defined).  Both persist across netCDF round-trip.
 * Add ``tangent_lines()`` as a low-level helper that returns per-piece chord expressions as a ``LinearExpression`` — no variables created.  Most users should prefer ``add_piecewise_formulation`` with a bounded tuple ``(y, y_pts, "<=")``, which builds on this helper and adds domain bounds and curvature validation.
 * Add ``linopy.breakpoints()`` (lists/Series/DataFrame/DataArray/dict, plus a slopes-mode constructor), ``linopy.segments()`` (disjunctive operating regions), and ``slopes_to_points()`` (per-piece slopes → breakpoint y-coordinates) as breakpoint-construction helpers.
-* Add ``slopes_align`` keyword to ``linopy.breakpoints()``. With ``slopes_align="leading"``, ``slopes`` may have the same length as ``x_points`` where ``slopes[0]`` is a NaN sentinel that is dropped — useful when a marginal value is tabulated alongside each breakpoint.
 * Add the `sphinx-copybutton` to the documentation
 * Add SOS1 and SOS2 reformulations for solvers not supporting them.
 * Add semi-continous variables for solvers that support them

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -17,6 +17,7 @@ Upcoming Version
 * Surface formulation metadata on the returned ``PiecewiseFormulation``: ``.method`` (resolved method name) and ``.convexity`` (``"convex"`` / ``"concave"`` / ``"linear"`` / ``"mixed"`` when well-defined).  Both persist across netCDF round-trip.
 * Add ``tangent_lines()`` as a low-level helper that returns per-piece chord expressions as a ``LinearExpression`` — no variables created.  Most users should prefer ``add_piecewise_formulation`` with a bounded tuple ``(y, y_pts, "<=")``, which builds on this helper and adds domain bounds and curvature validation.
 * Add ``linopy.breakpoints()`` (lists/Series/DataFrame/DataArray/dict, plus a slopes-mode constructor), ``linopy.segments()`` (disjunctive operating regions), and ``slopes_to_points()`` (per-piece slopes → breakpoint y-coordinates) as breakpoint-construction helpers.
+* Add ``slopes_align`` keyword to ``linopy.breakpoints()``. With ``slopes_align="leading"``, ``slopes`` may have the same length as ``x_points`` where ``slopes[0]`` is a NaN sentinel that is dropped — useful when a marginal value is tabulated alongside each breakpoint.
 * Add the `sphinx-copybutton` to the documentation
 * Add SOS1 and SOS2 reformulations for solvers not supporting them.
 * Add semi-continous variables for solvers that support them

--- a/linopy/piecewise.py
+++ b/linopy/piecewise.py
@@ -332,9 +332,7 @@ def _breakpoints_from_slopes(
 
     if slopes_align == "leading":
         if slopes_arr.sizes[BREAKPOINT_DIM] == 0:
-            raise ValueError(
-                "slopes_align='leading' requires at least one slope entry"
-            )
+            raise ValueError("slopes_align='leading' requires at least one slope entry")
         first_slope = slopes_arr.isel({BREAKPOINT_DIM: 0})
         if not bool(first_slope.isnull().all()):
             raise ValueError(

--- a/linopy/piecewise.py
+++ b/linopy/piecewise.py
@@ -324,10 +324,24 @@ def _breakpoints_from_slopes(
     x_points: BreaksLike,
     y0: float | dict[str, float] | pd.Series | DataArray,
     dim: str | None,
+    slopes_align: Literal["pieces", "leading"] = "pieces",
 ) -> DataArray:
     """Convert slopes + x_points + y0 into a breakpoint DataArray."""
     slopes_arr = _coerce_breaks(slopes, dim)
     xp_arr = _coerce_breaks(x_points, dim)
+
+    if slopes_align == "leading":
+        if slopes_arr.sizes[BREAKPOINT_DIM] == 0:
+            raise ValueError(
+                "slopes_align='leading' requires at least one slope entry"
+            )
+        first_slope = slopes_arr.isel({BREAKPOINT_DIM: 0})
+        if not bool(first_slope.isnull().all()):
+            raise ValueError(
+                "slopes_align='leading' requires the first slope of each "
+                "entity to be NaN"
+            )
+        slopes_arr = slopes_arr.isel({BREAKPOINT_DIM: slice(1, None)})
 
     # 1D case: single set of breakpoints
     if slopes_arr.ndim == 1:
@@ -420,6 +434,7 @@ def breakpoints(
     x_points: BreaksLike | None = None,
     y0: float | dict[str, float] | pd.Series | DataArray | None = None,
     dim: str | None = None,
+    slopes_align: Literal["pieces", "leading"] = "pieces",
 ) -> DataArray:
     """
     Create a breakpoint DataArray for piecewise linear constraints.
@@ -448,6 +463,16 @@ def breakpoints(
     dim : str, optional
         Entity dimension name. Required when ``values`` or ``slopes`` is a
         ``pd.DataFrame`` or ``dict``.
+    slopes_align : {"pieces", "leading"}, default "pieces"
+        Alignment of ``slopes`` relative to ``x_points``.
+
+        - ``"pieces"``: ``len(slopes) == len(x_points) - 1``. ``slopes[i]``
+          is the slope between ``x[i]`` and ``x[i+1]``.
+        - ``"leading"``: ``len(slopes) == len(x_points)``. ``slopes[0]``
+          must be NaN and is ignored; ``slopes[i]`` for ``i>=1`` is the
+          slope between ``x[i-1]`` and ``x[i]``. Useful when a marginal
+          value is tabulated alongside each breakpoint with the first
+          row's marginal undefined.
 
     Returns
     -------
@@ -458,10 +483,12 @@ def breakpoints(
         raise ValueError("'values' and 'slopes' are mutually exclusive")
     if values is not None and (x_points is not None or y0 is not None):
         raise ValueError("'x_points' and 'y0' are forbidden when 'values' is given")
+    if slopes_align != "pieces" and slopes is None:
+        raise ValueError("'slopes_align' is only valid in slopes mode")
     if slopes is not None:
         if x_points is None or y0 is None:
             raise ValueError("'slopes' requires both 'x_points' and 'y0'")
-        return _breakpoints_from_slopes(slopes, x_points, y0, dim)
+        return _breakpoints_from_slopes(slopes, x_points, y0, dim, slopes_align)
 
     # Points mode
     if values is None:

--- a/test/test_piecewise_constraints.py
+++ b/test/test_piecewise_constraints.py
@@ -223,6 +223,66 @@ class TestBreakpointsFactory:
 
 
 # ===========================================================================
+# breakpoints(slopes_align="leading")
+# ===========================================================================
+
+
+class TestSlopesAlignLeading:
+    """
+    `slopes_align="leading"` accepts slopes of length len(x_points),
+    where slopes[0] is a NaN sentinel that gets dropped.
+    """
+
+    def test_1d_matches_pieces(self) -> None:
+        leading = breakpoints(
+            slopes=[np.nan, 1, 2], x_points=[0, 1, 2], y0=0, slopes_align="leading"
+        )
+        pieces = breakpoints(slopes=[1, 2], x_points=[0, 1, 2], y0=0)
+        xr.testing.assert_equal(leading, pieces)
+
+    def test_dict_ragged(self) -> None:
+        bp = breakpoints(
+            slopes={"a": [np.nan, 1, 0.5], "b": [np.nan, 2]},
+            x_points={"a": [0, 10, 50], "b": [0, 20]},
+            y0={"a": 0, "b": 10},
+            dim="gen",
+            slopes_align="leading",
+        )
+        np.testing.assert_allclose(bp.sel(gen="a").values, [0, 10, 30])
+        np.testing.assert_allclose(
+            bp.sel(gen="b").dropna(BREAKPOINT_DIM).values, [10, 50]
+        )
+
+    def test_dataarray(self) -> None:
+        slopes_da = xr.DataArray(
+            [[np.nan, 1, 2], [np.nan, 3, 4]],
+            dims=["gen", BREAKPOINT_DIM],
+            coords={"gen": ["a", "b"], BREAKPOINT_DIM: [0, 1, 2]},
+        )
+        xp_da = xr.DataArray(
+            [[0, 1, 2], [0, 1, 2]],
+            dims=["gen", BREAKPOINT_DIM],
+            coords={"gen": ["a", "b"], BREAKPOINT_DIM: [0, 1, 2]},
+        )
+        y0_da = xr.DataArray([0, 5], dims=["gen"], coords={"gen": ["a", "b"]})
+        bp = breakpoints(
+            slopes=slopes_da, x_points=xp_da, y0=y0_da, slopes_align="leading"
+        )
+        np.testing.assert_allclose(bp.sel(gen="a").values, [0, 1, 3])
+        np.testing.assert_allclose(bp.sel(gen="b").values, [5, 8, 12])
+
+    def test_non_nan_first_slope_raises(self) -> None:
+        with pytest.raises(ValueError, match="first slope"):
+            breakpoints(
+                slopes=[1, 2, 3], x_points=[0, 1, 2], y0=0, slopes_align="leading"
+            )
+
+    def test_without_slopes_mode_raises(self) -> None:
+        with pytest.raises(ValueError, match="only valid in slopes mode"):
+            breakpoints([0, 1, 2], slopes_align="leading")
+
+
+# ===========================================================================
 # segments() factory
 # ===========================================================================
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

Adds a new ``slopes_align`` keyword to ``linopy.breakpoints()`` to support an alternative slope-to-breakpoint alignment convention.

- ``slopes_align="pieces"`` (default, unchanged): ``len(slopes) == len(x_points) - 1``; ``slopes[i]`` is the slope between ``x[i]`` and ``x[i+1]``.
- ``slopes_align="leading"``: ``len(slopes) == len(x_points)``; ``slopes[0]`` must be NaN and is dropped, ``slopes[i]`` for ``i>=1`` is the slope between ``x[i-1]`` and ``x[i]``.

The "leading" mode matches the common convention where a marginal value is tabulated alongside each breakpoint with the first row's marginal undefined. It removes the manual ``shift(-1)`` callers (e.g. PyPSA) currently apply before passing slopes to ``breakpoints``.

Validation:
- ``slopes_align`` is rejected outside slopes mode.
- The first slope of each entity must be NaN under ``"leading"``; otherwise a ``ValueError`` is raised.

Per-entity NaN-stripping logic and ragged-input handling are unchanged — the alignment is normalized up front by slicing position 0 along the breakpoint dim.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.