### PR TITLE
docs: credit Felix Bumann in copyright, author, and pyproject maintainers

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,8 +18,8 @@ import linopy
 # -- Project information -----------------------------------------------------
 
 project = "linopy"
-copyright = "2021-2026, Fabian Hofmann"
-author = "Fabian Hofmann"
+copyright = "2021-2026, Fabian Hofmann, Felix Bumann"
+author = "Fabian Hofmann, Felix Bumann"
 
 # The full version, including alpha/beta/rc tags
 version = linopy.__version__

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -81,7 +81,7 @@ A BibTeX entry for LaTeX users is
 License
 -------
 
-Copyright 2021-2026 Fabian Hofmann
+Copyright 2021-2026 Fabian Hofmann, Felix Bumann
 
 This package is published under MIT license.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,10 @@ dynamic = ["version"]
 description = "Linear optimization with N-D labeled arrays in Python"
 readme = "README.md"
 authors = [{ name = "Fabian Hofmann", email = "fabianmarikhofmann@gmail.com" }]
+maintainers = [
+    { name = "Fabian Hofmann", email = "fabianmarikhofmann@gmail.com" },
+    { name = "Felix Bumann", email = "dev@fxbumann.de" },
+]
 license = { file = "LICENSE" }
 classifiers = [
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
## Summary

Mention Felix Bumann as an author/maintainer of linopy.

## Changes

- `doc/conf.py` — adds Felix Bumann to `copyright` **and** `author`.
- `doc/index.rst` — updates the matching `Copyright 2021-2026 Fabian Hofmann` line in the License section.
- `pyproject.toml` — adds Felix Bumann as a `maintainers` entry alongside the existing `authors`.


## Reasoning with Claude

### Why both `copyright` and `author` in conf.py?

Sphinx convention is to keep the two aligned: `copyright` renders in the docs footer, `author` is used in PDF builds and metadata. Updating only one would leave the footer crediting two people while the PDF title page still credits one.

### Why also `doc/index.rst`?

The License section there renders the same copyright statement to the user; touching only `conf.py` would leave the footer and the rendered License section out of sync.

### Why `maintainers` and not `authors` in pyproject.toml?

PEP 621 convention is that `authors` records the original creators of a package and `maintainers` records ongoing contributors. Listing the new contributor under `maintainers` reflects the package history accurately while still surfacing the credit on PyPI and in `pip show linopy` output.

### Why the `Hofmann2023` JOSS BibTeX is left alone

That citation block is for the published JOSS paper, not the codebase. The author list there reflects who's on the paper and should stay as-is.