### PR TITLE
refactor(types): unify SUPPORTED_CONSTANT_TYPES with ConstantLike alias

### DIFF
--- a/linopy/common.py
+++ b/linopy/common.py
@@ -35,6 +35,7 @@ from linopy.constants import (
     sign_replace_dict,
 )
 from linopy.types import (
+    CONSTANT_TYPES,
     CoordsLike,
     DimsLike,
     SideLike,
@@ -1528,7 +1529,6 @@ def is_constant(x: SideLike) -> bool:
         True if the object is constant-like, False otherwise.
     """
     from linopy.expressions import (
-        SUPPORTED_CONSTANT_TYPES,
         LinearExpression,
         QuadraticExpression,
     )
@@ -1538,7 +1538,7 @@ def is_constant(x: SideLike) -> bool:
         return False
     if isinstance(x, LinearExpression | QuadraticExpression):
         return x.is_constant
-    if isinstance(x, SUPPORTED_CONSTANT_TYPES):
+    if isinstance(x, CONSTANT_TYPES):
         return True
     raise TypeError(
         "Expected a constant, variable, or expression on the constraint side, "

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -82,6 +82,7 @@ from linopy.constants import (
     TERM_DIM,
 )
 from linopy.types import (
+    CONSTANT_TYPES,
     ConstantLike,
     DimsLike,
     ExpressionLike,
@@ -337,13 +338,13 @@ class BaseExpression(ABC):
         if data is None:
             da = xr.DataArray([], dims=[TERM_DIM])
             data = Dataset({"coeffs": da, "vars": da, "const": 0.0})
-        elif isinstance(data, SUPPORTED_CONSTANT_TYPES):
+        elif isinstance(data, CONSTANT_TYPES):
             const = as_dataarray(data)
             da = xr.DataArray([], dims=[TERM_DIM])
             data = Dataset({"coeffs": da, "vars": da, "const": const})
         elif not isinstance(data, Dataset):
             supported_types = ", ".join(
-                map(lambda s: s.__qualname__, (*SUPPORTED_CONSTANT_TYPES, Dataset))
+                map(lambda s: s.__qualname__, (*CONSTANT_TYPES, Dataset))
             )
             raise ValueError(
                 f"data must be an instance of {supported_types}, got {type(data)}"
@@ -691,7 +692,7 @@ class BaseExpression(ABC):
         """
         if join is None:
             return self.__add__(other)
-        if isinstance(other, SUPPORTED_CONSTANT_TYPES):
+        if isinstance(other, CONSTANT_TYPES):
             return self._add_constant(other, join=join)
         other = as_expression(other, model=self.model, dims=self.coord_dims)
         if isinstance(other, LinearExpression) and isinstance(
@@ -1101,7 +1102,7 @@ class BaseExpression(ABC):
                 f"Both sides of the constraint are constant. At least one side must contain variables. {self} {rhs}"
             )
 
-        if isinstance(rhs, SUPPORTED_CONSTANT_TYPES):
+        if isinstance(rhs, CONSTANT_TYPES):
             rhs = as_dataarray(rhs, coords=self.coords, dims=self.coord_dims)
 
             extra_dims = set(rhs.dims) - set(self.coord_dims)
@@ -1564,7 +1565,7 @@ class LinearExpression(BaseExpression):
             return other.__add__(self)
 
         try:
-            if isinstance(other, SUPPORTED_CONSTANT_TYPES):
+            if isinstance(other, CONSTANT_TYPES):
                 return self._add_constant(other)
             else:
                 other = as_expression(other, model=self.model, dims=self.coord_dims)
@@ -1962,7 +1963,7 @@ class LinearExpression(BaseExpression):
         ) -> LinearExpression:
             nonlocal model
 
-            if isinstance(t, SUPPORTED_CONSTANT_TYPES):
+            if isinstance(t, CONSTANT_TYPES):
                 if model is None:
                     raise ValueError("Model must be provided when using constants.")
                 expr = LinearExpression(t, model)
@@ -1981,7 +1982,7 @@ class LinearExpression(BaseExpression):
                         )
                     expr = v.to_linexpr(c)
                 elif isinstance(v, variables.Variable):
-                    if not isinstance(c, SUPPORTED_CONSTANT_TYPES):
+                    if not isinstance(c, CONSTANT_TYPES):
                         raise TypeError(
                             "Expected constant as coefficient of variable (first element of tuple)."
                         )
@@ -2098,7 +2099,7 @@ class QuadraticExpression(BaseExpression):
         dimension names of self will be filled in other
         """
         try:
-            if isinstance(other, SUPPORTED_CONSTANT_TYPES):
+            if isinstance(other, CONSTANT_TYPES):
                 return self._add_constant(other)
             else:
                 other = as_expression(other, model=self.model, dims=self.coord_dims)
@@ -2590,18 +2591,6 @@ class ScalarLinearExpression:
         ds = xr.Dataset({"coeffs": coeffs, "vars": vars})
         return LinearExpression(ds, self.model)
 
-
-SUPPORTED_CONSTANT_TYPES = (
-    np.number,
-    np.bool_,
-    int,
-    float,
-    DataArray,
-    pd.Series,
-    pd.DataFrame,
-    np.ndarray,
-    pl.Series,
-)
 
 SUPPORTED_EXPRESSION_TYPES = (
     BaseExpression,

--- a/linopy/types.py
+++ b/linopy/types.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Hashable, Iterable, Mapping, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, TypeAlias, Union
+from typing import TYPE_CHECKING, TypeAlias, Union, get_args
 
 import numpy
 import polars as pl
@@ -41,6 +41,7 @@ ConstantLike: TypeAlias = (
     | DataFrame
     | pl.Series
 )
+CONSTANT_TYPES: tuple[type, ...] = get_args(ConstantLike)
 SignLike: TypeAlias = str | numpy.ndarray | DataArray | Series | DataFrame
 MaskLike: TypeAlias = numpy.ndarray | DataArray | Series | DataFrame
 PathLike: TypeAlias = str | Path


### PR DESCRIPTION
Drop the hand-rolled `SUPPORTED_CONSTANT_TYPES` tuple in `expressions.py`; use `CONSTANT_TYPES = get_args(ConstantLike)` from `linopy/types.py` instead. Single source of truth for "what counts as a constant".

The old tuple had drifted from the `ConstantLike` alias in two places, both narrowed back to the alias:

- **`np.bool_`**: only uniquely covered scalar `np.True_`/`np.False_` (Python `bool` passes via `int`, bool arrays via `np.ndarray`). Feeding one into an LP coefficient is almost always a bug — caller meant `int(...)`. `LinearExpression(np.True_, m)` crashed downstream on master anyway.
- **`np.number`**: silently subsumed `np.complexfloating`, so complex arrays slipped through and miscomputed.

Both now reject at the gate with a clear error.