### PR TITLE
fix(io): write LP bounds for tightened binary variables

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -4,6 +4,10 @@ Release Notes
 Upcoming Version
 ----------------
 
+**Bug fixes**
+
+* LP file export now writes a ``bounds`` section for binary variables whose bounds were tightened below the implied ``[0, 1]`` (e.g. masking out entries with ``upper = 0``). Previously such bounds were silently dropped, so the same model could relax when solved through ``io_api="lp"`` while ``io_api="direct"`` honored them. (https://github.com/PyPSA/linopy/issues/776)
+
 Version 0.8.0
 -------------
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -6,7 +6,7 @@ Upcoming Version
 
 **Bug fixes**
 
-* LP file export now writes a ``bounds`` section for binary variables whose bounds were tightened below the implied ``[0, 1]`` (e.g. masking out entries with ``upper = 0``). Previously such bounds were silently dropped, so the same model could relax when solved through ``io_api="lp"`` while ``io_api="direct"`` honored them. (https://github.com/PyPSA/linopy/issues/776)
+* LP file export now honors bounds tightened below ``[0, 1]`` on a binary variable via the ``.lower``/``.upper`` setters after creation (e.g. ``upper = 0``). Previously such bounds were written only by ``io_api="direct"`` and dropped by ``io_api="lp"``. (https://github.com/PyPSA/linopy/issues/776)
 
 Version 0.8.0
 -------------

--- a/linopy/io.py
+++ b/linopy/io.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     from highspy.highs import Highs
 
     from linopy.model import Model
+    from linopy.variables import Variable
 
 
 logger = logging.getLogger(__name__)
@@ -235,6 +236,17 @@ def objective_to_file(
         objective_write_quadratic_terms(f, quads, print_variable)
 
 
+def _binary_has_nondefault_bounds(var: Variable) -> bool:
+    """
+    Whether a binary variable carries bounds other than the implied (0, 1).
+
+    Scans the raw bound values (a single vectorised pass each), so masked
+    slots are tolerated: a false positive only routes the variable through
+    the bounds loop, where masked labels are dropped before writing.
+    """
+    return bool((var.lower.values != 0).any() or (var.upper.values != 1).any())
+
+
 def bounds_to_file(
     m: Model,
     f: BufferedWriter,
@@ -250,8 +262,10 @@ def bounds_to_file(
         + list(m.variables.integers)
         + list(m.variables.semi_continuous)
         + [
-            n for n in m.variables.binaries if m.variables[n].fixed
-        ]  # fixed binaries need bounds
+            n
+            for n in m.variables.binaries
+            if _binary_has_nondefault_bounds(m.variables[n])
+        ]
     )
     if not len(list(names)):
         return

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -536,7 +536,9 @@ class TestLPBinaryBounds:
     def make_tightened_model(self):
         def build() -> Model:
             m = Model()
-            x = m.add_variables(binary=True, coords=[pd.RangeIndex(4, name="t")], name="x")
+            x = m.add_variables(
+                binary=True, coords=[pd.RangeIndex(4, name="t")], name="x"
+            )
             x.upper = pd.Series([1, 1, 0, 0], index=pd.RangeIndex(4, name="t"))
             m.add_constraints(x.sum() >= 2, name="atleast2")
             m.add_objective(-1 * x.sum())
@@ -555,7 +557,9 @@ class TestLPBinaryBounds:
         m.to_file(fn)
         assert "bounds" not in fn.read_text()
 
-    def test_tightened_bounds_written(self, make_tightened_model, tmp_path: Path) -> None:
+    def test_tightened_bounds_written(
+        self, make_tightened_model, tmp_path: Path
+    ) -> None:
         """Per-element bounds tighter than [0, 1] reach the LP `bounds` section."""
         m = make_tightened_model()
         fn = tmp_path / "binary_tightened.lp"

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -515,62 +515,54 @@ def test_to_file_lp_mixed_sign_constraints(tmp_path: Path) -> None:
     assert "=" in content
 
 
-def test_to_file_lp_binary_default_bounds_omitted(tmp_path: Path) -> None:
-    """A binary with the implied [0, 1] bounds gets no bounds section."""
-    m = Model()
-    b = m.add_variables(binary=True, coords=[pd.RangeIndex(3, name="t")], name="b")
-    m.add_constraints(b.sum() >= 1, name="c")
-    m.add_objective(b.sum())
+class TestLPBinaryBounds:
+    """LP export honors binary bounds tightened below [0, 1] (#776)."""
 
-    fn = tmp_path / "binary_default.lp"
-    m.to_file(fn)
-    assert "bounds" not in fn.read_text()
+    @pytest.fixture
+    def make_tightened_model(self):
+        def build() -> Model:
+            m = Model()
+            x = m.add_variables(binary=True, coords=[pd.RangeIndex(4, name="t")], name="x")
+            x.upper = pd.Series([1, 1, 0, 0], index=pd.RangeIndex(4, name="t"))
+            m.add_constraints(x.sum() >= 2, name="atleast2")
+            m.add_objective(-1 * x.sum())
+            return m
 
+        return build
 
-def test_to_file_lp_binary_tightened_bounds(tmp_path: Path) -> None:
-    """
-    Per-element bounds tighter than [0, 1] on a binary reach the LP file.
-
-    Regression test for https://github.com/PyPSA/linopy/issues/776: the LP
-    export used to emit binaries only in the `binary` section (implied
-    [0, 1]), diverging from the direct API which honored the bounds.
-    """
-    m = Model()
-    x = m.add_variables(binary=True, coords=[pd.RangeIndex(4, name="t")], name="x")
-    x.upper = pd.Series([1, 1, 0, 0], index=pd.RangeIndex(4, name="t"))
-    m.add_constraints(x.sum() >= 2, name="atleast2")
-    m.add_objective(-1 * x.sum())
-
-    fn = tmp_path / "binary_tightened.lp"
-    m.to_file(fn)
-    content = fn.read_text()
-
-    bounds_section = content.split("bounds")[1].split("binary")[0]
-    labels = m.variables["x"].labels.values
-    for label in labels[2:]:
-        assert f"x{label} <= +0.0" in bounds_section
-
-
-@pytest.mark.skipif(not available_solvers, reason="No solver installed")
-def test_lp_and_direct_agree_on_binary_bounds(tmp_path: Path) -> None:
-    """The LP and direct paths see the same feasible set for tightened binaries."""
-    solver = available_solvers[0]
-
-    def build() -> Model:
+    def test_default_bounds_omitted(self, tmp_path: Path) -> None:
+        """A binary with the implied [0, 1] bounds gets no bounds section."""
         m = Model()
-        x = m.add_variables(binary=True, coords=[pd.RangeIndex(4, name="t")], name="x")
-        x.upper = pd.Series([1, 1, 0, 0], index=pd.RangeIndex(4, name="t"))
-        m.add_constraints(x.sum() >= 2, name="atleast2")
-        m.add_objective(-1 * x.sum())
-        return m
+        b = m.add_variables(binary=True, coords=[pd.RangeIndex(3, name="t")], name="b")
+        m.add_constraints(b.sum() >= 1, name="c")
+        m.add_objective(b.sum())
 
-    m_direct = build()
-    m_direct.solve(solver_name=solver, io_api="direct")
+        fn = tmp_path / "binary_default.lp"
+        m.to_file(fn)
+        assert "bounds" not in fn.read_text()
 
-    m_lp = build()
-    m_lp.solve(solver_name=solver, io_api="lp")
+    def test_tightened_bounds_written(self, make_tightened_model, tmp_path: Path) -> None:
+        """Per-element bounds tighter than [0, 1] reach the LP `bounds` section."""
+        m = make_tightened_model()
+        fn = tmp_path / "binary_tightened.lp"
+        m.to_file(fn)
 
-    assert m_direct.objective.value == m_lp.objective.value == -2
+        bounds_section = fn.read_text().split("bounds")[1].split("binary")[0]
+        for label in m.variables["x"].labels.values[2:]:
+            assert f"x{label} <= +0.0" in bounds_section
+
+    @pytest.mark.skipif(not available_solvers, reason="No solver installed")
+    def test_lp_and_direct_agree(self, make_tightened_model) -> None:
+        """LP and direct paths see the same feasible set for tightened binaries."""
+        solver = available_solvers[0]
+
+        m_direct = make_tightened_model()
+        m_direct.solve(solver_name=solver, io_api="direct")
+
+        m_lp = make_tightened_model()
+        m_lp.solve(solver_name=solver, io_api="lp")
+
+        assert m_direct.objective.value == m_lp.objective.value == -2
 
 
 def test_to_file_lp_frozen_vs_mutable(tmp_path: Path) -> None:

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -515,6 +515,64 @@ def test_to_file_lp_mixed_sign_constraints(tmp_path: Path) -> None:
     assert "=" in content
 
 
+def test_to_file_lp_binary_default_bounds_omitted(tmp_path: Path) -> None:
+    """A binary with the implied [0, 1] bounds gets no bounds section."""
+    m = Model()
+    b = m.add_variables(binary=True, coords=[pd.RangeIndex(3, name="t")], name="b")
+    m.add_constraints(b.sum() >= 1, name="c")
+    m.add_objective(b.sum())
+
+    fn = tmp_path / "binary_default.lp"
+    m.to_file(fn)
+    assert "bounds" not in fn.read_text()
+
+
+def test_to_file_lp_binary_tightened_bounds(tmp_path: Path) -> None:
+    """
+    Per-element bounds tighter than [0, 1] on a binary reach the LP file.
+
+    Regression test for https://github.com/PyPSA/linopy/issues/776: the LP
+    export used to emit binaries only in the `binary` section (implied
+    [0, 1]), diverging from the direct API which honored the bounds.
+    """
+    m = Model()
+    x = m.add_variables(binary=True, coords=[pd.RangeIndex(4, name="t")], name="x")
+    x.upper = pd.Series([1, 1, 0, 0], index=pd.RangeIndex(4, name="t"))
+    m.add_constraints(x.sum() >= 2, name="atleast2")
+    m.add_objective(-1 * x.sum())
+
+    fn = tmp_path / "binary_tightened.lp"
+    m.to_file(fn)
+    content = fn.read_text()
+
+    bounds_section = content.split("bounds")[1].split("binary")[0]
+    labels = m.variables["x"].labels.values
+    for label in labels[2:]:
+        assert f"x{label} <= +0.0" in bounds_section
+
+
+@pytest.mark.skipif(not available_solvers, reason="No solver installed")
+def test_lp_and_direct_agree_on_binary_bounds(tmp_path: Path) -> None:
+    """The LP and direct paths see the same feasible set for tightened binaries."""
+    solver = available_solvers[0]
+
+    def build() -> Model:
+        m = Model()
+        x = m.add_variables(binary=True, coords=[pd.RangeIndex(4, name="t")], name="x")
+        x.upper = pd.Series([1, 1, 0, 0], index=pd.RangeIndex(4, name="t"))
+        m.add_constraints(x.sum() >= 2, name="atleast2")
+        m.add_objective(-1 * x.sum())
+        return m
+
+    m_direct = build()
+    m_direct.solve(solver_name=solver, io_api="direct")
+
+    m_lp = build()
+    m_lp.solve(solver_name=solver, io_api="lp")
+
+    assert m_direct.objective.value == m_lp.objective.value == -2
+
+
 def test_to_file_lp_frozen_vs_mutable(tmp_path: Path) -> None:
     """Test that frozen and mutable constraints produce identical LP output."""
     m_frozen = Model()

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -8,6 +8,7 @@ Created on Thu Mar 18 09:03:35 2021.
 import importlib.util
 import json
 import pickle
+from collections.abc import Callable
 from pathlib import Path
 
 import numpy as np
@@ -533,7 +534,7 @@ class TestLPBinaryBounds:
     """LP export honors binary bounds tightened below [0, 1] (#776)."""
 
     @pytest.fixture
-    def make_tightened_model(self):
+    def make_tightened_model(self) -> Callable[[], Model]:
         def build() -> Model:
             m = Model()
             x = m.add_variables(
@@ -558,7 +559,7 @@ class TestLPBinaryBounds:
         assert "bounds" not in fn.read_text()
 
     def test_tightened_bounds_written(
-        self, make_tightened_model, tmp_path: Path
+        self, make_tightened_model: Callable[[], Model], tmp_path: Path
     ) -> None:
         """Per-element bounds tighter than [0, 1] reach the LP `bounds` section."""
         m = make_tightened_model()
@@ -570,7 +571,9 @@ class TestLPBinaryBounds:
             assert f"x{label} <= +0.0" in bounds_section
 
     @pytest.mark.skipif(not available_solvers, reason="No solver installed")
-    def test_lp_and_direct_agree(self, make_tightened_model) -> None:
+    def test_lp_and_direct_agree(
+        self, make_tightened_model: Callable[[], Model]
+    ) -> None:
         """LP and direct paths see the same feasible set for tightened binaries."""
         solver = available_solvers[0]
 


### PR DESCRIPTION
<!-- Replace this line with your own intent/motivation, in your own words. -->

> [!NOTE]
> The following content was generated by AI.

## Summary

Closes #776.

Per-element bounds set below the implied `[0, 1]` on a **binary** variable (e.g. masking out a subset of entries with `upper = 0`) were silently dropped by LP file export. Such binaries appeared only in the `binary` section, which implies `[0, 1]`. The direct/matrix API honored the bounds (`matrices._build_vars` reads `var.lower`/`var.upper` unconditionally), so the same model had a **different feasible set depending on `io_api`** — a silent correctness trap where a model correct under `io_api="direct"` relaxed when solved through an LP file.

`#773` had already added bound rows for fully-`fixed` binaries; this extends the same treatment to any binary whose bounds differ from `(0, 1)` anywhere.

## Change

`bounds_to_file` now selects a binary for the `bounds` section when it has any non-default bound, via a small helper:

```python
def _binary_has_nondefault_bounds(var):
    return bool((var.lower.values != 0).any() or (var.upper.values != 1).any())
```

- All-default binaries (the common case) still emit **no** bounds rows — one cheap vectorised `.any()` per binary, no change to output.
- Masked slots are tolerated: a false positive only routes the variable through the bounds loop, where masked labels (`-1`) are already dropped before writing.
- The matrix/direct path is intentionally left unchanged: it builds dense per-column bound arrays with no implicit `[0, 1]` default to skip, and it is already correct.

### Before / after (repro from the issue)

```python
m = linopy.Model()
x = m.add_variables(binary=True, coords=[pd.RangeIndex(4, name="t")], name="x")
x.upper = pd.Series([1, 1, 0, 0], index=pd.RangeIndex(4, name="t"))
m.add_constraints(x.sum() >= 2, name="atleast2")
m.add_objective(-1 * x.sum())
```

- Before: LP file had no `bounds` section → optimum `-4`; direct → `-2`.
- After: both paths → `-2`.

## Tests

- `test_to_file_lp_binary_default_bounds_omitted` — default binary emits no bounds section.
- `test_to_file_lp_binary_tightened_bounds` — tightened entries reach the LP `bounds` section.
- `test_lp_and_direct_agree_on_binary_bounds` — the two paths agree on the optimum.

## Follow-up

A separate PR will relax `add_variables(binary=True, ...)` to accept `{0, 1}` bounds at construction (currently raises), per the issue comment. Kept separate because that feature depends on this export fix being in place.

