### PR TITLE
feat(io): stamp linopy version into netCDF export

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -4,6 +4,8 @@ Release Notes
 Upcoming Version
 ----------------
 
+* ``Model.to_netcdf`` now records the writing linopy version in the ``_linopy_version`` dataset attribute. Files written by older versions (without the attribute) continue to read unchanged.
+
 Version 0.8.0
 -------------
 

--- a/linopy/io.py
+++ b/linopy/io.py
@@ -12,6 +12,7 @@ import shutil
 import time
 import warnings
 from collections.abc import Callable, Iterable
+from importlib.metadata import version
 from io import BufferedWriter
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -36,6 +37,8 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+NETCDF_VERSION_ATTR = "_linopy_version"
 
 
 ufunc_kwargs = dict(vectorize=True)
@@ -971,6 +974,7 @@ def to_netcdf(m: Model, *args: Any, **kwargs: Any) -> None:
     scalars = {k: getattr(m, k) for k in m.scalar_attrs}
     ds = xr.merge(vars + cons + obj + params, combine_attrs="drop_conflicts")
     ds = ds.assign_attrs(scalars)
+    ds.attrs[NETCDF_VERSION_ATTR] = version("linopy")
     if m._relaxed_registry:
         ds.attrs["_relaxed_registry"] = json.dumps(m._relaxed_registry)
     if m._piecewise_formulations:

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -221,6 +221,32 @@ def test_read_netcdf_with_multiindex_legacy_list_attr(
     assert_model_equal(m, read_netcdf(fn_legacy))
 
 
+def test_model_to_netcdf_stamps_version(model: Model, tmp_path: Path) -> None:
+    from importlib.metadata import version
+
+    from linopy.io import NETCDF_VERSION_ATTR
+
+    fn = tmp_path / "test.nc"
+    model.to_netcdf(fn)
+
+    ds = xr.load_dataset(fn)
+    assert ds.attrs[NETCDF_VERSION_ATTR] == version("linopy")
+
+
+def test_read_netcdf_without_version_stamp(model: Model, tmp_path: Path) -> None:
+    from linopy.io import NETCDF_VERSION_ATTR
+
+    fn = tmp_path / "test.nc"
+    model.to_netcdf(fn)
+
+    ds = xr.load_dataset(fn).load()
+    del ds.attrs[NETCDF_VERSION_ATTR]
+    fn_legacy = tmp_path / "legacy.nc"
+    ds.to_netcdf(fn_legacy)
+
+    assert_model_equal(model, read_netcdf(fn_legacy))
+
+
 @pytest.mark.skipif("gurobi" not in available_solvers, reason="Gurobipy not installed")
 def test_to_file_lp(model: Model, tmp_path: Path) -> None:
     import gurobipy

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -221,18 +221,6 @@ def test_read_netcdf_with_multiindex_legacy_list_attr(
     assert_model_equal(m, read_netcdf(fn_legacy))
 
 
-def test_model_to_netcdf_stamps_version(model: Model, tmp_path: Path) -> None:
-    from importlib.metadata import version
-
-    from linopy.io import NETCDF_VERSION_ATTR
-
-    fn = tmp_path / "test.nc"
-    model.to_netcdf(fn)
-
-    ds = xr.load_dataset(fn)
-    assert ds.attrs[NETCDF_VERSION_ATTR] == version("linopy")
-
-
 def test_read_netcdf_without_version_stamp(model: Model, tmp_path: Path) -> None:
     from linopy.io import NETCDF_VERSION_ATTR
 


### PR DESCRIPTION
I think this might allow us to change some storage things while staying backwards compatible in the future.
Is a no-brainer imo.

> [!NOTE]
> The content below was generated by AI.

## What

`Model.to_netcdf` now records the writing linopy version under the `_linopy_version` dataset attribute.

## Why

netCDF exports previously carried no record of which linopy wrote them, and `read_netcdf` had no version signal to work with. Stamping the version is the one thing that *must* happen now — it can't be added to files retroactively. It serves as provenance today and, more importantly, as a monotonic **branch key** for the day a future release changes the on-disk layout: read logic can then do `if file_version < parse("0.x"): <old reader>`.

We deliberately ship **only the stamp** — no floor constant, no warning, no branch scaffolding. Those are read-side and can be added in the exact release that needs them; adding them now would be inert code reading a value nothing yet consumes.

## Behaviour

- New files carry `_linopy_version == linopy.__version__`.
- Files written by older linopy (no attribute) read unchanged — a future reader treats a missing stamp as `"0"` (older than everything), which routes such files to the oldest format branch, correctly.

## Tests

- `test_read_netcdf_without_version_stamp` — a file with the attribute stripped (simulating a pre-versioning export) still round-trips.

<details>
<summary>How to consume the stamp on read (future)</summary>

When a release eventually changes the on-disk layout, the stamp becomes the branch key. Read it once near the top of `read_netcdf`, defaulting a missing attribute to `"0"` so pre-versioning files sort below every real release:

```python
from packaging.version import parse  # already a linopy dependency, used in solvers.py

file_version = parse(ds.attrs.get(NETCDF_VERSION_ATTR, "0"))
```

**Branching** — handle each format generation explicitly. Strict `<` against the release that *introduced* the new layout, so that release reads via the new path and everything older via the old:

```python
if file_version < parse("0.10.0"):
    ...   # gen 0 reader
elif file_version < parse("0.13.0"):
    ...   # gen 1 reader
else:
    ...   # current reader
```

Because the stamp is a monotonic ordered key, this chains cleanly across any number of future format generations — something the existing ad-hoc data-sniffing (e.g. the `_linopy_format == \"csr\"` check, the multiindex JSON-vs-list handling) can't do in order. Thread `file_version` down into sub-parsers rather than re-reading `ds.attrs` deep in the call stack, keeping the boundary logic in one place.

**Missing stamp → `\"0\"`** routes every pre-versioning file to the oldest branch, which is correct: those files predate any new layout. The only thing version branching *can't* distinguish is format variation that existed *before* stamping shipped (everything collapses to `\"0\"`); those still need the data-sniffing already in place.

**Warn / give-up threshold (optional, separate concern)** — branching keeps old formats *readable*. If a release instead *drops* support for a format, that's a different threshold: introduce a `MIN_COMPATIBLE_NETCDF_VERSION` floor and warn when `file_version < parse(floor)`. Comparing against a fixed floor (not the running version) avoids false positives on every patch release. This stays out of the current PR.

Note: a forward-incompat case (a *newer* file read by an *older* linopy) can't be detected from this stamp alone — an old reader has no way to know which future release will break the layout. That would require a separate writer-supplied format-generation integer, which we are intentionally not adding unless it's ever needed.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)