### PR TITLE
Xpress 9.9+ backward compatibility and other updates

### DIFF
--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -2180,34 +2180,105 @@ class Xpress(Solver[None]):
             entind = None
             coltype = None
 
-        problem.loadproblem(
-            probname="linopy",
-            rowtype=rowtype,
-            rhs=rhs,
-            rng=None,
-            objcoef=np.asarray(M.c, dtype=float),
-            start=start,
-            collen=None,
-            rowind=rowind,
-            rowcoef=rowcoef,
-            lb=lb,
-            ub=ub,
-            objqcol1=objqcol1,
-            objqcol2=objqcol2,
-            objqcoef=objqcoef,
-            qrowind=None,
-            nrowqcoefs=None,
-            rowqcol1=None,
-            rowqcol2=None,
-            rowqcoef=None,
-            coltype=coltype,
-            entind=entind,
-            limit=None,
-            settype=None,
-            setstart=None,
-            setind=None,
-            refval=None,
-        )
+        objcoef = np.asarray(M.c, dtype=float)
+        has_q = objqcol1 is not None
+        has_int = coltype is not None
+        try:  # Try new API first (Xpress 9.8+)
+            if has_q and has_int:
+                problem.loadMIQP(
+                    probname="linopy",
+                    rowtype=rowtype,
+                    rhs=rhs,
+                    rng=None,
+                    objcoef=objcoef,
+                    start=start,
+                    collen=None,
+                    rowind=rowind,
+                    rowcoef=rowcoef,
+                    lb=lb,
+                    ub=ub,
+                    objqcol1=objqcol1,
+                    objqcol2=objqcol2,
+                    objqcoef=objqcoef,
+                    coltype=coltype,
+                    entind=entind,
+                )
+            elif has_q:
+                problem.loadQP(
+                    probname="linopy",
+                    rowtype=rowtype,
+                    rhs=rhs,
+                    rng=None,
+                    objcoef=objcoef,
+                    start=start,
+                    collen=None,
+                    rowind=rowind,
+                    rowcoef=rowcoef,
+                    lb=lb,
+                    ub=ub,
+                    objqcol1=objqcol1,
+                    objqcol2=objqcol2,
+                    objqcoef=objqcoef,
+                )
+            elif has_int:
+                problem.loadMIP(
+                    probname="linopy",
+                    rowtype=rowtype,
+                    rhs=rhs,
+                    rng=None,
+                    objcoef=objcoef,
+                    start=start,
+                    collen=None,
+                    rowind=rowind,
+                    rowcoef=rowcoef,
+                    lb=lb,
+                    ub=ub,
+                    coltype=coltype,
+                    entind=entind,
+                )
+            else:
+                problem.loadLP(
+                    probname="linopy",
+                    rowtype=rowtype,
+                    rhs=rhs,
+                    rng=None,
+                    objcoef=objcoef,
+                    start=start,
+                    collen=None,
+                    rowind=rowind,
+                    rowcoef=rowcoef,
+                    lb=lb,
+                    ub=ub,
+                )
+        except AttributeError:  # Fallback to old API
+            problem.loadproblem(
+                probname="linopy",
+                rowtype=rowtype,
+                rhs=rhs,
+                rng=None,
+                objcoef=objcoef,
+                start=start,
+                collen=None,
+                rowind=rowind,
+                rowcoef=rowcoef,
+                lb=lb,
+                ub=ub,
+                objqcol1=objqcol1,
+                objqcol2=objqcol2,
+                objqcoef=objqcoef,
+                qrowind=None,
+                nrowqcoefs=None,
+                rowqcol1=None,
+                rowqcol2=None,
+                rowqcoef=None,
+                coltype=coltype,
+                entind=entind,
+                limit=None,
+                settype=None,
+                setstart=None,
+                setind=None,
+                refval=None,
+            )
 
         if model.objective.sense == "max":
             problem.chgobjsense(xpress.maximize)
@@ -2218,10 +2289,16 @@ class Xpress(Solver[None]):
             )
             vnames = print_variable(M.vlabels)
             if vnames:
-                problem.addnames(xpress_Namespaces.COLUMN, vnames, 0, len(vnames) - 1)
+                try:  # Try new API first (Xpress 9.8+)
+                    problem.addNames(xpress_Namespaces.COLUMN, vnames, 0, len(vnames) - 1)
+                except AttributeError:  # Fallback to old API
+                    problem.addnames(xpress_Namespaces.COLUMN, vnames, 0, len(vnames) - 1)
             cnames = print_constraint(M.clabels)
             if cnames:
-                problem.addnames(xpress_Namespaces.ROW, cnames, 0, len(cnames) - 1)
+                try:  # Try new API first (Xpress 9.8+)
+                    problem.addNames(xpress_Namespaces.ROW, cnames, 0, len(cnames) - 1)
+                except AttributeError:  # Fallback to old API
+                    problem.addnames(xpress_Namespaces.ROW, cnames, 0, len(cnames) - 1)
 
         if model.variables.sos:
             for var_name in model.variables.sos:
@@ -2285,7 +2362,7 @@ class Xpress(Solver[None]):
         sense = read_sense_from_problem_file(problem_fn)
 
         m = xpress.problem()
-        m.read(path_to_string(problem_fn))
+        m.readProb(path_to_string(problem_fn))
 
         return self._solve(
             m,
@@ -2321,25 +2398,40 @@ class Xpress(Solver[None]):
             m.setControl(self.solver_options)
 
         if log_fn is not None:
-            m.setlogfile(path_to_string(log_fn))
+            try:  # Try new API first
+                m.setLogFile(path_to_string(log_fn))
+            except AttributeError:  # Fallback to old API
+                m.setlogfile(path_to_string(log_fn))
 
         if warmstart_fn is not None:
-            m.readbasis(path_to_string(warmstart_fn))
+            try:  # Try new API first
+                m.readBasis(path_to_string(warmstart_fn))
+            except AttributeError:  # Fallback to old API
+                m.readbasis(path_to_string(warmstart_fn))
 
         m.optimize()
 
         if m.attributes.solvestatus == xpress.enums.SolveStatus.STOPPED:
-            m.postsolve()
+            try:  # Try new API first
+                m.postSolve()
+            except AttributeError:  # Fallback to old API
+                m.postsolve()
 
         if basis_fn is not None:
             try:
-                m.writebasis(path_to_string(basis_fn))
+                try:  # Try new API first
+                    m.writeBasis(path_to_string(basis_fn))
+                except AttributeError:  # Fallback to old API
+                    m.writebasis(path_to_string(basis_fn))
             except (xpress.SolverError, xpress.ModelError) as err:  # pragma: no cover
                 logger.info("No model basis stored. Raised error: %s", err)
 
         if solution_fn is not None:
             try:
-                m.writebinsol(path_to_string(solution_fn))
+                try:  # Try new API first
+                    m.writeBinSol(path_to_string(solution_fn))
+                except AttributeError:  # Fallback to old API
+                    m.writebinsol(path_to_string(solution_fn))
             except (xpress.SolverError, xpress.ModelError) as err:  # pragma: no cover
                 logger.info("Unable to save solution file. Raised error: %s", err)
 
@@ -2365,7 +2457,7 @@ class Xpress(Solver[None]):
                 if m.attributes.rows == 0:
                     dual = np.array([], dtype=float)
                 else:
-                    dual_values = np.asarray(m.getDual(), dtype=float)
+                    dual_values = np.asarray(m.getDuals(), dtype=float)
                     if from_file:
                         dual = _solution_from_names(
                             dual_values,

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -2290,9 +2290,13 @@ class Xpress(Solver[None]):
             vnames = print_variable(M.vlabels)
             if vnames:
                 try:  # Try new API first (Xpress 9.8+)
-                    problem.addNames(xpress_Namespaces.COLUMN, vnames, 0, len(vnames) - 1)
+                    problem.addNames(
+                        xpress_Namespaces.COLUMN, vnames, 0, len(vnames) - 1
+                    )
                 except AttributeError:  # Fallback to old API
-                    problem.addnames(xpress_Namespaces.COLUMN, vnames, 0, len(vnames) - 1)
+                    problem.addnames(
+                        xpress_Namespaces.COLUMN, vnames, 0, len(vnames) - 1
+                    )
             cnames = print_constraint(M.clabels)
             if cnames:
                 try:  # Try new API first (Xpress 9.8+)

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -2183,20 +2183,23 @@ class Xpress(Solver[None]):
         objcoef = np.asarray(M.c, dtype=float)
         has_q = objqcol1 is not None
         has_int = coltype is not None
+        base_kwargs: dict[str, Any] = dict(
+            probname="linopy",
+            rowtype=rowtype,
+            rhs=rhs,
+            rng=None,
+            objcoef=objcoef,
+            start=start,
+            collen=None,
+            rowind=rowind,
+            rowcoef=rowcoef,
+            lb=lb,
+            ub=ub,
+        )
         try:  # Try new API first (Xpress 9.8+)
             if has_q and has_int:
                 problem.loadMIQP(
-                    probname="linopy",
-                    rowtype=rowtype,
-                    rhs=rhs,
-                    rng=None,
-                    objcoef=objcoef,
-                    start=start,
-                    collen=None,
-                    rowind=rowind,
-                    rowcoef=rowcoef,
-                    lb=lb,
-                    ub=ub,
+                    **base_kwargs,
                     objqcol1=objqcol1,
                     objqcol2=objqcol2,
                     objqcoef=objqcoef,
@@ -2205,51 +2208,19 @@ class Xpress(Solver[None]):
                 )
             elif has_q:
                 problem.loadQP(
-                    probname="linopy",
-                    rowtype=rowtype,
-                    rhs=rhs,
-                    rng=None,
-                    objcoef=objcoef,
-                    start=start,
-                    collen=None,
-                    rowind=rowind,
-                    rowcoef=rowcoef,
-                    lb=lb,
-                    ub=ub,
+                    **base_kwargs,
                     objqcol1=objqcol1,
                     objqcol2=objqcol2,
                     objqcoef=objqcoef,
                 )
             elif has_int:
                 problem.loadMIP(
-                    probname="linopy",
-                    rowtype=rowtype,
-                    rhs=rhs,
-                    rng=None,
-                    objcoef=objcoef,
-                    start=start,
-                    collen=None,
-                    rowind=rowind,
-                    rowcoef=rowcoef,
-                    lb=lb,
-                    ub=ub,
+                    **base_kwargs,
                     coltype=coltype,
                     entind=entind,
                 )
             else:
-                problem.loadLP(
-                    probname="linopy",
-                    rowtype=rowtype,
-                    rhs=rhs,
-                    rng=None,
-                    objcoef=objcoef,
-                    start=start,
-                    collen=None,
-                    rowind=rowind,
-                    rowcoef=rowcoef,
-                    lb=lb,
-                    ub=ub,
-                )
+                problem.loadLP(**base_kwargs)
         except AttributeError:  # Fallback to old API
             problem.loadproblem(
                 probname="linopy",
@@ -2366,7 +2337,10 @@ class Xpress(Solver[None]):
         sense = read_sense_from_problem_file(problem_fn)
 
         m = xpress.problem()
-        m.readProb(path_to_string(problem_fn))
+        try:  # Try new API first
+            m.readProb(path_to_string(problem_fn))
+        except AttributeError:  # Fallback to old API
+            m.read(path_to_string(problem_fn))
 
         return self._solve(
             m,
@@ -2461,7 +2435,10 @@ class Xpress(Solver[None]):
                 if m.attributes.rows == 0:
                     dual = np.array([], dtype=float)
                 else:
-                    dual_values = np.asarray(m.getDuals(), dtype=float)
+                    try:  # getDuals introduced in 9.5; fallback for 9.4
+                        dual_values = np.asarray(m.getDuals(), dtype=float)
+                    except AttributeError:
+                        dual_values = np.asarray(m.getDual(), dtype=float)
                     if from_file:
                         dual = _solution_from_names(
                             dual_values,


### PR DESCRIPTION
Restore Xpress 9.9+ API backward compatibility and fix deprecation warnings

Closes # (if applicable).

## Changes proposed in this Pull Request

Xpress 9.8 renamed several API methods (e.g. `loadproblem` → `loadLP/loadMIP/loadQP/loadMIQP`, `addnames` → `addNames`, `getDual` → `getDuals`, etc.). PR #542 added `try/except AttributeError` wrappers to support both old and new API. These wrappers were inadvertently dropped in the Xpress direct-IO rewrite (787c4ce), reintroducing deprecation warnings when running against Xpress 9.9.

This PR restores the wrappers across all affected call sites in:

- **Problem loading:** selects `loadLP`, `loadMIP`, `loadQP`, or `loadMIQP` based on problem type (integer variables / quadratic objective); falls back to `loadproblem` on Xpress < 9.8
- **Names:** `addNames()` with `addnames()` fallback
- **File I/O:** `readProb`, `readBasis`, `writeBasis`, `writeBinSol` with lowercase fallbacks
- **Solve helpers:** `postSolve`, `setLogFile` with lowercase fallbacks
- **Solution retrieval:** `getDuals()` (was incorrectly `getDual()`)

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.