### PR TITLE
Fix variables via bound collapse instead of equality constraint

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -7,6 +7,8 @@ Upcoming Version
 * Add documentation about `LinearExpression.where` with `drop=True`. Add `BaseExpression.variable_names` property.
 * Add ``BaseExpression.has_terms`` property: boolean array, true at slots with at least one live term (`#741 <https://github.com/PyPSA/linopy/issues/741>`_).
 * ``Variable.fix(value)`` now places ``value`` correctly on variables with named dimensions; previously array values could be misaligned.
+* ``Variable.fix()`` now fixes a variable by collapsing its bounds (``lower = upper = value``) instead of adding a ``__fix__`` equality constraint; ``unfix()`` restores the original bounds (`#769 <https://github.com/PyPSA/linopy/issues/769>`_). A fix outside the current bounds now warns and overrides instead of raising, and its shadow price appears as the variable's reduced cost rather than a constraint dual.
+* Binary variable bounds are now respected by the solver, so fixing a binary works (they were previously forced to ``[0, 1]``).
 
 **Features**
 

--- a/examples/manipulating-models.ipynb
+++ b/examples/manipulating-models.ipynb
@@ -357,7 +357,7 @@
    "id": "30",
    "metadata": {},
    "source": [
-    "Calling `unfix()` on all variables removes the fix constraints and `unrelax()` restores the integrality of `z`."
+    "Calling `unfix()` on all variables restores their original bounds and `unrelax()` restores the integrality of `z`."
    ]
   },
   {

--- a/linopy/constants.py
+++ b/linopy/constants.py
@@ -39,6 +39,7 @@ sign_replace_dict: dict[str, str] = {
 
 STASHED_LOWER = "_stashed_lower"
 STASHED_UPPER = "_stashed_upper"
+STASHED_ATTRS: list[str] = [STASHED_LOWER, STASHED_UPPER]
 
 TERM_DIM = "_term"
 STACKED_TERM_DIM = "_stacked_term"

--- a/linopy/constants.py
+++ b/linopy/constants.py
@@ -37,7 +37,8 @@ sign_replace_dict: dict[str, str] = {
     short_LESS_EQUAL: LESS_EQUAL,
 }
 
-FIX_CONSTRAINT_PREFIX = "__fix__"
+STASHED_LOWER = "_stashed_lower"
+STASHED_UPPER = "_stashed_upper"
 
 TERM_DIM = "_term"
 STACKED_TERM_DIM = "_stacked_term"

--- a/linopy/io.py
+++ b/linopy/io.py
@@ -249,7 +249,9 @@ def bounds_to_file(
         list(m.variables.continuous)
         + list(m.variables.integers)
         + list(m.variables.semi_continuous)
-        + [n for n in m.variables.binaries if m.variables[n].fixed] # fixed binaries need bounds
+        + [
+            n for n in m.variables.binaries if m.variables[n].fixed
+        ]  # fixed binaries need bounds
     )
     if not len(list(names)):
         return

--- a/linopy/io.py
+++ b/linopy/io.py
@@ -245,12 +245,11 @@ def bounds_to_file(
     """
     Write out variables of a model to a lp file.
     """
-    # Fixed binaries need explicit bounds; the `binary` section implies [0, 1].
     names = (
         list(m.variables.continuous)
         + list(m.variables.integers)
         + list(m.variables.semi_continuous)
-        + [n for n in m.variables.binaries if m.variables[n].fixed]
+        + [n for n in m.variables.binaries if m.variables[n].fixed] # fixed binaries need bounds
     )
     if not len(list(names)):
         return

--- a/linopy/io.py
+++ b/linopy/io.py
@@ -245,10 +245,12 @@ def bounds_to_file(
     """
     Write out variables of a model to a lp file.
     """
+    # Fixed binaries need explicit bounds; the `binary` section implies [0, 1].
     names = (
         list(m.variables.continuous)
         + list(m.variables.integers)
         + list(m.variables.semi_continuous)
+        + [n for n in m.variables.binaries if m.variables[n].fixed]
     )
     if not len(list(names)):
         return

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -1149,16 +1149,8 @@ class Model:
         -------
         None.
         """
-        from linopy.constants import FIX_CONSTRAINT_PREFIX
-
         variable = self.variables[name]
 
-        # Clean up fix constraint if present
-        fix_name = f"{FIX_CONSTRAINT_PREFIX}{name}"
-        if fix_name in self.constraints:
-            self.constraints.remove(fix_name)
-
-        # Clean up relaxed registry if present
         self._relaxed_registry.pop(name, None)
 
         to_remove = [

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -2821,7 +2821,6 @@ class Mosek(Solver[None]):
         if len(model.binaries.labels) + len(model.integers.labels) > 0:
             idx = [i for (i, v) in enumerate(M.vtypes) if v in ["B", "I"]]
             task.putvartypelist(idx, [mosek.variabletype.type_int] * len(idx))
-            # Do not reset binary bounds to [0, 1]; that would free a fixed binary.
 
         if len(model.constraints) > 0:
             if set_names:

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -1268,12 +1268,6 @@ class Highs(Solver[None]):
                 [integrality_map[v] for v in vtypes[int_mask]], dtype=np.int32
             )
             h.changeColsIntegrality(len(labels), labels, integrality)
-            if len(model.binaries):
-                labels = np.arange(len(vtypes))[vtypes == "B"]
-                n = len(labels)
-                h.changeColsBounds(
-                    n, labels, np.zeros_like(labels), np.ones_like(labels)
-                )
 
         c = M.c
         h.changeColsCost(len(c), np.arange(len(c), dtype=np.int32), c)
@@ -2827,9 +2821,7 @@ class Mosek(Solver[None]):
         if len(model.binaries.labels) + len(model.integers.labels) > 0:
             idx = [i for (i, v) in enumerate(M.vtypes) if v in ["B", "I"]]
             task.putvartypelist(idx, [mosek.variabletype.type_int] * len(idx))
-            if len(model.binaries.labels) > 0:
-                bidx = [i for (i, v) in enumerate(M.vtypes) if v == "B"]
-                task.putvarboundlistconst(bidx, mosek.boundkey.ra, 0.0, 1.0)
+            # Do not reset binary bounds to [0, 1]; that would free a fixed binary.
 
         if len(model.constraints) > 0:
             if set_names:

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -56,10 +56,11 @@ from linopy.common import (
 )
 from linopy.config import options
 from linopy.constants import (
-    FIX_CONSTRAINT_PREFIX,
     HELPER_DIMS,
     SOS_DIM_ATTR,
     SOS_TYPE_ATTR,
+    STASHED_LOWER,
+    STASHED_UPPER,
     TERM_DIM,
 )
 from linopy.types import (
@@ -1341,9 +1342,15 @@ class Variable:
         overwrite: bool = True,
     ) -> None:
         """
-        Fix the variable to a given value by adding an equality constraint.
+        Fix the variable to a given value by collapsing its bounds.
+
+        Sets ``lower = upper = value``.
 
         If no value is given, the current solution value is used.
+
+        A fix value outside the variable's current bounds emits a warning, but
+        does not cause infeasibilities (the bounds are overridden). Fixing a
+        binary variable to anything other than 0 or 1 raises.
 
         Parameters
         ----------
@@ -1354,8 +1361,9 @@ class Variable:
             Integer and binary variables are always rounded to 0 decimal places.
             Default is 8.
         overwrite : bool, optional
-            If True (default), overwrite an existing fix constraint for this
-            variable. If False, raise an error if the variable is already fixed.
+            If True (default), re-fix a variable that is already fixed to the
+            new value (the originally stashed bounds are kept). If False, raise
+            an error if the variable is already fixed.
         """
         if value is None:
             try:
@@ -1377,41 +1385,59 @@ class Variable:
         else:
             value = value.round(decimals)
 
-        if (value < self.lower).any() or (value > self.upper).any():
+        if self.fixed and not overwrite:
             msg = (
-                f"Fix values for variable '{self.name}' are outside the "
-                "variable bounds."
+                f"Variable '{self.name}' is already fixed. Use "
+                "overwrite=True to replace the existing fix value."
             )
             raise ValueError(msg)
 
-        constraint_name = f"{FIX_CONSTRAINT_PREFIX}{self.name}"
+        if self.fixed:
+            lower, upper = self.data[STASHED_LOWER], self.data[STASHED_UPPER]
+        else:
+            lower, upper = self.data.lower, self.data.upper
 
-        if constraint_name in self.model.constraints:
-            if not overwrite:
+        if self.attrs.get("binary"):
+            if (((value != 0) & (value != 1)).any()).item():
                 msg = (
-                    f"Variable '{self.name}' is already fixed. Use "
-                    "overwrite=True to replace the existing fix constraint."
+                    f"Cannot fix binary variable '{self.name}' to a value "
+                    "other than 0 or 1."
                 )
                 raise ValueError(msg)
-            self.model.remove_constraints(constraint_name)
+        elif (value < lower).any() or (value > upper).any():
+            warn(
+                f"Fix values for variable '{self.name}' lie outside its current "
+                "bounds; the bounds are overridden by the fix value.",
+                UserWarning,
+                stacklevel=2,
+            )
 
-        self.model.add_constraints(self, "=", value, name=constraint_name)
+        if not self.fixed:
+            self._data = assign_multiindex_safe(
+                self.data,
+                **{STASHED_LOWER: lower, STASHED_UPPER: upper},
+            )
+
+        self.lower = value
+        self.upper = value
 
     def unfix(self) -> None:
         """
-        Remove the fix constraint for this variable.
+        Unfix the variable, restoring the bounds it had before :meth:`fix`.
         """
-        constraint_name = f"{FIX_CONSTRAINT_PREFIX}{self.name}"
-        if constraint_name in self.model.constraints:
-            self.model.remove_constraints(constraint_name)
+        if not self.fixed:
+            return
+
+        self.lower = self.data[STASHED_LOWER]
+        self.upper = self.data[STASHED_UPPER]
+        self._data = self.data.drop_vars([STASHED_LOWER, STASHED_UPPER])
 
     @property
     def fixed(self) -> bool:
         """
         Return whether the variable is currently fixed.
         """
-        constraint_name = f"{FIX_CONSTRAINT_PREFIX}{self.name}"
-        return constraint_name in self.model.constraints
+        return STASHED_LOWER in self.data
 
 
 class AtIndexer:

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -59,6 +59,7 @@ from linopy.constants import (
     HELPER_DIMS,
     SOS_DIM_ATTR,
     SOS_TYPE_ATTR,
+    STASHED_ATTRS,
     STASHED_LOWER,
     STASHED_UPPER,
     TERM_DIM,
@@ -1014,7 +1015,7 @@ class Variable:
         -------
         df : pandas.DataFrame
         """
-        ds = self.data
+        ds = self.data.drop_vars(STASHED_ATTRS, errors="ignore")
 
         def mask_func(data: pd.DataFrame) -> pd.Series:
             return data["labels"] != -1
@@ -1034,7 +1035,8 @@ class Variable:
         -------
         pl.DataFrame
         """
-        df = to_polars(self.data)
+        ds = self.data.drop_vars(STASHED_ATTRS, errors="ignore")
+        df = to_polars(ds)
         df = filter_nulls_polars(df)
         check_has_nulls_polars(df, name=f"{self.type} {self.name}")
         return df
@@ -1376,35 +1378,39 @@ class Variable:
                 )
                 raise ValueError(msg) from None
 
-        value = broadcast_to_coords(
-            value, self.coords, label=f"fix() for variable '{self.name}'"
-        )
+        is_fixed = self.fixed
+        is_binary = self.attrs["binary"]
+        is_integer = self.attrs["integer"]
 
-        if self.attrs.get("integer") or self.attrs.get("binary"):
-            value = value.round(0)
-        else:
-            value = value.round(decimals)
-
-        if self.fixed and not overwrite:
+        if is_fixed and not overwrite:
             msg = (
                 f"Variable '{self.name}' is already fixed. Use "
                 "overwrite=True to replace the existing fix value."
             )
             raise ValueError(msg)
 
-        if self.fixed:
+        value = broadcast_to_coords(
+            value, self.coords, label=f"fix() for variable '{self.name}'"
+        )
+
+        if is_binary and not (np.isclose(value, 0) | np.isclose(value, 1)).all():
+            msg = (
+                f"Cannot fix binary variable '{self.name}' to a value "
+                "other than 0 or 1."
+            )
+            raise ValueError(msg)
+
+        if is_integer or is_binary:
+            value = value.round(0)
+        else:
+            value = value.round(decimals)
+
+        if is_fixed:
             lower, upper = self.data[STASHED_LOWER], self.data[STASHED_UPPER]
         else:
             lower, upper = self.data.lower, self.data.upper
 
-        if self.attrs.get("binary"):
-            if (((value != 0) & (value != 1)).any()).item():
-                msg = (
-                    f"Cannot fix binary variable '{self.name}' to a value "
-                    "other than 0 or 1."
-                )
-                raise ValueError(msg)
-        elif (value < lower).any() or (value > upper).any():
+        if not is_binary and ((value < lower).any() or (value > upper).any()):
             warn(
                 f"Fix values for variable '{self.name}' lie outside its current "
                 "bounds; the bounds are overridden by the fix value.",
@@ -1412,7 +1418,7 @@ class Variable:
                 stacklevel=2,
             )
 
-        if not self.fixed:
+        if not is_fixed:
             self._data = assign_multiindex_safe(
                 self.data,
                 **{STASHED_LOWER: lower, STASHED_UPPER: upper},
@@ -1430,14 +1436,14 @@ class Variable:
 
         self.lower = self.data[STASHED_LOWER]
         self.upper = self.data[STASHED_UPPER]
-        self._data = self.data.drop_vars([STASHED_LOWER, STASHED_UPPER])
+        self._data = self.data.drop_vars(STASHED_ATTRS)
 
     @property
     def fixed(self) -> bool:
         """
         Return whether the variable is currently fixed.
         """
-        return STASHED_LOWER in self.data
+        return all(attr in self.data for attr in STASHED_ATTRS)
 
 
 class AtIndexer:
@@ -1753,7 +1759,7 @@ class Variables:
         decimals : int, optional
             Number of decimal places to round continuous variables to.
         overwrite : bool, optional
-            If True, overwrite existing fix constraints.
+            If True, re-fix variables that are already fixed.
         """
         for var in self.data.values():
             var.fix(value=value, decimals=decimals, overwrite=overwrite)

--- a/test/test_fix_relax.py
+++ b/test/test_fix_relax.py
@@ -172,6 +172,19 @@ class TestVariableFix:
             m.variables["y"].upper.values, [2.71828, -1.41421]
         )
 
+    def test_fix_aligns_positional_value_to_named_dimension(self) -> None:
+        m = Model()
+        t = m.add_variables(
+            lower=-5,
+            upper=5,
+            coords=[pd.Index([2020, 2030, 2040], name="time")],
+            name="t",
+        )
+        t.fix([1.0, 2.0, 3.0])
+        assert t.lower.dims == ("time",)
+        np.testing.assert_array_almost_equal(t.lower.values, [1.0, 2.0, 3.0])
+        np.testing.assert_array_almost_equal(t.upper.values, [1.0, 2.0, 3.0])
+
 
 class TestVariableUnfix:
     def test_unfix_restores_bounds(self, model_with_solution: Model) -> None:
@@ -579,14 +592,3 @@ class TestFixIO:
         m2.variables["z"].unrelax()
         assert m2.variables["z"].attrs["binary"]
         assert "z" not in m2._relaxed_registry
-
-
-def test_fix_aligns_positional_value_to_named_dimension() -> None:
-    m = Model()
-    t = m.add_variables(
-        lower=-5, upper=5, coords=[pd.Index([2020, 2030, 2040], name="time")], name="t"
-    )
-    t.fix([1.0, 2.0, 3.0])
-    assert t.lower.dims == ("time",)
-    np.testing.assert_array_almost_equal(t.lower.values, [1.0, 2.0, 3.0])
-    np.testing.assert_array_almost_equal(t.upper.values, [1.0, 2.0, 3.0])

--- a/test/test_fix_relax.py
+++ b/test/test_fix_relax.py
@@ -8,7 +8,6 @@ import pytest
 from xarray import DataArray
 
 from linopy import Model
-from linopy.constants import FIX_CONSTRAINT_PREFIX
 
 
 @pytest.fixture
@@ -54,58 +53,91 @@ class TestVariableFix:
         m = model_with_solution
         m.variables["x"].fix(value=value)
         assert m.variables["x"].fixed
-        con = m.constraints[f"{FIX_CONSTRAINT_PREFIX}x"]
-        np.testing.assert_almost_equal(con.rhs.item(), 5.0)
+        np.testing.assert_almost_equal(m.variables["x"].lower.item(), 5.0)
+        np.testing.assert_almost_equal(m.variables["x"].upper.item(), 5.0)
 
     @pytest.mark.parametrize("value", ARRAY_VALUES)
     def test_fix_array_dtypes(self, model_with_solution: Model, value: object) -> None:
         m = model_with_solution
         m.variables["y"].fix(value=value)
         assert m.variables["y"].fixed
-        con = m.constraints[f"{FIX_CONSTRAINT_PREFIX}y"]
-        np.testing.assert_array_almost_equal(con.rhs.values, [2.5, -1.5])
+        np.testing.assert_array_almost_equal(m.variables["y"].lower.values, [2.5, -1.5])
+        np.testing.assert_array_almost_equal(m.variables["y"].upper.values, [2.5, -1.5])
 
     def test_fix_uses_solution(self, model_with_solution: Model) -> None:
         m = model_with_solution
         m.variables["x"].fix()
         assert m.variables["x"].fixed
-        assert f"{FIX_CONSTRAINT_PREFIX}x" in m.constraints
+        np.testing.assert_almost_equal(m.variables["x"].lower.item(), 3.14159265)
+        np.testing.assert_almost_equal(m.variables["x"].upper.item(), 3.14159265)
+
+    def test_fix_does_not_add_constraint(self, model_with_solution: Model) -> None:
+        m = model_with_solution
+        m.variables["x"].fix(value=5.0)
+        assert len(m.constraints) == 0
 
     def test_fix_rounds_binary(self, model_with_solution: Model) -> None:
         m = model_with_solution
         m.variables["z"].fix()
-        con = m.constraints[f"{FIX_CONSTRAINT_PREFIX}z"]
-        np.testing.assert_equal(con.rhs.item(), 1.0)
+        np.testing.assert_equal(m.variables["z"].lower.item(), 1.0)
+        np.testing.assert_equal(m.variables["z"].upper.item(), 1.0)
+
+    def test_fix_binary_to_zero(self, model_with_solution: Model) -> None:
+        m = model_with_solution
+        m.variables["z"].fix(value=0)
+        np.testing.assert_equal(m.variables["z"].lower.item(), 0.0)
+        np.testing.assert_equal(m.variables["z"].upper.item(), 0.0)
+
+    def test_fix_binary_outside_domain_raises(self, model_with_solution: Model) -> None:
+        m = model_with_solution
+        with pytest.raises(ValueError, match="binary variable"):
+            m.variables["z"].fix(value=5)
 
     def test_fix_rounds_integer(self, model_with_solution: Model) -> None:
         m = model_with_solution
         m.variables["w"].fix()
-        con = m.constraints[f"{FIX_CONSTRAINT_PREFIX}w"]
-        np.testing.assert_equal(con.rhs.item(), 42.0)
+        np.testing.assert_equal(m.variables["w"].lower.item(), 42.0)
+        np.testing.assert_equal(m.variables["w"].upper.item(), 42.0)
 
     def test_fix_rounds_continuous(self, model_with_solution: Model) -> None:
         m = model_with_solution
         m.variables["x"].fix(decimals=4)
-        con = m.constraints[f"{FIX_CONSTRAINT_PREFIX}x"]
-        np.testing.assert_almost_equal(con.rhs.item(), 3.1416, decimal=4)
+        np.testing.assert_almost_equal(m.variables["x"].lower.item(), 3.1416, decimal=4)
+        np.testing.assert_almost_equal(m.variables["x"].upper.item(), 3.1416, decimal=4)
 
-    def test_fix_raises_above_upper_bound(self, model_with_solution: Model) -> None:
+    def test_fix_above_upper_bound_warns_and_overrides(
+        self, model_with_solution: Model
+    ) -> None:
         m = model_with_solution
-        with pytest.raises(ValueError, match="outside the variable bounds"):
+        with pytest.warns(UserWarning, match="outside its current"):
             m.variables["x"].fix(value=11.0)
+        np.testing.assert_almost_equal(m.variables["x"].lower.item(), 11.0)
+        np.testing.assert_almost_equal(m.variables["x"].upper.item(), 11.0)
 
-    def test_fix_raises_below_lower_bound(self, model_with_solution: Model) -> None:
+    def test_fix_below_lower_bound_warns_and_overrides(
+        self, model_with_solution: Model
+    ) -> None:
         m = model_with_solution
-        with pytest.raises(ValueError, match="outside the variable bounds"):
+        with pytest.warns(UserWarning, match="outside its current"):
             m.variables["x"].fix(value=-1.0)
+        np.testing.assert_almost_equal(m.variables["x"].lower.item(), -1.0)
+        np.testing.assert_almost_equal(m.variables["x"].upper.item(), -1.0)
+
+    def test_fix_within_bounds_does_not_warn(self, model_with_solution: Model) -> None:
+        m = model_with_solution
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            m.variables["x"].fix(value=5.0)
 
     def test_fix_small_overshoot_rounded_within_bounds(
         self, model_with_solution: Model
     ) -> None:
         m = model_with_solution
         m.variables["x"].fix(value=10.0000000001)
-        con = m.constraints[f"{FIX_CONSTRAINT_PREFIX}x"]
-        np.testing.assert_almost_equal(con.rhs.item(), 10.0)
+        np.testing.assert_almost_equal(m.variables["x"].lower.item(), 10.0)
+        np.testing.assert_almost_equal(m.variables["x"].upper.item(), 10.0)
 
     def test_fix_raises_if_already_fixed_no_overwrite(
         self, model_with_solution: Model
@@ -115,28 +147,54 @@ class TestVariableFix:
         with pytest.raises(ValueError, match="already fixed"):
             m.variables["x"].fix(value=5.0, overwrite=False)
 
-    def test_fix_overwrite_replaces_existing(self, model_with_solution: Model) -> None:
+    def test_fix_overwrite_keeps_original_stashed_bounds(
+        self, model_with_solution: Model
+    ) -> None:
         m = model_with_solution
         m.variables["x"].fix(value=3.0)
         m.variables["x"].fix(value=5.0, overwrite=True)
-        con = m.constraints[f"{FIX_CONSTRAINT_PREFIX}x"]
-        np.testing.assert_almost_equal(con.rhs.item(), 5.0)
+        np.testing.assert_almost_equal(m.variables["x"].lower.item(), 5.0)
+        np.testing.assert_almost_equal(m.variables["x"].upper.item(), 5.0)
+        m.variables["x"].unfix()
+        np.testing.assert_almost_equal(m.variables["x"].lower.item(), 0.0)
+        np.testing.assert_almost_equal(m.variables["x"].upper.item(), 10.0)
 
     def test_fix_multidimensional(self, model_with_solution: Model) -> None:
         m = model_with_solution
         m.variables["y"].fix()
         assert m.variables["y"].fixed
-        con = m.constraints[f"{FIX_CONSTRAINT_PREFIX}y"]
-        np.testing.assert_array_almost_equal(con.rhs.values, [2.71828, -1.41421])
+        np.testing.assert_array_almost_equal(
+            m.variables["y"].lower.values, [2.71828, -1.41421]
+        )
+        np.testing.assert_array_almost_equal(
+            m.variables["y"].upper.values, [2.71828, -1.41421]
+        )
 
 
 class TestVariableUnfix:
-    def test_unfix_removes_constraint(self, model_with_solution: Model) -> None:
+    def test_unfix_restores_bounds(self, model_with_solution: Model) -> None:
         m = model_with_solution
         m.variables["x"].fix(value=5.0)
         m.variables["x"].unfix()
         assert not m.variables["x"].fixed
-        assert f"{FIX_CONSTRAINT_PREFIX}x" not in m.constraints
+        np.testing.assert_almost_equal(m.variables["x"].lower.item(), 0.0)
+        np.testing.assert_almost_equal(m.variables["x"].upper.item(), 10.0)
+
+    def test_unfix_restores_multidimensional_bounds(
+        self, model_with_solution: Model
+    ) -> None:
+        m = model_with_solution
+        m.variables["y"].fix()
+        m.variables["y"].unfix()
+        np.testing.assert_array_almost_equal(m.variables["y"].lower.values, [-5, -5])
+        np.testing.assert_array_almost_equal(m.variables["y"].upper.values, [5, 5])
+
+    def test_unfix_restores_binary_bounds(self, model_with_solution: Model) -> None:
+        m = model_with_solution
+        m.variables["z"].fix()
+        m.variables["z"].unfix()
+        np.testing.assert_equal(m.variables["z"].lower.item(), 0.0)
+        np.testing.assert_equal(m.variables["z"].upper.item(), 1.0)
 
     def test_unfix_noop_if_not_fixed(self, model_with_solution: Model) -> None:
         m = model_with_solution
@@ -157,9 +215,7 @@ class TestUnfixDoesNotUnrelaxIndependently:
     def test_unfix_on_relaxed_only_variable(self, model_with_solution: Model) -> None:
         m = model_with_solution
         m.variables["z"].relax()
-        # unfix should be a no-op — no fix constraint exists
         m.variables["z"].unfix()
-        # relaxation should still be in effect
         assert m.variables["z"].relaxed
         assert not m.variables["z"].attrs["binary"]
 
@@ -237,6 +293,8 @@ class TestVariablesContainerFixUnfix:
         m.variables.unfix()
         for name in m.variables:
             assert not m.variables[name].fixed
+        np.testing.assert_almost_equal(m.variables["x"].lower.item(), 0.0)
+        np.testing.assert_almost_equal(m.variables["x"].upper.item(), 10.0)
 
     def test_fix_integers_only(self, model_with_solution: Model) -> None:
         m = model_with_solution
@@ -423,7 +481,7 @@ class TestRemoveVariablesCleansUpFix:
         m = model_with_solution
         m.variables["x"].fix(value=5.0)
         m.remove_variables("x")
-        assert f"{FIX_CONSTRAINT_PREFIX}x" not in m.constraints
+        assert "x" not in m.variables
 
     def test_remove_relaxed_variable(self, model_with_solution: Model) -> None:
         m = model_with_solution
@@ -431,10 +489,45 @@ class TestRemoveVariablesCleansUpFix:
         m.variables["z"].relax()
         m.remove_variables("z")
         assert "z" not in m._relaxed_registry
-        assert f"{FIX_CONSTRAINT_PREFIX}z" not in m.constraints
+        assert "z" not in m.variables
 
 
 class TestFixIO:
+    def test_fixed_bounds_survive_netcdf(
+        self, model_with_solution: Model, tmp_path: Path
+    ) -> None:
+        m = model_with_solution
+        m.variables["x"].fix(value=5.0)
+        m.variables["y"].fix()
+
+        path = tmp_path / "model.nc"
+        m.to_netcdf(path)
+
+        from linopy.io import read_netcdf
+
+        m2 = read_netcdf(path)
+        assert m2.variables["x"].fixed
+        assert m2.variables["y"].fixed
+        np.testing.assert_almost_equal(m2.variables["x"].lower.item(), 5.0)
+        np.testing.assert_almost_equal(m2.variables["x"].upper.item(), 5.0)
+
+    def test_unfix_after_roundtrip_restores_bounds(
+        self, model_with_solution: Model, tmp_path: Path
+    ) -> None:
+        m = model_with_solution
+        m.variables["x"].fix(value=5.0)
+
+        path = tmp_path / "model.nc"
+        m.to_netcdf(path)
+
+        from linopy.io import read_netcdf
+
+        m2 = read_netcdf(path)
+        m2.variables["x"].unfix()
+        assert not m2.variables["x"].fixed
+        np.testing.assert_almost_equal(m2.variables["x"].lower.item(), 0.0)
+        np.testing.assert_almost_equal(m2.variables["x"].upper.item(), 10.0)
+
     def test_relaxed_registry_survives_netcdf(
         self, model_with_solution: Model, tmp_path: Path
     ) -> None:
@@ -451,9 +544,8 @@ class TestFixIO:
 
         m2 = read_netcdf(path)
         assert m2._relaxed_registry == {"z": "binary", "w": "integer"}
-        # Fix constraints should also survive
-        assert f"{FIX_CONSTRAINT_PREFIX}z" in m2.constraints
-        assert f"{FIX_CONSTRAINT_PREFIX}w" in m2.constraints
+        assert m2.variables["z"].fixed
+        assert m2.variables["w"].fixed
 
     def test_empty_registry_netcdf(
         self, model_with_solution: Model, tmp_path: Path
@@ -485,14 +577,11 @@ class TestFixIO:
 
 
 def test_fix_aligns_positional_value_to_named_dimension() -> None:
-    # fix() delegates alignment to the (separately tested) broadcast_to_coords;
-    # this only guards that it passes the variable's own coords, so a positional
-    # value lands on the named dimension instead of gaining a spurious dim_0.
     m = Model()
-    m.add_variables(
+    t = m.add_variables(
         lower=-5, upper=5, coords=[pd.Index([2020, 2030, 2040], name="time")], name="t"
     )
-    m.variables["t"].fix([1.0, 2.0, 3.0])
-    con = m.constraints[f"{FIX_CONSTRAINT_PREFIX}t"]
-    assert con.rhs.dims == ("time",)
-    np.testing.assert_array_almost_equal(con.rhs.values, [1.0, 2.0, 3.0])
+    t.fix([1.0, 2.0, 3.0])
+    assert t.lower.dims == ("time",)
+    np.testing.assert_array_almost_equal(t.lower.values, [1.0, 2.0, 3.0])
+    np.testing.assert_array_almost_equal(t.upper.values, [1.0, 2.0, 3.0])

--- a/test/test_fix_relax.py
+++ b/test/test_fix_relax.py
@@ -1,5 +1,6 @@
 """Tests for Variable.fix(), Variable.unfix(), and Variable.fixed."""
 
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -88,10 +89,13 @@ class TestVariableFix:
         np.testing.assert_equal(m.variables["z"].lower.item(), 0.0)
         np.testing.assert_equal(m.variables["z"].upper.item(), 0.0)
 
-    def test_fix_binary_outside_domain_raises(self, model_with_solution: Model) -> None:
+    @pytest.mark.parametrize("value", [5, 0.4, 0.6, -1])
+    def test_fix_binary_outside_domain_raises(
+        self, model_with_solution: Model, value: float
+    ) -> None:
         m = model_with_solution
         with pytest.raises(ValueError, match="binary variable"):
-            m.variables["z"].fix(value=5)
+            m.variables["z"].fix(value=value)
 
     def test_fix_rounds_integer(self, model_with_solution: Model) -> None:
         m = model_with_solution
@@ -125,10 +129,8 @@ class TestVariableFix:
 
     def test_fix_within_bounds_does_not_warn(self, model_with_solution: Model) -> None:
         m = model_with_solution
-        import warnings
-
         with warnings.catch_warnings():
-            warnings.simplefilter("error")
+            warnings.simplefilter("error", UserWarning)
             m.variables["x"].fix(value=5.0)
 
     def test_fix_small_overshoot_rounded_within_bounds(
@@ -237,6 +239,9 @@ class TestFixThenRelax:
         m.variables["z"].relax()
         m.variables["z"].unfix()
         assert not m.variables["z"].fixed
+        # unfix restores the original binary bounds regardless of relaxation
+        np.testing.assert_equal(m.variables["z"].lower.item(), 0.0)
+        np.testing.assert_equal(m.variables["z"].upper.item(), 1.0)
         # relaxation is independent — still in effect
         assert m.variables["z"].relaxed
         assert not m.variables["z"].attrs["binary"]

--- a/test/test_optimization.py
+++ b/test/test_optimization.py
@@ -737,9 +737,6 @@ def test_milp_binary_model(
     ).all()
 
 
-# (kind, add_variables kwargs, fixval, objective coef). The coef drives the var
-# to the bound opposite fixval, so ending at fixval proves the fix is honored;
-# the two rows per kind cover collapsing the lower and the upper bound.
 FIXED_VAR_CASES = [
     pytest.param("continuous", {}, 7.0, 100, id="continuous-lower-raised"),
     pytest.param("continuous", {}, 3.0, -100, id="continuous-upper-lowered"),

--- a/test/test_optimization.py
+++ b/test/test_optimization.py
@@ -737,6 +737,53 @@ def test_milp_binary_model(
     ).all()
 
 
+# (kind, add_variables kwargs, fixval, objective coef). The coef drives the var
+# to the bound opposite fixval, so ending at fixval proves the fix is honored;
+# the two rows per kind cover collapsing the lower and the upper bound.
+FIXED_VAR_CASES = [
+    pytest.param("continuous", {}, 7.0, 100, id="continuous-lower-raised"),
+    pytest.param("continuous", {}, 3.0, -100, id="continuous-upper-lowered"),
+    pytest.param("integer", {"integer": True}, 7.0, 100, id="integer-lower-raised"),
+    pytest.param("integer", {"integer": True}, 3.0, -100, id="integer-upper-lowered"),
+    pytest.param("binary", {"binary": True}, 1.0, 100, id="binary-1"),
+    pytest.param("binary", {"binary": True}, 0.0, -100, id="binary-0"),
+]
+
+
+@pytest.mark.parametrize("kind,var_kwargs,fixval,coef", FIXED_VAR_CASES)
+@pytest.mark.parametrize(
+    "solver,io_api,explicit_coordinate_names",
+    [p for p in params if p[0] not in ["mindopt"]],
+)
+def test_fixed_variable_is_held(
+    solver: str,
+    io_api: str,
+    explicit_coordinate_names: bool,
+    kind: str,
+    var_kwargs: dict,
+    fixval: float,
+    coef: float,
+) -> None:
+    if kind in ("integer", "binary") and solver not in feasible_mip_solvers:
+        pytest.skip(f"{solver} does not support MIP")
+
+    m = Model()
+    if "binary" in var_kwargs:
+        v = m.add_variables(name="v", **var_kwargs)
+    else:
+        v = m.add_variables(lower=0, upper=10, name="v", **var_kwargs)
+    x = m.add_variables(lower=0, upper=10, name="x")
+    m.add_constraints(x >= 2, name="c")
+    m.add_objective(x + coef * v)
+    v.fix(fixval)
+
+    status, condition = m.solve(
+        solver, io_api=io_api, explicit_coordinate_names=explicit_coordinate_names
+    )
+    assert condition == "optimal"
+    assert float(m.solution.v) == pytest.approx(fixval)
+
+
 @pytest.mark.parametrize(
     "solver,io_api,explicit_coordinate_names",
     [p for p in params if p[0] not in ["mindopt"]],


### PR DESCRIPTION
> [!Note]
> AI-assisted implementation.

Closes #769.

> [!Important]
> **Stacked on #774** (the `Variable.fix()` value-alignment bug fix). This PR's base is `fix/fix-value-coord-alignment`; review/merge #774 first, then this diff shows only the bound-collapse + binary-export work.

## What

`Variable.fix()` now fixes a variable by collapsing its bounds (`lower = upper = value`) — the meaning of "fix" in JuMP, Pyomo and gurobipy — instead of adding a `__fix__` equality constraint.

## Why

- **Keeps fix/re-solve loops on the persistent in-place update path** (#718): a `__fix__` constraint row changes the active label set → full solver rebuild; a bound change is a pure value update and stays in-place. This is the path #768 (`restrict`/`advance`) depends on.
- **Ecosystem convention** — "fix" means bound/domain collapse everywhere else.
- **Cleaner model** — no extra rows, no `__fix__` namespace pollution, no `remove_variables` cleanup hook.

## How

- `fix(value)` stashes the pre-fix `lower`/`upper` as `_stashed_lower` / `_stashed_upper` data variables **on the variable's own Dataset**, then collapses the bounds. `unfix()` restores them; `fixed` checks for the stash.
- The stash rides on `var.data`, so it **round-trips through netcdf for free** — no separate registry to serialize. (`relax` / `_relaxed_registry` is left untouched.)
- A fix value outside the current bounds **warns and overrides** (avoiding the old `fix >= ub` infeasibility); fixing a binary to anything other than 0/1 **raises**.
- Removes `FIX_CONSTRAINT_PREFIX` and all `__fix__` handling.

## Binary bounds at export (latent bug)

Fixing a binary that stays binary requires the solver to see its collapsed bounds. Several export paths hardcoded `[0, 1]` for binaries and silently freed a fixed binary:

- **LP writer** — binaries were emitted with no bounds; now a fixed binary's explicit bounds are written.
- **HiGHS direct** — dropped a `changeColsBounds(..., 0, 1)` override.
- **Mosek direct** — dropped a `putvarboundlistconst([0, 1])` override.

Gurobi / Xpress / cuPDLPx direct and the MPS path were already correct. This also fixes the standalone bug that a binary's bounds could not be restricted at all.

## Behavioral changes (release note)

- A fix value outside the current bounds warns and overrides instead of raising.
- The marginal of a fix appears as the variable's **reduced cost** instead of a constraint dual.
- `model.constraints` no longer lists `__fix__*` entries.

No deprecation shim — the API is recent (v0.7.0) and unused downstream (PyPSA does not use it).

## Tests

- `test_fix_relax.py` — unit coverage of collapse / stash / unfix-restore / netcdf round-trip / binary-domain raise / overwrite-keeps-original-stash.
- `test_optimization.py::test_fixed_variable_is_held` — cross-solver, cross-io integration test that **solves** and asserts the fix is honored, for continuous / integer / binary and both bound directions. Verified locally on cbc, cplex, gurobi, highs, mosek, scip, xpress across lp / lp-polars / mps / direct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)