### PR TITLE
refactor(deps): split contributor extras into PEP 735 dependency groups

### DIFF
--- a/.github/workflows/claude-code-review.yml.bkp
+++ b/.github/workflows/claude-code-review.yml.bkp
@@ -78,7 +78,7 @@ jobs:
           #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
 
           # Project-specific tools for Python development
-          allowed_tools: "Bash(pytest),Bash(ruff check .),Bash(ruff format .),Bash(mypy .),Bash(uv pip install -e .[dev,solvers])"
+          allowed_tools: "Bash(pytest),Bash(ruff check .),Bash(ruff format .),Bash(mypy .),Bash(uv pip install -e .[solvers] --group dev)"
 
           # Optional: Skip review for certain conditions
           # if: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -59,7 +59,7 @@ jobs:
           # assignee_trigger: "claude-bot"
 
           # Project-specific tools for Python development
-          allowed_tools: "Bash(pytest),Bash(ruff check .),Bash(ruff format .),Bash(mypy .),Bash(uv pip install -e .[dev,solvers])"
+          allowed_tools: "Bash(pytest),Bash(ruff check .),Bash(ruff format .),Bash(mypy .),Bash(uv pip install -e .[solvers] --group dev)"
 
           # Custom instructions for linopy project
           custom_instructions: |

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install package and dependencies
       run: |
         python -m pip install uv
-        uv pip install --system -e ".[docs]"
+        uv pip install --system -e . --group docs
 
     - name: Execute notebooks
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
     - name: Install package and dependencies
       run: |
         python -m pip install uv
-        uv pip install --system "$(ls dist/*.whl)[dev,solvers,oetc]"
+        uv pip install --system "$(ls dist/*.whl)[solvers,oetc]" --group dev
 
     - name: Test with pytest
       env:
@@ -120,7 +120,7 @@ jobs:
     - name: Install package and dependencies
       run: |
         python -m pip install uv
-        uv pip install --system "$(ls dist/*.whl)[dev]"
+        uv pip install --system "$(ls dist/*.whl)" --group dev
 
     - name: Run type checker (mypy)
       run: |

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,7 +10,7 @@ build:
     - git fetch --unshallow # Needed to get version tags
 python:
   install:
-    - method: pip
-      path: .
-      extra_requirements:
+    - method: uv
+      command: sync
+      groups:
         - docs

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Note that these do have to be installed by the user separately.
 To set up a local development environment for linopy and to run the same tests that are run in the CI, you can run:
 
 ```sh
-uv sync --extra dev --extra solvers
+uv sync --group dev --extra solvers
 source .venv/bin/activate
 pytest
 ```

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -7,7 +7,8 @@ Measures linopy's own performance (build time, LP write speed, memory usage) acr
 ## Setup
 
 ```bash
-pip install -e ".[benchmarks]"
+pip install -e . --group benchmarks   # pip >= 25.1
+# or: uv sync --group benchmarks
 ```
 
 ## Running benchmarks

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -43,7 +43,7 @@ To run the test suite:
 .. code-block:: bash
 
     # Install development dependencies
-    uv sync --extra dev --extra solvers
+    uv sync --group dev --extra solvers
 
     # Run all tests
     pytest
@@ -56,6 +56,20 @@ To run the test suite:
 
     # Run a specific test function
     pytest test/test_model.py::test_model_creation
+
+The contributor toolchains (``dev``, ``docs``, ``benchmarks``) are
+`PEP 735 <https://peps.python.org/pep-0735/>`_ dependency groups rather than
+extras, so they are installed with ``--group`` instead of ``--extra`` and are
+not reachable through the ``.[...]`` syntax. With pip, dependency groups
+require **pip >= 25.1**:
+
+.. code-block:: bash
+
+    pip install -e . --group dev      # pip >= 25.1
+    uv sync --group dev               # uv (any recent version)
+
+The runtime extras (``solvers``, ``oetc``, ``remote``) are unaffected and are
+still installed the usual way, e.g. ``pip install linopy[solvers]``.
 
 GPU Testing
 -----------
@@ -84,7 +98,7 @@ When working on performance-sensitive code, use the internal benchmark suite in 
 .. code-block:: bash
 
     # Install benchmark dependencies
-    uv sync --extra benchmarks
+    uv sync --group benchmarks
 
     # Quick timing benchmarks
     pytest benchmarks/ --quick

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,21 @@ oetc = [
 remote = [
     "paramiko",
 ]
+solvers = [
+    "gurobipy",
+    "highspy>=1.5.0,!=1.14.0; python_version < '3.12'",
+    "highspy>=1.7.1,!=1.14.0; python_version >= '3.12'",
+    "cplex; platform_system != 'Darwin'",
+    "mosek",
+    "mindoptpy",
+    "coptpy!=7.2.1",
+    "xpress; platform_system != 'Darwin'",
+    "pyscipopt; platform_system != 'Darwin'",
+    "knitro>=15.1.0",
+    # "cupdlpx>=0.1.2", pip package currently unstable
+]
+
+[dependency-groups]
 docs = [
     "ipython==8.26.0",
     "numpydoc==1.7.0",
@@ -87,19 +102,6 @@ benchmarks = [
     "pypsa",
     "highspy>=1.7.1",
     "pytest-memray",
-]
-solvers = [
-    "gurobipy",
-    "highspy>=1.5.0,!=1.14.0; python_version < '3.12'",
-    "highspy>=1.7.1,!=1.14.0; python_version >= '3.12'",
-    "cplex; platform_system != 'Darwin'",
-    "mosek",
-    "mindoptpy",
-    "coptpy!=7.2.1",
-    "xpress; platform_system != 'Darwin'",
-    "pyscipopt; platform_system != 'Darwin'",
-    "knitro>=15.1.0",
-    # "cupdlpx>=0.1.2", pip package currently unstable
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Refactor deps to modern "dependency-groupy". Also, update readthedocs to use uv directly.

Closes #763

> [!NOTE]
> The following content was generated by AI.

### What

Move the dev/contributor-only dependency sets out of `[project.optional-dependencies]` (extras) into `[dependency-groups]` (PEP 735):

- **→ dependency groups:** `dev`, `docs`, `benchmarks`
- **stay as extras:** `solvers`, `oetc`, `remote` (runtime-facing — consumers install these from PyPI, so they belong in the wheel metadata)

### Why

The contributor toolchains have no business shipping in the published wheel metadata. PEP 735 groups are the right home for them; they're never exposed to consumers and can't be pulled via `pip install linopy[dev]`.

### Implications for installers

| | how |
|---|---|
| extras (`solvers`, `oetc`, `remote`) | `pip install ".[solvers]"` — unchanged |
| groups (`dev`, `docs`, `benchmarks`) | `uv sync --group dev` / `pip install --group dev` (**pip ≥ 25.1**) |

Groups are **not** reachable via the `.[...]` syntax, so this is a breaking change for contributors on pip < 25.1.

### Call-outs for review

- **CI** (`test.yml`, `test-notebooks.yml`): groups now installed via `uv ... --group`; runtime extras stay on the built wheel.
- **Read the Docs**: switched to RTD's native uv install (`method: uv`, `command: sync`, `groups: [docs]`) — verified against the [RTD config schema](https://docs.readthedocs.com/platform/stable/config-file/v2.html). This avoids depending on the RTD builder's system pip version.
- **`claude.yml` `allowed_tools`**: updated to match the new install command.
- Docs (`README`, `contributing.rst`, `benchmarks/README`) updated, incl. an explicit pip ≥ 25.1 note.

### Draft — open question

Should `dev` move too, or only `docs`/`benchmarks`? Moving `dev` is the most invasive part (it changes the contributor onboarding command and the wheel-install step in `test.yml`). Flagging for maintainer preference.