### PR TITLE
perf(matrices): cache MatrixAccessor properties with cached_property

### DIFF
--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -963,7 +963,8 @@ class BaseExpression(ABC):
         Replace variable labels by solution values.
         """
         m = self.model
-        sol = pd.Series(m.matrices.sol, m.matrices.vlabels)
+        M = m.matrices
+        sol = pd.Series(M.sol, M.vlabels)
         sol[-1] = np.nan
         idx = np.ravel(self.vars)
         values = np.asarray(sol[idx]).reshape(self.vars.shape)

--- a/linopy/matrices.py
+++ b/linopy/matrices.py
@@ -7,6 +7,7 @@ Created on Mon Oct 10 13:33:55 2022.
 
 from __future__ import annotations
 
+from functools import cached_property
 from typing import TYPE_CHECKING, cast
 
 import numpy as np
@@ -96,7 +97,7 @@ class MatrixAccessor:
             np.concatenate(sense_list) if sense_list else np.array([], dtype=object)
         )
 
-    @property
+    @cached_property
     def c(self) -> ndarray:
         """Objective coefficients aligned with vlabels."""
         m = self._parent
@@ -121,7 +122,7 @@ class MatrixAccessor:
         np.add.at(result, label_to_pos[var_labels[mask]], coeffs[mask])
         return result
 
-    @property
+    @cached_property
     def Q(self) -> scipy.sparse.csc_matrix | None:
         """Quadratic objective matrix, shape (n_active_vars, n_active_vars)."""
         m = self._parent
@@ -130,7 +131,7 @@ class MatrixAccessor:
             return None
         return expr.to_matrix()[self.vlabels][:, self.vlabels]
 
-    @property
+    @cached_property
     def sol(self) -> ndarray:
         """Solution values aligned with vlabels."""
         if not self._parent.status == "ok":
@@ -146,7 +147,7 @@ class MatrixAccessor:
             result[positions] = var.solution.values.ravel()[mask]
         return result
 
-    @property
+    @cached_property
     def dual(self) -> ndarray:
         """Dual values aligned with clabels."""
         if not self._parent.status == "ok":


### PR DESCRIPTION
## Summary

Convert the remaining `@property` methods on `MatrixAccessor` (`c`, `Q`, `sol`, `dual`) to `functools.cached_property`. After #630, `vlabels`, `clabels`, `A`, `b`, `sense`, `lb`, `ub`, `vtypes` are already materialised once in `__init__`. The four remaining properties still recompute on every access, which shows up in solver paths that read the same attribute twice on one `MatrixAccessor` instance.

Also fix a small adjacent issue in `expressions.BaseExpression._map_solution`: `m.matrices.sol` followed by `m.matrices.vlabels` quietly constructed *two* `MatrixAccessor` instances (each running `_build_vars` + `_build_cons`). Binding to a local `M = m.matrices` reuses one.

## Why this is safe

Each `MatrixAccessor` is short-lived: `Model.matrices` is itself a `@property` that returns a *fresh* instance on every access (`linopy/model.py:350-352`). So the cache lives at most as long as the local variable a caller holds, and the accessor never sees a mutated model. No new `clean_cached_properties` plumbing is needed.

## Where the gain shows up

Multiple solver builders read the same property twice within one `M = model.matrices`:

- `solvers.Highs._build_solver_model` — `M.c` at line 1278, `M.Q` at 1299; both can be re-read in user code that inspects the accessor after solve.
- `solvers.Gurobi._build_solver_model` — `M.Q` at 1586, used again at 1587 in the QP branch.
- `solvers.Mosek._build_solver_model` — `M.Q` at 2860, again at 2861.

Repeat reads of `M.sol` / `M.dual` are also common in post-solve introspection.

## Benchmark

Model: 360,600 variables, 1,200 constraints, solved with HiGHS (Python 3.12, scipy 1.17, numpy 2.4):

|        | cold (first access) | warm (repeat access) |
|--------|---------------------|----------------------|
| master | 1.0 ms              | 1.1 ms (recomputed)  |
| patch  | 1.2 ms              | 0.4 µs (~2500×)      |

Repro script:

```python
import numpy as np, pandas as pd, xarray as xr, time
from linopy import Model

N = 600
m = Model()
idx = pd.RangeIndex(N); jdx = pd.RangeIndex(N)
x = m.add_variables(xr.DataArray(np.zeros((N, N)), coords=[idx, jdx]),
                    xr.DataArray(np.full((N, N), 100.0), coords=[idx, jdx]), name="x")
y = m.add_variables(0, 100, coords=[idx], name="y")
m.add_constraints(x.sum(dim="dim_1") + y >= 10)
m.add_constraints(x.sum(dim="dim_0") >= 1)
m.add_objective(x.sum() + 2 * y.sum())
m.solve(solver_name="highs", io_api="direct", log_to_console=False)

for attr in ["c", "sol"]:
    M = m.matrices
    t = time.perf_counter(); _ = getattr(M, attr); cold = time.perf_counter() - t
    t = time.perf_counter(); _ = getattr(M, attr); warm = time.perf_counter() - t
    print(f"M.{attr}: cold={cold*1e3:.2f} ms  warm={warm*1e6:.2f} us")
```

## Tests

- `pytest test/test_matrices.py test/test_objective.py test/test_solution_lookup.py test/test_model.py test/test_constraints.py test/test_linear_expression.py test/test_quadratic_expression.py` → 399 passed
- `pytest test/test_optimization.py -k "not modified_model and not netcdf"` → 241 passed, 2 skipped

(Pre-existing master failures unrelated to this PR: `test_modified_model[*]` and `test_model_to_netcdf_*` — both fail on `upstream/master` with the same scipy/numpy stack.)

## Files touched

- `linopy/matrices.py` (+4 `@cached_property`, +1 import)
- `linopy/expressions.py` (1 line: bind `m.matrices` to local before reading two attributes)
