### PR TITLE
fix(variables): Variable.where works with solution attached

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -30,6 +30,7 @@ Upcoming Version
 
 * LP file export now honors bounds tightened below ``[0, 1]`` on a binary variable via the ``.lower``/``.upper`` setters after creation (e.g. ``upper = 0``). Previously such bounds were written only by ``io_api="direct"`` and dropped by ``io_api="lp"``. (https://github.com/PyPSA/linopy/issues/776)
 * Freezing an empty constraint group (e.g. an empty ``isel`` slice) no longer raises ``ValueError: cannot reshape array of size 0``. ``Model(freeze_constraints=True)`` and ``Constraint.freeze()`` now round-trip zero-row constraints losslessly.
+* ``Variable.where`` no longer raises ``ValueError: exact match required for all data variable names`` once a solution is attached (after ``Model.solve``) or the variable is fixed. The fill value now covers auxiliary data variables (``solution``, stashed bounds) instead of only ``labels``/``lower``/``upper``.
 
 Version 0.8.0
 -------------

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -1223,6 +1223,8 @@ class Variable:
             raise ValueError(
                 f"other must be a Variable, ScalarVariable, dict or Dataset, got {type(other)}"
             )
+        if isinstance(_other, dict):
+            _other = {**{k: np.nan for k in self.data}, **_other}
         return self.__class__(
             self.data.where(cond, _other, **kwargs), self.model, self.name
         )

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -1224,7 +1224,8 @@ class Variable:
                 f"other must be a Variable, ScalarVariable, dict or Dataset, got {type(other)}"
             )
         if isinstance(_other, dict):
-            _other = {**{k: np.nan for k in self.data}, **_other}
+            fill: dict[str, float] = {str(k): np.nan for k in self.data}
+            _other = {**fill, **_other}
         return self.__class__(
             self.data.where(cond, _other, **kwargs), self.model, self.name
         )

--- a/test/test_variable.py
+++ b/test/test_variable.py
@@ -276,6 +276,15 @@ def test_variable_where(x: linopy.Variable) -> None:
         x.where([True] * 4 + [False] * 6, 0)  # type: ignore
 
 
+def test_variable_where_with_solution(x: linopy.Variable) -> None:
+    x.solution = xr.DataArray(np.arange(10.0), coords=x.labels.coords)
+    cond = [True] * 4 + [False] * 6
+    filtered = x.where(cond)
+    assert filtered.labels[9] == x._fill_value["labels"]
+    assert filtered.data["solution"][0] == 0.0
+    assert np.isnan(filtered.data["solution"][9])
+
+
 def test_variable_shift(x: linopy.Variable) -> None:
     x = x.shift(first=3)
     assert isinstance(x, linopy.variables.Variable)


### PR DESCRIPTION
> [!NOTE]
> This PR's description and code changes were generated with AI assistance (Claude Code) and reviewed by a human.

## Changes proposed in this Pull Request

`Variable.where` raised `ValueError: exact match required for all data variable names` as soon as a solution was attached to the model (after `Model.solve`) or the variable was fixed.

**Cause:** `Variable.where` passes a fill dict covering only `labels`/`lower`/`upper` to `Dataset.where`, which requires the fill keys to exactly match the dataset's data variables. After solving (or `fix()`), the variable's data gains extra columns (`solution`, `_stashed_lower`, `_stashed_upper`), so the match fails.

**Fix:** Augment the fill dict to cover every data variable present, defaulting extras to `NaN`. The explicit `labels=-1` / `lower=upper=NaN` entries still override; only auxiliary columns pick up the `NaN` default.

This routes through `Variable.fillna` too, since it delegates to `where`. Audited the related methods — `ffill`/`bfill` (`Dataset.where(cond)` + `Dataset.fillna(dict)`) and `shift` (`Dataset.shift(fill_value=dict)`) already tolerate extra data variables, and `LinearExpression`/`QuadraticExpression`/`Constraint` are unaffected (they don't store `solution`/`dual`).

Added a regression test `test_variable_where_with_solution` and a release note.

## Checklist

- [x] AI-generated content is marked (see [`AGENTS.md`](../blob/master/AGENTS.md)).
- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
