### PR TITLE
fix(alignment): tolerate xarray without CoordinateValidationError

### DIFF
--- a/linopy/alignment.py
+++ b/linopy/alignment.py
@@ -33,9 +33,16 @@ from numpy import arange
 from xarray import Coordinates, DataArray, Dataset, broadcast
 from xarray import align as xr_align
 from xarray.core import dtypes
-from xarray.core.coordinates import CoordinateValidationError
 from xarray.core.types import JoinOptions, T_Alignable
 from xarray.namedarray.utils import is_dict_like
+
+try:
+    from xarray.core.coordinates import CoordinateValidationError
+except ImportError:
+    # CoordinateValidationError was added in xarray 2025.6.0. On older
+    # versions the same failures surface as plain ValueError, which it
+    # subclasses, so falling back to ValueError preserves the catch below.
+    CoordinateValidationError = ValueError  # type: ignore[assignment, misc]
 
 from linopy.constants import (
     HELPER_DIMS,

--- a/linopy/alignment.py
+++ b/linopy/alignment.py
@@ -39,9 +39,7 @@ from xarray.namedarray.utils import is_dict_like
 try:
     from xarray.core.coordinates import CoordinateValidationError
 except ImportError:
-    # CoordinateValidationError was added in xarray 2025.6.0. On older
-    # versions the same failures surface as plain ValueError, which it
-    # subclasses, so falling back to ValueError preserves the catch below.
+    # Added in xarray 2025.6.0; it subclasses ValueError on newer versions.
     CoordinateValidationError = ValueError  # type: ignore[assignment, misc]
 
 from linopy.constants import (


### PR DESCRIPTION
Subtle import bug introduced when refactoring alignment.py. Older xarray did not have the used 'CoordinateValidationError'.

> [!NOTE]
> The following content was generated by AI.

## Summary

Fixes #761. `import linopy` currently fails on xarray versions in `[2024.2.0, 2025.5]` with:

```
ImportError: cannot import name 'CoordinateValidationError'
```

`CoordinateValidationError` was only added in **xarray 2025.6.0**, but `pyproject.toml` declares a floor of `xarray>=2024.2.0`, so the hard import in `linopy/alignment.py` breaks any install with an older (but supported) xarray.

## Fix

Wrap the import in a `try/except ImportError` and fall back to `ValueError` when the symbol is absent. `CoordinateValidationError` subclasses `ValueError`, so the existing `except (ValueError, CoordinateValidationError)` in `broadcast_to_coords` behaves identically on older xarray — the fix is behavior-preserving on both new and old versions.

This takes option 2 from the issue (import resilience) rather than bumping the xarray floor, keeping the declared compatibility range honest.

## Testing

- `ruff check` / `ruff format --check` / `mypy` clean on the changed file
- `pytest test/test_alignment.py` — 95 passed
- Manually verified the fallback resolves to `ValueError` when the symbol is removed, and the normal path still resolves to the real class

🤖 Generated with [Claude Code](https://claude.com/claude-code)