### PR TITLE
refactor(solver): validation, sanitize kwargs, and result wiring on Solver path

### DIFF
--- a/linopy/model.py
+++ b/linopy/model.py
@@ -1753,6 +1753,11 @@ class Model:
             # If SOS is present and the solver doesn't support it (and the user
             # didn't ask for reformulation), Solver._build() will raise.
 
+        if sanitize_zeros:
+            self.constraints.sanitize_zeros()
+        if sanitize_infinities:
+            self.constraints.sanitize_infinities()
+
         try:
             self.solver = None  # closes any previous solver
             if io_api == "direct":
@@ -1762,8 +1767,6 @@ class Model:
                     "explicit_coordinate_names": explicit_coordinate_names,
                     "set_names": set_names,
                     "log_fn": to_path(log_fn),
-                    "sanitize_zeros": sanitize_zeros,
-                    "sanitize_infinities": sanitize_infinities,
                 }
                 if env is not None:
                     build_kwargs["env"] = env
@@ -1773,8 +1776,6 @@ class Model:
                     "slice_size": slice_size,
                     "progress": progress,
                     "problem_fn": to_path(problem_fn),
-                    "sanitize_zeros": sanitize_zeros,
-                    "sanitize_infinities": sanitize_infinities,
                 }
             self.solver = solver = solvers.Solver.from_name(
                 solver_name,

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -1650,12 +1650,6 @@ class Model:
                 sanitize_zeros=sanitize_zeros, sanitize_infinities=sanitize_infinities
             )
 
-        if self.objective.expression.empty:
-            raise ValueError(
-                "No objective has been set on the model. Use `m.add_objective(...)` "
-                "first (e.g. `m.add_objective(0 * x)` for a pure feasibility problem)."
-            )
-
         # check io_api
         if io_api is not None and io_api not in IO_APIS:
             raise ValueError(

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -1650,6 +1650,12 @@ class Model:
                 sanitize_zeros=sanitize_zeros, sanitize_infinities=sanitize_infinities
             )
 
+        if self.objective.expression.empty:
+            raise ValueError(
+                "No objective has been set on the model. Use `m.add_objective(...)` "
+                "first (e.g. `m.add_objective(0 * x)` for a pure feasibility problem)."
+            )
+
         # check io_api
         if io_api is not None and io_api not in IO_APIS:
             raise ValueError(

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -1650,12 +1650,6 @@ class Model:
                 sanitize_zeros=sanitize_zeros, sanitize_infinities=sanitize_infinities
             )
 
-        if self.objective.expression.empty:
-            raise ValueError(
-                "No objective has been set on the model. Use `m.add_objective(...)` "
-                "first (e.g. `m.add_objective(0 * x)` for a pure feasibility problem)."
-            )
-
         # check io_api
         if io_api is not None and io_api not in IO_APIS:
             raise ValueError(
@@ -1663,6 +1657,16 @@ class Model:
             )
 
         if remote is not None:
+            # The remote branch short-circuits before reaching Solver.solve(),
+            # which is where the empty-objective check normally fires. Replicate
+            # it here. This duplication becomes obsolete once OETC is folded
+            # into the Solver pipeline (see PyPSA/linopy#683).
+            if self.objective.expression.empty:
+                raise ValueError(
+                    "No objective has been set on the model. Use "
+                    "`m.add_objective(...)` first (e.g. `m.add_objective(0 * x)` "
+                    "for a pure feasibility problem)."
+                )
             if isinstance(remote, OetcHandler):
                 solved = remote.solve_on_oetc(
                     self, solver_name=solver_name, **solver_options

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -1728,19 +1728,6 @@ class Model:
             else:
                 solution_fn = self.get_solution_file()
 
-        if sanitize_zeros:
-            self.constraints.sanitize_zeros()
-
-        if sanitize_infinities:
-            self.constraints.sanitize_infinities()
-
-        if self.is_quadratic and not solver_class.supports(
-            SolverFeature.QUADRATIC_OBJECTIVE
-        ):
-            raise ValueError(
-                f"Solver {solver_name} does not support quadratic problems."
-            )
-
         if reformulate_sos not in (True, False, "auto"):
             raise ValueError(
                 f"Invalid value for reformulate_sos: {reformulate_sos!r}. "
@@ -1762,13 +1749,6 @@ class Model:
             # If SOS is present and the solver doesn't support it (and the user
             # didn't ask for reformulation), Solver._build() will raise.
 
-        if self.variables.semi_continuous:
-            if not solver_class.supports(SolverFeature.SEMI_CONTINUOUS_VARIABLES):
-                raise ValueError(
-                    f"Solver {solver_name} does not support semi-continuous variables. "
-                    "Use a solver that supports them (gurobi, cplex, highs)."
-                )
-
         try:
             self.solver = None  # closes any previous solver
             if io_api == "direct":
@@ -1778,6 +1758,8 @@ class Model:
                     "explicit_coordinate_names": explicit_coordinate_names,
                     "set_names": set_names,
                     "log_fn": to_path(log_fn),
+                    "sanitize_zeros": sanitize_zeros,
+                    "sanitize_infinities": sanitize_infinities,
                 }
                 if env is not None:
                     build_kwargs["env"] = env
@@ -1787,6 +1769,8 @@ class Model:
                     "slice_size": slice_size,
                     "progress": progress,
                     "problem_fn": to_path(problem_fn),
+                    "sanitize_zeros": sanitize_zeros,
+                    "sanitize_infinities": sanitize_infinities,
                 }
             self.solver = solver = solvers.Solver.from_name(
                 solver_name,
@@ -1815,7 +1799,34 @@ class Model:
             if applied_sos_reformulation_here:
                 self.undo_sos_reformulation()
 
-    def assign_result(self, result: Result) -> tuple[str, str]:
+    def assign_result(
+        self,
+        result: Result,
+        solver: solvers.Solver | None = None,
+    ) -> tuple[str, str]:
+        """
+        Write a solver Result back onto the model.
+
+        Copies primal / dual values onto variables / constraints, sets
+        :attr:`status`, :attr:`termination_condition`, and
+        :attr:`objective.value`. When ``solver`` is provided, also stores it on
+        ``self.solver`` so post-solve introspection (``model.solver_model``,
+        ``compute_infeasibilities()``) works.
+
+        Parameters
+        ----------
+        result : Result
+            The :class:`linopy.constants.Result` returned by
+            :meth:`linopy.solvers.Solver.solve`.
+        solver : Solver, optional
+            The solver instance that produced the result. Pass this when going
+            through the low-level ``Solver.from_name(...).solve()`` path so the
+            model's solver reference is wired up the same way ``Model.solve()``
+            wires it.
+        """
+        if solver is not None:
+            self.solver = solver
+
         result.info()
 
         if result.solution is not None:

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -1851,10 +1851,10 @@ class Model:
             The :class:`linopy.constants.Result` returned by
             :meth:`linopy.solvers.Solver.solve`.
         solver : Solver, optional
-            The solver instance that produced the result. Pass this when going
-            through the low-level ``Solver.from_name(...).solve()`` path so the
-            model's solver reference is wired up the same way ``Model.solve()``
-            wires it.
+            The solver instance that produced the result. Pass it on the
+            low-level ``Solver.from_name(...).solve()`` path to attach it as
+            ``self.solver`` for post-solve introspection. ``Model.solve()``
+            attaches the solver itself and does not pass this argument.
         """
         if solver is not None:
             self.solver = solver

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -507,18 +507,44 @@ class Solver(ABC, Generic[EnvType]):
         """Dispatch to direct or file build based on ``io_api``."""
         if self.model is None:
             raise RuntimeError("Solver has no model attached; cannot build.")
-        if self.model.variables.sos and not type(self).supports(
-            SolverFeature.SOS_CONSTRAINTS
-        ):
-            raise ValueError(
-                f"Solver {self.solver_name.value} does not support SOS constraints. "
-                "Call `model.apply_sos_reformulation()` first, or use a solver that "
-                "supports SOS."
-            )
+        sanitize_zeros = build_kwargs.pop("sanitize_zeros", True)
+        sanitize_infinities = build_kwargs.pop("sanitize_infinities", True)
+        self._validate_model()
+        if sanitize_zeros:
+            self.model.constraints.sanitize_zeros()
+        if sanitize_infinities:
+            self.model.constraints.sanitize_infinities()
         if self.io_api == "direct":
             self._build_direct(**build_kwargs)
         else:
             self._build_file(**build_kwargs)
+
+    def _validate_model(self) -> None:
+        """Pre-build checks on whether this solver can handle ``self.model``."""
+        model = self.model
+        assert model is not None
+        solver_name = self.solver_name.value
+        cls = type(self)
+
+        if model.is_quadratic and not cls.supports(SolverFeature.QUADRATIC_OBJECTIVE):
+            raise ValueError(
+                f"Solver {solver_name} does not support quadratic problems."
+            )
+
+        if model.variables.semi_continuous and not cls.supports(
+            SolverFeature.SEMI_CONTINUOUS_VARIABLES
+        ):
+            raise ValueError(
+                f"Solver {solver_name} does not support semi-continuous variables. "
+                "Use a solver that supports them (gurobi, cplex, highs)."
+            )
+
+        if model.variables.sos and not cls.supports(SolverFeature.SOS_CONSTRAINTS):
+            raise ValueError(
+                f"Solver {solver_name} does not support SOS constraints. "
+                "Call `model.apply_sos_reformulation()` first, or use a solver that "
+                "supports SOS."
+            )
 
     def _build_direct(self, **build_kwargs: Any) -> None:
         """Build the native solver model from ``self.model``. Override per-solver."""
@@ -560,7 +586,19 @@ class Solver(ABC, Generic[EnvType]):
         self._cache_model_sizes(model)
 
     def solve(self, **run_kwargs: Any) -> Result:
-        """Run the prepared solver and return a :class:`Result`."""
+        """
+        Run the prepared solver and return a :class:`Result`.
+
+        The canonical low-level pattern is::
+
+            solver = Solver.from_name("gurobi", model, io_api="direct")
+            result = solver.solve()
+            model.assign_result(result, solver=solver)
+
+        Passing ``solver=`` to :meth:`Model.assign_result` wires
+        ``model.solver`` so post-solve helpers like
+        :meth:`Model.compute_infeasibilities` keep working.
+        """
         if self.io_api == "direct" or self.solver_model is not None:
             return self._run_direct(**run_kwargs)
         if self._problem_fn is not None:

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -504,16 +504,19 @@ class Solver(ABC, Generic[EnvType]):
         return instance
 
     def _build(self, **build_kwargs: Any) -> None:
-        """Dispatch to direct or file build based on ``io_api``."""
+        """
+        Dispatch to direct or file build based on ``io_api``.
+
+        The Solver never mutates ``self.model``. Constraint sanitization
+        (``model.constraints.sanitize_zeros()`` /
+        ``.sanitize_infinities()``) and SOS reformulation
+        (``model.apply_sos_reformulation()``) are Model-level operations
+        the caller applies first; this builder consumes whatever shape it
+        is handed.
+        """
         if self.model is None:
             raise RuntimeError("Solver has no model attached; cannot build.")
-        sanitize_zeros = build_kwargs.pop("sanitize_zeros", True)
-        sanitize_infinities = build_kwargs.pop("sanitize_infinities", True)
         self._validate_model()
-        if sanitize_zeros:
-            self.model.constraints.sanitize_zeros()
-        if sanitize_infinities:
-            self.model.constraints.sanitize_infinities()
         if self.io_api == "direct":
             self._build_direct(**build_kwargs)
         else:

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -546,8 +546,8 @@ class Solver(ABC, Generic[EnvType]):
         if model.variables.sos and not cls.supports(SolverFeature.SOS_CONSTRAINTS):
             raise ValueError(
                 f"Solver {solver_name} does not support SOS constraints. "
-                "Call `model.apply_sos_reformulation()` first, or use a solver that "
-                "supports SOS."
+                "Reformulate first via `Model.solve(reformulate_sos=True)` or "
+                "`model.apply_sos_reformulation()`, or use a solver that supports SOS."
             )
 
     def _build_direct(self, **build_kwargs: Any) -> None:

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -598,7 +598,18 @@ class Solver(ABC, Generic[EnvType]):
         Passing ``solver=`` to :meth:`Model.assign_result` wires
         ``model.solver`` so post-solve helpers like
         :meth:`Model.compute_infeasibilities` keep working.
+
+        Raises
+        ------
+        ValueError
+            If the attached model has no objective set. Submit-time check
+            shared by both ``Model.solve()`` and direct-Solver callers.
         """
+        if self.model is not None and self.model.objective.expression.empty:
+            raise ValueError(
+                "No objective has been set on the model. Use `m.add_objective(...)` "
+                "first (e.g. `m.add_objective(0 * x)` for a pure feasibility problem)."
+            )
         if self.io_api == "direct" or self.solver_model is not None:
             return self._run_direct(**run_kwargs)
         if self._problem_fn is not None:

--- a/test/test_solvers.py
+++ b/test/test_solvers.py
@@ -5,6 +5,7 @@ Created on Tue Jan 28 09:03:35 2025.
 @author: sid
 """
 
+from collections.abc import Callable
 from pathlib import Path
 
 import numpy as np
@@ -505,26 +506,24 @@ class TestValidateModelOnBuild:
     @pytest.mark.skipif(
         "highs" not in solvers.available_solvers, reason="HiGHS not installed"
     )
-    def test_solve_without_objective_raises_on_solver_path(self) -> None:
-        m = Model()
-        m.add_variables(name="x", lower=0, upper=10)
-        # No objective added.
-
-        # Build is permitted (translate-only paths like to_gurobipy() need this).
-        solver = solvers.Solver.from_name("highs", m, io_api="lp")
-        # Solve is not — the check fires at the submit primitive.
-        with pytest.raises(ValueError, match="No objective has been set"):
-            solver.solve()
-
-    @pytest.mark.skipif(
-        "highs" not in solvers.available_solvers, reason="HiGHS not installed"
+    @pytest.mark.parametrize(
+        "submit",
+        [
+            pytest.param(
+                lambda m: solvers.Solver.from_name("highs", m, io_api="lp").solve(),
+                id="Solver.from_name(...).solve()",
+            ),
+            pytest.param(lambda m: m.solve("highs"), id="Model.solve()"),
+        ],
     )
-    def test_solve_without_objective_raises_on_model_path(self) -> None:
+    def test_solve_without_objective_raises(
+        self, submit: "Callable[[Model], object]"
+    ) -> None:
         m = Model()
         m.add_variables(name="x", lower=0, upper=10)
-
+        # No objective added — both entry points should raise the same error.
         with pytest.raises(ValueError, match="No objective has been set"):
-            m.solve("highs")
+            submit(m)
 
 
 class TestSanitizeKwargs:

--- a/test/test_solvers.py
+++ b/test/test_solvers.py
@@ -24,6 +24,14 @@ from linopy.solvers import _installed_version_in
 
 
 @pytest.fixture
+def lp_only_solver() -> str:
+    for name in ("glpk", "cbc"):
+        if name in solvers.available_solvers:
+            return name
+    pytest.skip("Need an LP-only solver (glpk or cbc) installed")
+
+
+@pytest.fixture
 def simple_model() -> Model:
     m = Model(chunk=None)
     x = m.add_variables(name="x")
@@ -469,38 +477,21 @@ def test_xpress_gpu_feature_reflects_installed_version() -> None:
 class TestValidateModelOnBuild:
     """Solver._build() runs solver-feature checks regardless of entry point."""
 
-    @pytest.mark.skipif(
-        "highs" not in solvers.available_solvers, reason="HiGHS not installed"
-    )
-    def test_quadratic_without_qp_support_raises(self) -> None:
-        # GLPK is LP-only; if not installed, fall back to a different LP-only path.
-        # CBC and GLPK both lack QUADRATIC_OBJECTIVE.
-        lp_only = next(
-            (s for s in ("glpk", "cbc") if s in solvers.available_solvers), None
-        )
-        if lp_only is None:
-            pytest.skip("Need an LP-only solver (glpk or cbc) to run this test")
-
+    def test_quadratic_without_qp_support_raises(self, lp_only_solver: str) -> None:
         m = Model()
         x = m.add_variables(name="x", lower=0, upper=10)
         m.add_objective(x * x, sense="min")
 
         with pytest.raises(ValueError, match="does not support quadratic"):
-            solvers.Solver.from_name(lp_only, m, io_api="lp")
+            solvers.Solver.from_name(lp_only_solver, m, io_api="lp")
 
-    def test_semi_continuous_without_support_raises(self) -> None:
-        lp_only = next(
-            (s for s in ("glpk", "cbc") if s in solvers.available_solvers), None
-        )
-        if lp_only is None:
-            pytest.skip("Need an LP-only solver (glpk or cbc) to run this test")
-
+    def test_semi_continuous_without_support_raises(self, lp_only_solver: str) -> None:
         m = Model()
         x = m.add_variables(name="x", lower=1, upper=10, semi_continuous=True)
         m.add_objective(x)
 
         with pytest.raises(ValueError, match="does not support semi-continuous"):
-            solvers.Solver.from_name(lp_only, m, io_api="lp")
+            solvers.Solver.from_name(lp_only_solver, m, io_api="lp")
 
     @pytest.mark.skipif(
         "highs" not in solvers.available_solvers, reason="HiGHS not installed"

--- a/test/test_solvers.py
+++ b/test/test_solvers.py
@@ -464,3 +464,110 @@ def test_xpress_gpu_feature_reflects_installed_version() -> None:
     assert solvers.Xpress.supports(
         SolverFeature.GPU_ACCELERATION
     ) == _installed_version_in("xpress", ">=9.8.0")
+
+
+class TestValidateModelOnBuild:
+    """Solver._build() runs solver-feature checks regardless of entry point."""
+
+    @pytest.mark.skipif(
+        "highs" not in solvers.available_solvers, reason="HiGHS not installed"
+    )
+    def test_quadratic_without_qp_support_raises(self) -> None:
+        # GLPK is LP-only; if not installed, fall back to a different LP-only path.
+        # CBC and GLPK both lack QUADRATIC_OBJECTIVE.
+        lp_only = next(
+            (s for s in ("glpk", "cbc") if s in solvers.available_solvers), None
+        )
+        if lp_only is None:
+            pytest.skip("Need an LP-only solver (glpk or cbc) to run this test")
+
+        m = Model()
+        x = m.add_variables(name="x", lower=0, upper=10)
+        m.add_objective(x * x, sense="min")
+
+        with pytest.raises(ValueError, match="does not support quadratic"):
+            solvers.Solver.from_name(lp_only, m, io_api="lp")
+
+    def test_semi_continuous_without_support_raises(self) -> None:
+        lp_only = next(
+            (s for s in ("glpk", "cbc") if s in solvers.available_solvers), None
+        )
+        if lp_only is None:
+            pytest.skip("Need an LP-only solver (glpk or cbc) to run this test")
+
+        m = Model()
+        x = m.add_variables(name="x", lower=1, upper=10, semi_continuous=True)
+        m.add_objective(x)
+
+        with pytest.raises(ValueError, match="does not support semi-continuous"):
+            solvers.Solver.from_name(lp_only, m, io_api="lp")
+
+
+class TestSanitizeKwargs:
+    """sanitize_zeros / sanitize_infinities on Solver.from_model() control the build."""
+
+    @pytest.mark.skipif(
+        "highs" not in solvers.available_solvers, reason="HiGHS not installed"
+    )
+    def test_sanitize_zeros_default_on_mutates_constraints(self) -> None:
+        m = Model()
+        x = m.add_variables(name="x", lower=0, upper=10)
+        # Constraint with a near-zero coefficient
+        m.add_constraints(1e-12 * x + x >= 0, name="c")
+        m.add_objective(x)
+
+        # Default: sanitize_zeros=True -> the near-zero term gets masked
+        solvers.Solver.from_name("highs", m, io_api="lp")
+        coeffs = m.constraints["c"].coeffs.values.ravel()
+        assert np.isnan(coeffs[0]) or coeffs[0] == 0 or coeffs[1] != 0
+
+    @pytest.mark.skipif(
+        "highs" not in solvers.available_solvers, reason="HiGHS not installed"
+    )
+    def test_sanitize_zeros_off_leaves_constraints_alone(self) -> None:
+        m = Model()
+        x = m.add_variables(name="x", lower=0, upper=10)
+        m.add_constraints(1e-12 * x + x >= 0, name="c")
+        m.add_objective(x)
+
+        before = m.constraints["c"].coeffs.values.copy()
+        solvers.Solver.from_name(
+            "highs", m, io_api="lp", sanitize_zeros=False, sanitize_infinities=False
+        )
+        after = m.constraints["c"].coeffs.values
+        # Without sanitization, the near-zero coefficient is preserved verbatim.
+        assert np.allclose(before, after, equal_nan=True)
+
+
+class TestAssignResultWiring:
+    """assign_result(result, solver=...) populates model.solver."""
+
+    @pytest.mark.skipif(
+        "highs" not in solvers.available_solvers, reason="HiGHS not installed"
+    )
+    def test_assign_result_with_solver_wires_model_solver(self) -> None:
+        m = Model()
+        x = m.add_variables(name="x", lower=0, upper=10)
+        m.add_objective(x, sense="min")
+
+        assert m.solver is None
+        solver = solvers.Solver.from_name("highs", m, io_api="lp")
+        result = solver.solve()
+        m.assign_result(result, solver=solver)
+
+        assert m.solver is solver
+        assert m.solver_model is solver.solver_model
+
+    @pytest.mark.skipif(
+        "highs" not in solvers.available_solvers, reason="HiGHS not installed"
+    )
+    def test_assign_result_without_solver_kwarg_leaves_solver_unset(self) -> None:
+        m = Model()
+        x = m.add_variables(name="x", lower=0, upper=10)
+        m.add_objective(x, sense="min")
+
+        solver = solvers.Solver.from_name("highs", m, io_api="lp")
+        result = solver.solve()
+        m.assign_result(result)  # no solver kwarg
+
+        assert m.solver is None

--- a/test/test_solvers.py
+++ b/test/test_solvers.py
@@ -515,40 +515,30 @@ class TestValidateModelOnBuild:
             m.solve("highs")
 
 
-class TestSanitizeKwargs:
-    """sanitize_zeros / sanitize_infinities on Solver.from_model() control the build."""
+class TestSolverDoesNotMutateModel:
+    """Solver.from_model() must not mutate model state (sanitize stays Model-level)."""
 
     @pytest.mark.skipif(
         "highs" not in solvers.available_solvers, reason="HiGHS not installed"
     )
-    def test_sanitize_zeros_default_on_mutates_constraints(self) -> None:
+    def test_from_model_leaves_constraints_untouched(self) -> None:
         m = Model()
         x = m.add_variables(name="x", lower=0, upper=10)
-        # Constraint with a near-zero coefficient
-        m.add_constraints(1e-12 * x + x >= 0, name="c")
-        m.add_objective(x)
-
-        # Default: sanitize_zeros=True -> the near-zero term gets masked
-        solvers.Solver.from_name("highs", m, io_api="lp")
-        coeffs = m.constraints["c"].coeffs.values.ravel()
-        assert np.isnan(coeffs[0]) or coeffs[0] == 0 or coeffs[1] != 0
-
-    @pytest.mark.skipif(
-        "highs" not in solvers.available_solvers, reason="HiGHS not installed"
-    )
-    def test_sanitize_zeros_off_leaves_constraints_alone(self) -> None:
-        m = Model()
-        x = m.add_variables(name="x", lower=0, upper=10)
+        # Constraint with a near-zero coefficient — would be sanitized away if
+        # the Solver path were sanitizing on build.
         m.add_constraints(1e-12 * x + x >= 0, name="c")
         m.add_objective(x)
 
         before = m.constraints["c"].coeffs.values.copy()
-        solvers.Solver.from_name(
-            "highs", m, io_api="lp", sanitize_zeros=False, sanitize_infinities=False
-        )
+        solvers.Solver.from_name("highs", m, io_api="lp")
         after = m.constraints["c"].coeffs.values
-        # Without sanitization, the near-zero coefficient is preserved verbatim.
-        assert np.allclose(before, after, equal_nan=True)
+
+        assert np.allclose(before, after, equal_nan=True), (
+            "Solver.from_model() must not mutate model constraints. "
+            "Sanitization is a Model-level primitive; call "
+            "model.constraints.sanitize_zeros() / .sanitize_infinities() "
+            "explicitly before building."
+        )
 
 
 class TestAssignResultWiring:

--- a/test/test_solvers.py
+++ b/test/test_solvers.py
@@ -5,7 +5,6 @@ Created on Tue Jan 28 09:03:35 2025.
 @author: sid
 """
 
-from collections.abc import Callable
 from pathlib import Path
 
 import numpy as np
@@ -506,24 +505,14 @@ class TestValidateModelOnBuild:
     @pytest.mark.skipif(
         "highs" not in solvers.available_solvers, reason="HiGHS not installed"
     )
-    @pytest.mark.parametrize(
-        "submit",
-        [
-            pytest.param(
-                lambda m: solvers.Solver.from_name("highs", m, io_api="lp").solve(),
-                id="Solver.from_name(...).solve()",
-            ),
-            pytest.param(lambda m: m.solve("highs"), id="Model.solve()"),
-        ],
-    )
-    def test_solve_without_objective_raises(
-        self, submit: "Callable[[Model], object]"
-    ) -> None:
+    def test_solve_without_objective_raises(self) -> None:
         m = Model()
         m.add_variables(name="x", lower=0, upper=10)
         # No objective added — both entry points should raise the same error.
         with pytest.raises(ValueError, match="No objective has been set"):
-            submit(m)
+            solvers.Solver.from_name("highs", m, io_api="lp").solve()
+        with pytest.raises(ValueError, match="No objective has been set"):
+            m.solve("highs")
 
 
 class TestSanitizeKwargs:

--- a/test/test_solvers.py
+++ b/test/test_solvers.py
@@ -502,6 +502,30 @@ class TestValidateModelOnBuild:
         with pytest.raises(ValueError, match="does not support semi-continuous"):
             solvers.Solver.from_name(lp_only, m, io_api="lp")
 
+    @pytest.mark.skipif(
+        "highs" not in solvers.available_solvers, reason="HiGHS not installed"
+    )
+    def test_solve_without_objective_raises_on_solver_path(self) -> None:
+        m = Model()
+        m.add_variables(name="x", lower=0, upper=10)
+        # No objective added.
+
+        # Build is permitted (translate-only paths like to_gurobipy() need this).
+        solver = solvers.Solver.from_name("highs", m, io_api="lp")
+        # Solve is not — the check fires at the submit primitive.
+        with pytest.raises(ValueError, match="No objective has been set"):
+            solver.solve()
+
+    @pytest.mark.skipif(
+        "highs" not in solvers.available_solvers, reason="HiGHS not installed"
+    )
+    def test_solve_without_objective_raises_on_model_path(self) -> None:
+        m = Model()
+        m.add_variables(name="x", lower=0, upper=10)
+
+        with pytest.raises(ValueError, match="No objective has been set"):
+            m.solve("highs")
+
 
 class TestSanitizeKwargs:
     """sanitize_zeros / sanitize_infinities on Solver.from_model() control the build."""


### PR DESCRIPTION
**Stacked on #690.** Closes the gap between `Model.solve()` and `Solver.from_name(...).solve()`.

## Core principle

`Solver.from_model()` does **not** mutate the model. Model-state transformations are Model-level primitives, called explicitly:

```python
model.constraints.sanitize_zeros()        # drop zero-coefficient terms
model.constraints.sanitize_infinities()   # drop trivial <= +inf / >= -inf rows
model.apply_sos_reformulation()           # rewrite SOS as binary + linear (#690)
model.undo_sos_reformulation()            # restore the original SOS form (#690)
```

`Model.solve()` calls these internally as orchestration. The low-level Solver path expects the caller to apply them — no silent mutation on build.

Canonical low-level pattern:

```python
model.constraints.sanitize_zeros()   # optional preprocessing
solver = Solver.from_name("highs", model, io_api="direct")
result = solver.solve()
model.assign_result(result, solver=solver)
```

## What lives where after this PR

`Port?` = should it move to `Solver`. `Status` = ✅ done · ⬜ todo · — n/a.

| Item | Port? | Status | Where (on `Solver` or why not) |
|---|---|---|---|
| Quadratic / semi-continuous feature gates | yes | ✅ | `Solver._validate_model()` (build-time, called from `_build()`) |
| SOS feature gate | yes | ✅ (#690) | `Solver._validate_model()` (build-time) |
| Empty-objective check | yes | ✅ | `Solver.solve()` (run-time); scoped dup in `Model.solve()`'s remote branch, removed by #683 |
| Result wiring (`model.solver` + primal/dual/status) | yes | ✅ | `Model.assign_result(result, solver=...)` (post-solve) |
| Build-time kwargs: `io_api`, `explicit_coordinate_names`, `set_names`, `problem_fn`, `slice_size`, `progress`, `**solver_options` | yes | ✅ | `Solver.from_model(...)` |
| Run-time kwargs: `basis_fn`, `warmstart_fn` | yes | ✅ | `Solver.solve(...)` |
| `env`, `log_fn` | yes | ⬜ | accepted on **both** `from_model()` and `solve()` today; PR3 consolidates to `from_model()` only (13 subclasses) |
| `sanitize_zeros` / `sanitize_infinities` | no | — | Model-level: `model.constraints.sanitize_*()`. Mutates — caller-owned. |
| SOS apply/undo lifecycle | no | — | Model-level: `model.apply_sos_reformulation()` / `undo_sos_reformulation()` (#690). Mutates — caller-owned. |
| `reformulate_sos` (`True`/`False`/`"auto"`) | no | — | Model.solve()-side convenience wrapping `model.apply_sos_reformulation()`. Solver-path users call apply/undo directly. |
| OETC remote (`remote=OetcHandler(...)`) | yes | ⬜ (#683) | refactor into a `Solver` subclass |
| Generic `remote=RemoteHandler(...)` | ? | — | could follow #683 |
| `mock_solve=True` | ? | — | could become a `Mock` `Solver` subclass |
| "Any solver installed" raise | ? | — | `Solver.__post_init__` covers "this-installed"; "any-installed" is module-level |
| `solver_name` auto-pick, default `solution_fn`, `keep_files` cleanup, info logs, `reset_solution()` | no | — | orchestration: belongs above the Solver layer |

> **Docs follow-up.** Keeping sanitize off the Solver kwargs makes it less discoverable for users coming from `Model.solve()`. The user guide / example notebooks should surface the model-level primitives — separate doc PR #685, not in scope here.
