### PR TITLE
chore: fix typing with new highspy version

### DIFF
--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -294,7 +294,7 @@ class _LazyModule:
 
 
 gurobipy = _LazyModule("gurobipy")  # type: ignore[assignment]
-highspy = _LazyModule("highspy")
+highspy = _LazyModule("highspy")  # type: ignore[assignment]
 scip = _LazyModule("pyscipopt")
 cplex = _LazyModule("cplex")
 knitro = _LazyModule("knitro")

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -1656,7 +1656,7 @@ class Highs(Solver[None]):
             int_mask = (vtypes == "B") | (vtypes == "I") | (vtypes == "S")
             labels = np.arange(len(vtypes))[int_mask]
             integrality = np.array(
-                [integrality_map[v] for v in vtypes[int_mask]], dtype=np.int32
+                [integrality_map[v] for v in vtypes[int_mask]], dtype=np.uint8
             )
             h.changeColsIntegrality(len(labels), labels, integrality)
 


### PR DESCRIPTION
mypy fix due to tightened stubs in highspy 1.15

> [!NOTE]
> This change was generated by AI.

The direct-solve HiGHS path built the integrality array as `int32` and passed it to `changeColsIntegrality`, whose `var_types` argument expects a `uint8` array — matching HiGHS's uint8-backed `HighsVarType` enum (Continuous=0, Integer=1, SemiContinuous=2, …).

Recent highspy (1.13.1) tightened its type stubs to require `uint8` here, which surfaces as a mypy error:

```
linopy/solvers.py: error: Argument 3 to "changeColsIntegrality" ...
  has incompatible type "ndarray[..., dtype[signedinteger[_32Bit]]]";
  expected "ndarray[..., dtype[unsignedinteger[_8Bit]]]"
```

The persistent in-place update path (`_apply_var_types`) already builds this array as `uint8`; this aligns the direct-solve path. `uint8` is accepted at runtime across highspy versions, so this is a safe correctness fix, not a version workaround.