### PR TITLE
chore: Return Self from SolverStatus.from_termination_condition

### DIFF
--- a/linopy/constants.py
+++ b/linopy/constants.py
@@ -156,7 +156,7 @@ class SolverStatus(StrEnum):
     @classmethod
     def from_termination_condition(
         cls, termination_condition: "TerminationCondition"
-    ) -> "SolverStatus":
+    ) -> Self:
         for status in STATUS_TO_TERMINATION_CONDITION_MAP:
             if termination_condition in STATUS_TO_TERMINATION_CONDITION_MAP[status]:
                 return status


### PR DESCRIPTION
## Changes proposed in this Pull Request

Small follow-up to #739 (Python 3.11 syntax modernization).

`SolverStatus.from_termination_condition` still returned the quoted `"SolverStatus"`, while its sibling `process` and `Status.from_termination_condition` were converted to `Self` in #739. This makes it consistent.

No functional change.

## Checklist
- [x] I consent to the release of this PR's code under the MIT license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)