### PR TITLE
fix: serialize MultiIndex level names as JSON for scipy netCDF backend

### DIFF
--- a/linopy/io.py
+++ b/linopy/io.py
@@ -1124,8 +1124,7 @@ def to_netcdf(m: Model, *args: Any, **kwargs: Any) -> None:
                 prefix_len = len(prefix) + 1  # leave original index level name
                 names = [n[prefix_len:] for n in ds[dim].to_index().names]
                 ds = ds.reset_index(dim)
-                # Store as JSON string for compatibility with the scipy
-                # netCDF3 backend, which cannot write unicode-array attrs.
+                # scipy netCDF3 backend cannot write unicode-array attrs.
                 ds.attrs[f"{dim}_multiindex"] = json.dumps(list(names))
 
         return ds
@@ -1206,8 +1205,7 @@ def read_netcdf(path: Path | str, **kwargs: Any) -> Model:
         return k[len(prefix) + 1 :]
 
     def parse_multiindex_attr(value: str | Iterable[str]) -> list[str]:
-        # New format: JSON-encoded string. Legacy format: list/array of names
-        # (e.g. files written by older linopy via the netCDF4 backend).
+        # str = JSON (new); iterable = legacy list from older linopy.
         if isinstance(value, str):
             return [str(n) for n in json.loads(value)]
         return [str(n) for n in value]
@@ -1233,9 +1231,6 @@ def read_netcdf(path: Path | str, **kwargs: Any) -> Model:
         for dim in ds.dims:
             if f"{dim}_multiindex" in ds.attrs:
                 names = parse_multiindex_attr(ds.attrs.pop(f"{dim}_multiindex"))
-                # mypy: dict-invariance trips xarray's
-                # Mapping[Any, Hashable | Sequence[Hashable]] stub even though
-                # list[str] is a valid Sequence[Hashable].
                 ds = ds.set_index({dim: names})  # type: ignore[dict-item]
 
         return ds

--- a/linopy/io.py
+++ b/linopy/io.py
@@ -1124,7 +1124,9 @@ def to_netcdf(m: Model, *args: Any, **kwargs: Any) -> None:
                 prefix_len = len(prefix) + 1  # leave original index level name
                 names = [n[prefix_len:] for n in ds[dim].to_index().names]
                 ds = ds.reset_index(dim)
-                ds.attrs[f"{dim}_multiindex"] = list(names)
+                # Store as JSON string for compatibility with the scipy
+                # netCDF3 backend, which cannot write unicode-array attrs.
+                ds.attrs[f"{dim}_multiindex"] = json.dumps(list(names))
 
         return ds
 
@@ -1203,11 +1205,20 @@ def read_netcdf(path: Path | str, **kwargs: Any) -> Model:
     def remove_prefix(k: str, prefix: str) -> str:
         return k[len(prefix) + 1 :]
 
+    def parse_multiindex_attr(value: Any) -> list[str]:
+        # New format: JSON-encoded string. Legacy format: list/array of names.
+        if isinstance(value, str):
+            return list(json.loads(value))
+        return list(value)
+
     def get_prefix(ds: xr.Dataset, prefix: str) -> xr.Dataset:
         ds = ds[[k for k in ds if has_prefix(str(k), prefix)]]
         multiindexes = []
         for dim in ds.dims:
-            for name in ds.attrs.get(f"{dim}_multiindex", []):
+            attr = ds.attrs.get(f"{dim}_multiindex")
+            if attr is None:
+                continue
+            for name in parse_multiindex_attr(attr):
                 multiindexes.append(prefix + "-" + name)
         ds = ds.drop_vars(set(ds.coords) - set(ds.dims) - set(multiindexes))
         to_rename = set([*ds.dims, *ds.coords, *ds])
@@ -1220,7 +1231,7 @@ def read_netcdf(path: Path | str, **kwargs: Any) -> Model:
 
         for dim in ds.dims:
             if f"{dim}_multiindex" in ds.attrs:
-                names = ds.attrs.pop(f"{dim}_multiindex")
+                names = parse_multiindex_attr(ds.attrs.pop(f"{dim}_multiindex"))
                 ds = ds.set_index({dim: names})
 
         return ds

--- a/linopy/io.py
+++ b/linopy/io.py
@@ -10,7 +10,7 @@ import logging
 import shutil
 import time
 import warnings
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from io import BufferedWriter
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -1205,11 +1205,12 @@ def read_netcdf(path: Path | str, **kwargs: Any) -> Model:
     def remove_prefix(k: str, prefix: str) -> str:
         return k[len(prefix) + 1 :]
 
-    def parse_multiindex_attr(value: Any) -> list[str]:
-        # New format: JSON-encoded string. Legacy format: list/array of names.
+    def parse_multiindex_attr(value: str | Iterable[str]) -> list[str]:
+        # New format: JSON-encoded string. Legacy format: list/array of names
+        # (e.g. files written by older linopy via the netCDF4 backend).
         if isinstance(value, str):
-            return list(json.loads(value))
-        return list(value)
+            return [str(n) for n in json.loads(value)]
+        return [str(n) for n in value]
 
     def get_prefix(ds: xr.Dataset, prefix: str) -> xr.Dataset:
         ds = ds[[k for k in ds if has_prefix(str(k), prefix)]]

--- a/linopy/io.py
+++ b/linopy/io.py
@@ -1233,7 +1233,10 @@ def read_netcdf(path: Path | str, **kwargs: Any) -> Model:
         for dim in ds.dims:
             if f"{dim}_multiindex" in ds.attrs:
                 names = parse_multiindex_attr(ds.attrs.pop(f"{dim}_multiindex"))
-                ds = ds.set_index({dim: names})
+                # mypy: dict-invariance trips xarray's
+                # Mapping[Any, Hashable | Sequence[Hashable]] stub even though
+                # list[str] is a valid Sequence[Hashable].
+                ds = ds.set_index({dim: names})  # type: ignore[dict-item]
 
         return ds
 

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -142,10 +142,7 @@ def test_model_to_netcdf_with_multiindex(
     assert_model_equal(m, p)
 
 
-# Regression test for https://github.com/PyPSA/linopy/issues/525: when only
-# scipy is installed (no netCDF4 / h5netcdf), xarray falls back to scipy's
-# netCDF3 backend, which cannot write unicode-array attributes. MultiIndex
-# level names must therefore be serialised as a scalar string.
+# Regression for https://github.com/PyPSA/linopy/issues/525.
 def test_model_to_netcdf_with_multiindex_scipy_engine(
     model_with_multiindex: Model, tmp_path: Path
 ) -> None:
@@ -153,46 +150,33 @@ def test_model_to_netcdf_with_multiindex_scipy_engine(
     fn = tmp_path / "test.nc"
     m.to_netcdf(fn, engine="scipy")
 
-    # Confirm the on-disk attr is a scalar string, not a unicode array — this
-    # is what makes the file writable by scipy in the first place.
-    with xr.load_dataset(fn) as raw:
-        multiindex_attrs = {
-            k: v for k, v in raw.attrs.items() if k.endswith("_multiindex")
-        }
-    assert multiindex_attrs, "expected at least one *_multiindex attr"
+    raw_attrs = xr.load_dataset(fn).attrs
+    multiindex_attrs = {k: v for k, v in raw_attrs.items() if k.endswith("_multiindex")}
+    assert multiindex_attrs
     for k, v in multiindex_attrs.items():
-        assert isinstance(v, str), f"{k}={v!r} should be a JSON-encoded string"
+        assert isinstance(v, str), f"{k!r}: {v!r}"
 
-    p = read_netcdf(fn)
-    assert_model_equal(m, p)
+    assert_model_equal(m, read_netcdf(fn))
 
 
-# Files written by older linopy versions stored MultiIndex level names as a
-# Python list of strings (which round-trips through netCDF4 but not scipy).
-# read_netcdf must keep accepting that legacy form so existing files don't
-# break after this change.
 @pytest.mark.skipif(not HAS_NETCDF4, reason="legacy format requires netCDF4 backend")
 def test_read_netcdf_with_multiindex_legacy_list_attr(
     model_with_multiindex: Model, tmp_path: Path
 ) -> None:
+    # Older linopy stored multiindex names as a Python list (netCDF4-only).
     m = model_with_multiindex
     fn = tmp_path / "test.nc"
     m.to_netcdf(fn, engine="netcdf4")
 
-    # Rewrite the JSON-encoded *_multiindex attrs as Python lists, mimicking
-    # what the previous linopy implementation produced.
-    with xr.load_dataset(fn, engine="netcdf4") as ds:
-        ds = ds.load()
-    rewritten = {
+    ds = xr.load_dataset(fn, engine="netcdf4").load()
+    ds.attrs = {
         k: (json.loads(v) if k.endswith("_multiindex") and isinstance(v, str) else v)
         for k, v in ds.attrs.items()
     }
-    ds.attrs = rewritten
     fn_legacy = tmp_path / "legacy.nc"
     ds.to_netcdf(fn_legacy, engine="netcdf4")
 
-    p = read_netcdf(fn_legacy)
-    assert_model_equal(m, p)
+    assert_model_equal(m, read_netcdf(fn_legacy))
 
 
 @pytest.mark.skipif("gurobi" not in available_solvers, reason="Gurobipy not installed")

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -5,6 +5,8 @@ Created on Thu Mar 18 09:03:35 2021.
 @author: fabian
 """
 
+import importlib.util
+import json
 import pickle
 from pathlib import Path
 
@@ -17,6 +19,8 @@ import xarray as xr
 from linopy import LESS_EQUAL, Model, available_solvers, read_netcdf
 from linopy.io import signed_number
 from linopy.testing import assert_model_equal
+
+HAS_NETCDF4 = importlib.util.find_spec("netCDF4") is not None
 
 
 @pytest.fixture
@@ -148,8 +152,46 @@ def test_model_to_netcdf_with_multiindex_scipy_engine(
     m = model_with_multiindex
     fn = tmp_path / "test.nc"
     m.to_netcdf(fn, engine="scipy")
-    p = read_netcdf(fn)
 
+    # Confirm the on-disk attr is a scalar string, not a unicode array — this
+    # is what makes the file writable by scipy in the first place.
+    with xr.load_dataset(fn) as raw:
+        multiindex_attrs = {
+            k: v for k, v in raw.attrs.items() if k.endswith("_multiindex")
+        }
+    assert multiindex_attrs, "expected at least one *_multiindex attr"
+    for k, v in multiindex_attrs.items():
+        assert isinstance(v, str), f"{k}={v!r} should be a JSON-encoded string"
+
+    p = read_netcdf(fn)
+    assert_model_equal(m, p)
+
+
+# Files written by older linopy versions stored MultiIndex level names as a
+# Python list of strings (which round-trips through netCDF4 but not scipy).
+# read_netcdf must keep accepting that legacy form so existing files don't
+# break after this change.
+@pytest.mark.skipif(not HAS_NETCDF4, reason="legacy format requires netCDF4 backend")
+def test_read_netcdf_with_multiindex_legacy_list_attr(
+    model_with_multiindex: Model, tmp_path: Path
+) -> None:
+    m = model_with_multiindex
+    fn = tmp_path / "test.nc"
+    m.to_netcdf(fn, engine="netcdf4")
+
+    # Rewrite the JSON-encoded *_multiindex attrs as Python lists, mimicking
+    # what the previous linopy implementation produced.
+    with xr.load_dataset(fn, engine="netcdf4") as ds:
+        ds = ds.load()
+    rewritten = {
+        k: (json.loads(v) if k.endswith("_multiindex") and isinstance(v, str) else v)
+        for k, v in ds.attrs.items()
+    }
+    ds.attrs = rewritten
+    fn_legacy = tmp_path / "legacy.nc"
+    ds.to_netcdf(fn_legacy, engine="netcdf4")
+
+    p = read_netcdf(fn_legacy)
     assert_model_equal(m, p)
 
 

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -127,17 +127,27 @@ def test_pickle_model(model_with_dash_names: Model, tmp_path: Path) -> None:
     assert_model_equal(m, p)
 
 
-# skip it xarray version is 2024.01.0 due to issue https://github.com/pydata/xarray/issues/8628
-@pytest.mark.skipif(
-    xr.__version__ in ["2024.1.0", "2024.1.1"],
-    reason="xarray version 2024.1.0 has a bug with MultiIndex deserialize",
-)
 def test_model_to_netcdf_with_multiindex(
     model_with_multiindex: Model, tmp_path: Path
 ) -> None:
     m = model_with_multiindex
     fn = tmp_path / "test.nc"
     m.to_netcdf(fn)
+    p = read_netcdf(fn)
+
+    assert_model_equal(m, p)
+
+
+# Regression test for https://github.com/PyPSA/linopy/issues/525: when only
+# scipy is installed (no netCDF4 / h5netcdf), xarray falls back to scipy's
+# netCDF3 backend, which cannot write unicode-array attributes. MultiIndex
+# level names must therefore be serialised as a scalar string.
+def test_model_to_netcdf_with_multiindex_scipy_engine(
+    model_with_multiindex: Model, tmp_path: Path
+) -> None:
+    m = model_with_multiindex
+    fn = tmp_path / "test.nc"
+    m.to_netcdf(fn, engine="scipy")
     p = read_netcdf(fn)
 
     assert_model_equal(m, p)


### PR DESCRIPTION
## Summary

- Fixes #525: `to_netcdf` fails with `KeyError: ('U', 24)` when only `scipy` is installed (no `netCDF4` / `h5netcdf`). xarray falls back to scipy's netCDF3 backend, which cannot write unicode-array (`<U_`) attributes — the format used by `linopy` to store MultiIndex level names as a Python list of strings.
- Encode the level names as a JSON-encoded scalar string instead, mirroring the existing pattern in the same file for `_relaxed_registry` / `_piecewise_formulations`. `read_netcdf` still accepts the legacy list form for backward compatibility with files written by older `linopy` versions.
- Drops a now-dead `skipif` on the existing MultiIndex test (the xarray bug it guarded was fixed in `xarray==2024.02.0`, and `pyproject.toml` already pins `xarray>=2024.2.0`).

## Repro (without this patch, on any xarray version including current `2026.4.0`)

```python
import pandas as pd
from linopy import LESS_EQUAL, Model

m = Model()
idx = pd.MultiIndex.from_tuples(
    [(1, "a"), (1, "b"), (2, "a"), (2, "b")], names=["first", "second"]
)
x = m.add_variables(4, pd.Series([8, 10, 12, 14], index=idx), name="x-var")
y = m.add_variables(0, pd.DataFrame([[1, 2], [3, 4], [5, 6], [7, 8]], index=idx), name="y-var")
m.add_constraints(x + y, LESS_EQUAL, 10, name="c1")
m.add_objective(2 * x + 3 * y)
m.to_netcdf("test.nc", engine="scipy")  # KeyError: ('U', 24)
```

The bug is a scipy-backend limitation, **not** an xarray regression — upgrading xarray does not fix it.

## Test plan

- [x] `test_model_to_netcdf_with_multiindex_scipy_engine` — exercises `engine="scipy"` explicitly and asserts the on-disk `*_multiindex` attribute is a scalar string (locks in the actual fix, not just the round-trip).
- [x] `test_read_netcdf_with_multiindex_legacy_list_attr` — backward-compat: rewrites a netCDF file with the old list-of-strings attribute and confirms `read_netcdf` still parses it. Skipped when `netCDF4` isn't installed (scipy cannot produce that format).
- [x] Existing `test_model_to_netcdf_with_multiindex` still passes (default engine).
- [x] `pytest test/test_io.py` — 25/25 pass.
- [x] `ruff check` / `ruff format --check` / pre-commit clean.

## Notes 

Debatable if we need this i think