### PR TITLE
feat(groupby): fast path for multi-key groupby([names]), flat + non-breaking

### DIFF
--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -252,6 +252,21 @@ class LinearExpressionGroupby:
         """
         group = _resolve_group(self.group, self.data)
 
+        # A list of coord names rides the fast path as a value frame, then
+        # unstacks back to flat dims -- fast and flat, like the fallback (#753).
+        flatten_multikey = False
+        if (
+            not use_fallback
+            and isinstance(group, (list, tuple))
+            and len(group) > 1
+            and all(isinstance(g, str) and g in self.data.coords for g in group)
+        ):
+            coord_dims = {self.data[g].dims for g in group}
+            if len(coord_dims) == 1 and len(next(iter(coord_dims))) == 1:
+                names = list(group)
+                group = self.data[names].to_dataframe()[names]
+                flatten_multikey = True
+
         non_fallback_types = (pd.Series, pd.DataFrame, xr.DataArray)
         if isinstance(group, non_fallback_types) and not use_fallback:
             if isinstance(group, pd.DataFrame):
@@ -297,6 +312,26 @@ class LinearExpressionGroupby:
                 ds = ds.assign_coords(new_coords)
 
             ds = ds.rename({GROUP_DIM: final_group_name})
+            if flatten_multikey:
+                # warn before unstack allocates the grid when the keys are
+                # sparse enough that most cells would be fill (O(observed), not O(N))
+                mi = ds.indexes[final_group_name].remove_unused_levels()
+                observed = len(mi)
+                grid = int(np.prod([len(level) for level in mi.levels]))
+                if grid > 2 * observed and grid - observed > 10_000:
+                    warn(
+                        f"Grouping a LinearExpression by {names} produces a dense "
+                        f"{grid:,}-cell grid, but only {observed:,} of those "
+                        f"combinations occur -- the {grid - observed:,} absent ones "
+                        f"are materialised as fill values. Group by a `pd.DataFrame` "
+                        f"of these keys instead to keep the result compact over only "
+                        f"the observed combinations.",
+                        UserWarning,
+                        stacklevel=2,
+                    )
+                ds = ds.unstack(
+                    final_group_name, fill_value=LinearExpression._fill_value
+                )
             return LinearExpression(ds, self.model)
 
         def func(ds: Dataset) -> Dataset:

--- a/test/test_linear_expression.py
+++ b/test/test_linear_expression.py
@@ -7,6 +7,7 @@ Created on Wed Mar 17 17:06:36 2021.
 
 from __future__ import annotations
 
+import warnings
 from typing import Any
 
 import numpy as np
@@ -1540,6 +1541,73 @@ class TestGroupbyByAttachedCoordinate:
         # is unhashable and raises in xarray itself, so linopy mirrors that.
         with pytest.raises(TypeError, match="unhashable"):
             expr.groupby([period, season]).sum()
+
+    @staticmethod
+    def _sparse_expr(period_vals: list, season_vals: list) -> LinearExpression:
+        n = len(period_vals)
+        s = pd.RangeIndex(n, name="s")
+        m = Model()
+        x = m.add_variables(coords=[s], name="x")
+        return (1.0 * x).assign_coords(
+            period=xr.DataArray(period_vals, dims="s", coords={"s": s}, name="period"),
+            season=xr.DataArray(season_vals, dims="s", coords={"s": s}, name="season"),
+        )
+
+    @pytest.mark.parametrize("spelling", [list, tuple], ids=["list", "tuple"])
+    def test_multikey_fast_path_matches_fallback(self, spelling: type) -> None:
+        # GH #753: the fast path must equal the slow fallback, sparse cells too.
+        expr = self._sparse_expr([2020, 2020, 2030, 2030, 2030], list("wswws"))
+        group = spelling(["period", "season"])
+
+        fast = expr.groupby(group).sum()
+        slow = expr.groupby(group).sum(use_fallback=True)
+
+        assert_linequal(fast, slow)
+
+    def test_multikey_fast_path_is_flat_not_stacked(self) -> None:
+        # built via a stacked index internally, but returns flat separate dims
+        expr = self._sparse_expr([2020, 2020, 2030, 2030], list("wsws"))
+
+        grouped = expr.groupby(["period", "season"]).sum()
+
+        assert {"period", "season"} <= set(grouped.dims)
+        assert "group" not in grouped.dims
+        assert not isinstance(grouped.data.indexes.get("period"), pd.MultiIndex)
+
+    def test_multikey_sparse_combination_is_filled(self) -> None:
+        # (2020, "s") never occurs -> empty term in the flat grid
+        expr = self._sparse_expr([2020, 2020, 2030, 2030], list("wwws"))
+
+        grouped = expr.groupby(["period", "season"]).sum()
+
+        cell = grouped.sel(period=2020, season="s")
+        assert (cell.vars == -1).all()
+        assert cell.coeffs.isnull().all()
+
+    def test_multikey_dataframe_grouper_stays_compact(self) -> None:
+        # the DataFrame grouper keeps the stacked observed-only group dim
+        expr = self._sparse_expr([2020, 2020, 2030, 2030], list("wwws"))
+        df = expr.data[["period", "season"]].to_dataframe()[["period", "season"]]
+
+        grouped = expr.groupby(df).sum()
+
+        assert "group" in grouped.dims
+        assert isinstance(grouped.data.indexes["group"], pd.MultiIndex)
+        assert grouped.sizes["group"] == 3  # observed, not the 2x2=4 grid
+
+    def test_multikey_blowup_warns_when_sparse(self) -> None:
+        # 200 observed combos, 200x200 grid -> nudge toward the DataFrame grouper
+        expr = self._sparse_expr(list(range(200)), list(range(200)))
+
+        with pytest.warns(UserWarning, match="dense .* grid"):
+            expr.groupby(["period", "season"]).sum()
+
+    def test_multikey_no_warning_when_dense(self) -> None:
+        expr = self._sparse_expr([2020, 2020, 2030, 2030], list("wsws"))
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            expr.groupby(["period", "season"]).sum()
 
     @pytest.mark.parametrize("use_fallback", [True, False])
     @pytest.mark.parametrize(


### PR DESCRIPTION
## What

Makes multi-key grouping by coordinate names — `expr.groupby(["a", "b"]).sum()` — take the fast reindex path instead of the slow xarray fallback, while keeping its **flat** output and changing nothing about the existing `DataFrame` grouper. Implements the validated, non-breaking direction from #753.

Stacked on top of #751 (`fix/groupby-coord-name`) — it builds on the `_resolve_group` helper introduced there. **Merge #751 first.**

## How

- A list/tuple of coordinate names (1-D, sharing one dimension) is resolved to a value frame so it rides the existing reindex fast path, then the stacked result is `unstack`ed back into one dim per name. The output is **byte-identical** to the old fallback, sparse fill cells included (verified with `assert_linequal`).
- `groupby(df)` (user-supplied `DataFrame`) is **untouched** — it keeps its compact stacked-`MultiIndex` output over observed combinations only. So this is non-breaking; the tested DataFrame contract still holds.

## Memory note

Flat dims are a dense cartesian grid, so a sparse key crossing materialises mostly-fill cells (measured ~100× vs the DataFrame grouper for a diagonal crossing — see #740). A `UserWarning` fires when the grid is much larger than the observed combinations, pointing users at the compact `DataFrame` grouper. The check reads the collapsed `MultiIndex` levels, so it is O(observed), not O(N), and fires *before* `unstack` allocates the grid.

This is fundamental to dense xarray (separate dims = dense grid); truly flat-and-compact needs a sparse/long-format kernel — tracked as "Future directions" on #753 and as evidence on #740.

## Tests

Six new cases in `TestGroupbyByAttachedCoordinate`: fast-path == fallback (list/tuple, sparse), flat-not-stacked, sparse-combination-filled, DataFrame-grouper-stays-compact, warns-when-sparse, silent-when-dense. Full groupby suite (58) + ruff + mypy green.

Closes #753.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
