### PR TITLE
fix(xpress): use ExitStack to manage xpress.problem() lifecycle

### DIFF
--- a/linopy/io.py
+++ b/linopy/io.py
@@ -695,13 +695,11 @@ def to_xpress(
     set_names: bool = True,
 ) -> Any:
     """Build the xpress.problem instance for `m`."""
-    solver = solvers.Xpress.from_model(
+    return solvers.Xpress._build_solver_model(
         m,
-        io_api="direct",
         explicit_coordinate_names=explicit_coordinate_names,
         set_names=set_names,
     )
-    return solver.solver_model
 
 
 def to_cupdlpx(m: Model) -> cupdlpxModel:

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -2097,11 +2097,14 @@ class Xpress(Solver[None]):
     ) -> None:
         model = self.model
         assert model is not None
+        self.close()
+        self._env_stack = contextlib.ExitStack()
         problem = self._build_solver_model(
             model,
             explicit_coordinate_names=explicit_coordinate_names,
             set_names=set_names,
         )
+        self._env_stack.enter_context(problem)
         self.solver_model = problem
         self.io_api = "direct"
         self.sense = model.sense
@@ -2336,7 +2339,9 @@ class Xpress(Solver[None]):
         io_api = read_io_api_from_problem_file(problem_fn)
         sense = read_sense_from_problem_file(problem_fn)
 
-        m = xpress.problem()
+        self.close()
+        self._env_stack = contextlib.ExitStack()
+        m = self._env_stack.enter_context(xpress.problem())
         try:  # Try new API first
             m.readProb(path_to_string(problem_fn))
         except AttributeError:  # Fallback to old API


### PR DESCRIPTION
Fix memory leak in Xpress solver by using `contextlib.ExitStack` to manage `xpress.problem()` lifecycle, as suggested in #695.

### Key Changes
- `_build_direct`: call `self.close()` before rebuild, register problem on `_env_stack` so `Solver.close()` properly calls `problem.__exit__()` → `XPRSdestroyprob()`
- `_run_file`: same pattern, replacing the bare `xpress.problem()` call

### Testing
✅ 278 passed on Xpress 9.9.0
✅ 278 passed on Xpress 9.4.6

### Checklist
- [x] Code changes are sufficiently documented
- [x] Unit tests for new features were added (if applicable)
- [ ] A note for the release notes `doc/release_notes.rst` is included
- [x] I consent to the release of this PR's code under the MIT license