### PR TITLE
docs: import AGENTS.md into CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,8 @@
 # CLAUDE.md
 
 This project's guidance for AI agents — contribution rules, development workflow
-and project conventions — lives in [`AGENTS.md`](AGENTS.md). Read it before
-making changes, opening pull requests or issues, or writing comments.
+and project conventions — lives in [`AGENTS.md`](AGENTS.md), imported below so
+it loads automatically. Read it before making changes, opening pull requests or
+issues, or writing comments.
+
+@AGENTS.md


### PR DESCRIPTION
Inject `AGENTS.md` into `CLAUDE.md` via the `@AGENTS.md` import syntax, so Claude Code loads the contribution rules, workflow and conventions automatically instead of depending on the agent to follow the markdown link.

`AGENTS.md` remains the single source of truth — no duplicated prose to keep in sync.

> [!NOTE]
> This change was generated by AI.