### PR TITLE
chore: Update release notes for v0.7.0

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -4,6 +4,10 @@ Release Notes
 Upcoming Version
 ----------------
 
+
+Version 0.7.0
+-------------
+
 **Features**
 
 *Piecewise linear constraints (new)*

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -47,7 +47,7 @@ Version 0.7.0
 
 * ``Model.solve()`` raises a clear ``ValueError`` when no objective is set.
 * ``add_variables`` no longer ignores ``coords`` when ``lower`` / ``upper`` are DataArrays, and handles MultiIndex coords correctly with scalar bounds.
-* ``Model.to_netcdf`` works on the scipy netCDF backend (old files remain readable).
+* ``Model.to_netcdf`` no longer fails on the scipy netCDF backend when variables or constraints have MultiIndex coords; level names are now serialised as a JSON string (the legacy list form remains readable).
 * CPLEX no longer errors on quality attributes that aren't always available.
 
 **Breaking Changes**


### PR DESCRIPTION
Cuts a `Version 0.7.0` section from the existing `Upcoming Version` block in `doc/release_notes.rst`. Once this lands, push a `v0.7.0` git tag at the merge commit to trigger the release workflow (PyPI + GitHub Release).

## Why minor and not patch (most important first)

- Coordinate-alignment semantics change for subset/superset operands.
- New piecewise sub-API (`add_piecewise_formulation`, `breakpoints`, `segments`, `Slopes`, `tangent_lines`, `PiecewiseFormulation`).
- New variable methods (`fix`/`unfix`, `relax`/`unrelax`) and the semi-continuous variable type.
- Breaking dependency change: `google-cloud-storage` and `requests` are now optional (`linopy[oetc]` extra).


@FabianHofmann I'm not entirely sure on how the actual workflow is, so I'll leave you with the honor :)