### PR TITLE
fix(docs): repair mobile sidebar by bumping sphinx-book-theme to 1.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ docs = [
     "numpydoc==1.7.0",
     "sphinx==7.3.7",
     "sphinx_rtd_theme==2.0.0",
-    "sphinx_book_theme==1.1.3",
+    "sphinx_book_theme==1.2.0",
     "sphinx-copybutton==0.5.2",
     "nbsphinx==0.9.4",
     "nbsphinx-link==1.3.0",


### PR DESCRIPTION
Closes #775 — the docs sidebar/ToC don't open on mobile.

> [!NOTE]
> The following content was generated by AI.

Bump `sphinx_book_theme` from `1.1.3` to `1.2.0` in the `docs` extra. The 1.1.x theme had no upper bound on `pydata-sphinx-theme`, so it pulled in `0.16.1`, whose DOM breaks the 1.1.x mobile sidebar/ToC toggle JS. `1.2.0` pins and supports `pydata-sphinx-theme==0.16.1`, restoring the toggles.

<details>
<summary>Cause, compatibility check and verification</summary>

**Cause** — `pyproject.toml` pins `sphinx_book_theme==1.1.3`, which declares `pydata-sphinx-theme>=0.15.2` with no upper bound, so pip resolves to `pydata-sphinx-theme==0.16.1`. The 1.1.x book theme predates pydata 0.16 and its mobile toggle JavaScript breaks against the 0.16 DOM.

Upstream confirms the mismatch: `sphinx-book-theme==1.1.4` hard-pins `pydata-sphinx-theme==0.15.4`, and `1.2.0` is the first release to pin and support `pydata-sphinx-theme==0.16.1`.

**Compatibility** — `1.2.0` requires `sphinx>=7.0` (we use `7.3.7`) and Python `>=3.11` (RTD builds on 3.12), so no other changes are needed.

**Verification** — docs build cleanly with the new theme (`sphinx-build -b html`, no errors).

</details>