### PR TITLE
perf(groupby): unify scatter kernel over numpy and dask via apply_ufunc

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -21,6 +21,10 @@ Upcoming Version
 
 * ``add_variables(binary=True, ...)`` now accepts ``lower``/``upper`` bounds, as long as they are 0 or 1. Previously binary bounds could only be set via the ``.lower``/``.upper`` setters after creation. (https://github.com/PyPSA/linopy/issues/776)
 
+**Performance**
+
+* ``LinearExpression.groupby(...).sum()`` now scatters terms directly into the padded result arrays instead of unstacking through pandas ``MultiIndex`` machinery, cutting peak memory to input + result and speeding up the grouping. 
+
 **Deprecations**
 
 * Mutation via assignment to ``Variable.lower`` / ``Variable.upper`` / ``Constraint.coeffs`` / ``Constraint.vars`` / ``Constraint.lhs`` / ``Constraint.sign`` / ``Constraint.rhs`` is deprecated and emits a ``DeprecationWarning``. Use ``Variable.update(...)`` / ``Constraint.update(...)`` instead — the canonical mutation API with one validation path and one place that flips the persistent-solver dirty flag. Read access to these properties is unchanged. The setters will be removed in a future release.

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -23,7 +23,7 @@ Upcoming Version
 
 **Performance**
 
-* ``LinearExpression.groupby(...).sum()`` now scatters terms directly into the padded result arrays instead of unstacking through pandas ``MultiIndex`` machinery, cutting peak memory to input + result and speeding up the grouping. 
+* ``LinearExpression.groupby(...).sum()`` now scatters terms directly into the padded result arrays via ``xarray.apply_ufunc``, avoiding intermediate copies and speeding up the grouping. A single kernel covers both numpy and chunked (dask) data, the latter staying lazy. On representative models this lowers build and export peak memory by up to ~3x.
 
 **Deprecations**
 

--- a/linopy/constants.py
+++ b/linopy/constants.py
@@ -75,7 +75,6 @@ BREAKPOINT_DIM = "_breakpoint"
 SEGMENT_DIM = "_segment"
 LP_PIECE_DIM = f"{BREAKPOINT_DIM}_piece"
 PWL_LINK_DIM = "_pwl_var"
-GROUPED_TERM_DIM = "_grouped_term"
 GROUP_DIM = "_group"
 FACTOR_DIM = "_factor"
 CONCAT_DIM = "_concat"
@@ -83,7 +82,6 @@ CV_DIM = "_cv"
 HELPER_DIMS: list[str] = [
     TERM_DIM,
     STACKED_TERM_DIM,
-    GROUPED_TERM_DIM,
     FACTOR_DIM,
     CONCAT_DIM,
     CV_DIM,

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -388,9 +388,9 @@ class LinearExpressionGroupby:
         group_dim = group.index.name
         fill_value = LinearExpression._fill_value
 
-        scatter_core_dims = {group_dim: -1, TERM_DIM: -1}
+        _scatter_core_dims = {group_dim: -1, TERM_DIM: -1}
         if data.chunks:
-            data = data.chunk(scatter_core_dims)
+            data = data.chunk(_scatter_core_dims)
 
         codes, unique_groups = pd.factorize(group, sort=True)
         if (codes == -1).any():

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -74,7 +74,6 @@ from linopy.constants import (
     FACTOR_DIM,
     GREATER_EQUAL,
     GROUP_DIM,
-    GROUPED_TERM_DIM,
     HELPER_DIMS,
     LESS_EQUAL,
     STACKED_TERM_DIM,
@@ -341,18 +340,7 @@ class LinearExpressionGroupby:
             # At this point, group is always a pandas Series
             assert isinstance(group, pd.Series)
 
-            numpy_backed = all(
-                isinstance(self.data[k].data, np.ndarray)
-                for k in ("coeffs", "vars", "const")
-            )
-            if numpy_backed:
-                ds = self._sum_by_scatter(group)
-            else:
-                logger.debug(
-                    "groupby-sum: non-numpy-backed (e.g. dask) data, "
-                    "falling back to the unstack kernel."
-                )
-                ds = self._sum_by_unstack(group)
+            ds = self._grouped_sum(group)
 
             if int_map is not None:
                 index = ds.indexes[GROUP_DIM].map({v: k for k, v in int_map.items()})
@@ -373,20 +361,18 @@ class LinearExpressionGroupby:
 
         return self.map(func, **kwargs, shortcut=True)
 
-    def _sum_by_scatter(self, group: pd.Series) -> Dataset:
+    def _grouped_sum(self, group: pd.Series) -> Dataset:
         """
         Sum groups by scattering all terms directly into the final padded arrays.
 
         Every group member keeps its block of ``nterm`` terms, so the resulting
         term dimension has size ``max_group_size * nterm`` and smaller groups are
-        padded with fill values. In contrast to :meth:`_sum_by_unstack` only the
-        result arrays are allocated, without intermediate copies of that size.
+        padded with fill values. Only the result arrays are allocated, keeping
+        peak memory at input + result.
 
-        Only the term and constant values are computed with numpy; the result
-        structure (dimensions, coordinates and their order) is assembled by
-        xarray itself and thereby matches the result of unstacking the group
-        dimension. The caller dispatches here only for numpy-backed data
-        (chunked data uses :meth:`_sum_by_unstack`).
+        The scatter runs inside :func:`xarray.apply_ufunc`, so it covers numpy
+        and chunked (dask) data alike: for dask the grouped dimension is gathered
+        into a single chunk and the scatter is applied lazily.
         """
         data = self.data
         group_dim = group.index.name
@@ -400,70 +386,65 @@ class LinearExpressionGroupby:
             )
 
         n_groups = len(unique_groups)
-        sizes = np.bincount(codes, minlength=n_groups)
-        max_size = int(sizes.max()) if n_groups else 0
-
+        max_size = int(np.bincount(codes, minlength=n_groups).max()) if n_groups else 0
         # position of each element within its group (order of appearance)
         positions = pd.Series(codes).groupby(codes).cumcount().to_numpy()
+        nterm = data.sizes[TERM_DIM]
 
-        def scatter(
-            da: DataArray, fill: Any
-        ) -> tuple[tuple[Hashable, ...], np.ndarray]:
-            """Scatter one term-array into its padded (group x term) layout."""
-            rest_dims = [d for d in da.dims if d not in (group_dim, TERM_DIM)]
-            values = da.transpose(group_dim, *rest_dims, TERM_DIM).values
-            rest_shape = values.shape[1:-1]
-            nterm = values.shape[-1]
+        def scatter_terms(values: np.ndarray, fill: Any) -> np.ndarray:
+            # (..., n_elem, nterm) -> (..., n_groups, nterm * max_size); each
+            # member's nterm block is kept together, padding at the block's end
+            rest = values.shape[:-2]
+            out = np.full((*rest, n_groups, nterm, max_size), fill, dtype=values.dtype)
+            out[..., codes, :, positions] = np.moveaxis(values, -2, 0)
+            return out.reshape((*rest, n_groups, nterm * max_size))
 
-            out = np.full(
-                (n_groups, *rest_shape, nterm, max_size), fill, dtype=values.dtype
+        def group_sum(values: np.ndarray) -> np.ndarray:
+            # (..., n_elem) -> (..., n_groups), summing within groups, skipping NaN
+            moved = np.moveaxis(values, -1, 0)
+            out = np.zeros((n_groups, *moved.shape[1:]), dtype=values.dtype)
+            np.add.at(out, codes, np.where(np.isnan(moved), 0, moved))
+            return np.moveaxis(out, 0, -1)
+
+        def single_chunk(da: DataArray) -> DataArray:
+            # the scatter's core dims must each sit in one chunk
+            if da.chunks is None:
+                return da
+            return da.chunk({d: -1 for d in (group_dim, TERM_DIM) if d in da.dims})
+
+        def scatter(da: DataArray, fill: Any) -> DataArray:
+            return xr.apply_ufunc(
+                scatter_terms,
+                single_chunk(da),
+                kwargs={"fill": fill},
+                input_core_dims=[[group_dim, TERM_DIM]],
+                output_core_dims=[[GROUP_DIM, TERM_DIM]],
+                exclude_dims={group_dim, TERM_DIM},
+                dask="parallelized",
+                dask_gufunc_kwargs={
+                    "output_sizes": {GROUP_DIM: n_groups, TERM_DIM: nterm * max_size}
+                },
+                output_dtypes=[da.dtype],
             )
-            locs = (codes, *(slice(None),) * (len(rest_shape) + 1), positions)
-            out[locs] = values
-            # collapsing (nterm, max_size) into one axis keeps all terms of one
-            # group member together, with padding at the end of each block
-            out = out.reshape((n_groups, *rest_shape, nterm * max_size))
-            return (GROUP_DIM, *rest_dims, TERM_DIM), out
 
-        coeffs_dims, coeffs = scatter(data.coeffs, fill_value["coeffs"])
-        vars_dims, vars = scatter(data.vars, fill_value["vars"])
-
-        # constants are summed up within each group, skipping NaN values
-        const_dims = [d for d in data.const.dims if d != group_dim]
-        const_values = data.const.transpose(group_dim, *const_dims).values
-        const = np.zeros((n_groups, *const_values.shape[1:]), dtype=const_values.dtype)
-        np.add.at(const, codes, np.where(np.isnan(const_values), 0, const_values))
-
-        structure = data.drop_vars(["coeffs", "vars", "const"])
-        structure = structure.drop_dims(group_dim)
-        structure = structure.expand_dims({GROUP_DIM: unique_groups})
-
-        return structure.assign(
-            coeffs=(coeffs_dims, coeffs),
-            vars=(vars_dims, vars),
-            const=((GROUP_DIM, *const_dims), const),
+        const = xr.apply_ufunc(
+            group_sum,
+            single_chunk(data.const),
+            input_core_dims=[[group_dim]],
+            output_core_dims=[[GROUP_DIM]],
+            exclude_dims={group_dim},
+            dask="parallelized",
+            dask_gufunc_kwargs={"output_sizes": {GROUP_DIM: n_groups}},
+            output_dtypes=[data.const.dtype],
         )
-
-    def _sum_by_unstack(self, group: pd.Series) -> Dataset:
-        """
-        Sum groups by unstacking the group dimension into a padded helper
-        dimension and summing over it.
-
-        Equivalent to :meth:`_sum_by_scatter`, but goes through xarray's
-        unstack/stack machinery. It is the fallback for chunked (dask) data,
-        which cannot be scattered into preallocated numpy buffers.
-        """
-        group_dim = group.index.name
-        arrays = [group, group.groupby(group).cumcount()]
-        idx = pd.MultiIndex.from_arrays(arrays, names=[GROUP_DIM, GROUPED_TERM_DIM])
-        new_coords = Coordinates.from_pandas_multiindex(idx, group_dim)
-        # collapsing group_dim invalidates every coordinate aligned to it
-        names_to_drop = [
-            name for name, coord in self.data.coords.items() if group_dim in coord.dims
-        ]
-        ds = self.data.drop_vars(names_to_drop).assign_coords(new_coords)
-        ds = ds.unstack(group_dim, fill_value=LinearExpression._fill_value)
-        return LinearExpression._sum(ds, dim=GROUPED_TERM_DIM)
+        ds = Dataset(
+            {
+                "coeffs": scatter(data.coeffs, fill_value["coeffs"]),
+                "vars": scatter(data.vars, fill_value["vars"]),
+                "const": const,
+            }
+        )
+        return ds.assign_coords({GROUP_DIM: unique_groups})
 
     def roll(self, **kwargs: Any) -> LinearExpression:
         """

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -340,20 +340,13 @@ class LinearExpressionGroupby:
 
             # At this point, group is always a pandas Series
             assert isinstance(group, pd.Series)
-            group_dim = group.index.name
 
-            arrays = [group, group.groupby(group).cumcount()]
-            idx = pd.MultiIndex.from_arrays(arrays, names=[GROUP_DIM, GROUPED_TERM_DIM])
-            new_coords = Coordinates.from_pandas_multiindex(idx, group_dim)
-            # collapsing group_dim invalidates every coordinate aligned to it
-            names_to_drop = [
-                name
-                for name, coord in self.data.coords.items()
-                if group_dim in coord.dims
-            ]
-            ds = self.data.drop_vars(names_to_drop).assign_coords(new_coords)
-            ds = ds.unstack(group_dim, fill_value=LinearExpression._fill_value)
-            ds = LinearExpression._sum(ds, dim=GROUPED_TERM_DIM)
+            if self._can_sum_by_scatter(group):
+                ds = self._sum_by_scatter(group)
+            else:
+                # chunked (e.g. dask-backed) data or exotic coordinates on the
+                # grouped dimension: use xarray's unstack machinery
+                ds = self._sum_by_unstack(group)
 
             if int_map is not None:
                 index = ds.indexes[GROUP_DIM].map({v: k for k, v in int_map.items()})
@@ -373,6 +366,125 @@ class LinearExpressionGroupby:
             return ds
 
         return self.map(func, **kwargs, shortcut=True)
+
+    def _can_sum_by_scatter(self, group: pd.Series) -> bool:
+        """
+        Whether :meth:`_sum_by_scatter` covers the structure of the data.
+
+        The scatter kernel requires numpy-backed arrays (chunked data cannot be
+        scattered into preallocated numpy arrays) and no coordinates tied to
+        the grouped dimension besides its own index. Everything else falls
+        back to :meth:`_sum_by_unstack`.
+        """
+        data = self.data
+        group_dim = group.index.name
+
+        numpy_backed = all(
+            isinstance(data[k].data, np.ndarray) for k in ("coeffs", "vars", "const")
+        )
+        if not numpy_backed:
+            return False
+
+        index = data.indexes.get(group_dim)
+        index_names = {group_dim, *(index.names if index is not None else ())}
+        return all(
+            coord.dims == (group_dim,) and name in index_names
+            for name, coord in data.coords.items()
+            if group_dim in coord.dims
+        )
+
+    def _sum_by_scatter(self, group: pd.Series) -> Dataset:
+        """
+        Sum groups by scattering all terms directly into the final padded arrays.
+
+        Every group member keeps its block of ``nterm`` terms, so the resulting
+        term dimension has size ``max_group_size * nterm`` and smaller groups are
+        padded with fill values. In contrast to :meth:`_sum_by_unstack` only the
+        result arrays are allocated, without intermediate copies of that size.
+
+        Only the term and constant values are computed with numpy; the result
+        structure (dimensions, coordinates and their order) is assembled by
+        xarray. :meth:`_can_sum_by_scatter` decides whether the data is simple
+        enough for this kernel.
+        """
+        data = self.data
+        group_dim = group.index.name
+        fill_value = LinearExpression._fill_value
+
+        codes, unique_groups = pd.factorize(group, sort=True)
+        if (codes == -1).any():
+            raise ValueError(
+                "Cannot group by a pandas object containing NaN values. "
+                "Drop or fill the corresponding entries before grouping."
+            )
+
+        n_groups = len(unique_groups)
+        sizes = np.bincount(codes, minlength=n_groups)
+        max_size = int(sizes.max()) if n_groups else 0
+
+        # position of each element within its group (order of appearance)
+        positions = pd.Series(codes).groupby(codes).cumcount().to_numpy()
+
+        def scatter(
+            da: DataArray, fill: Any
+        ) -> tuple[tuple[Hashable, ...], np.ndarray]:
+            """Scatter one term-array into its padded (group x term) layout."""
+            rest_dims = [d for d in da.dims if d not in (group_dim, TERM_DIM)]
+            values = da.transpose(group_dim, *rest_dims, TERM_DIM).values
+            rest_shape = values.shape[1:-1]
+            nterm = values.shape[-1]
+
+            out = np.full(
+                (n_groups, *rest_shape, nterm, max_size), fill, dtype=values.dtype
+            )
+            locs = (codes, *(slice(None),) * (len(rest_shape) + 1), positions)
+            out[locs] = values
+            # collapsing (nterm, max_size) into one axis keeps all terms of one
+            # group member together, with padding at the end of each block
+            out = out.reshape((n_groups, *rest_shape, nterm * max_size))
+            return (GROUP_DIM, *rest_dims, TERM_DIM), out
+
+        coeffs_dims, coeffs = scatter(data.coeffs, fill_value["coeffs"])
+        vars_dims, vars = scatter(data.vars, fill_value["vars"])
+
+        # constants are summed up within each group, skipping NaN values
+        const_dims = [d for d in data.const.dims if d != group_dim]
+        const_values = data.const.transpose(group_dim, *const_dims).values
+        const = np.zeros((n_groups, *const_values.shape[1:]), dtype=const_values.dtype)
+        np.add.at(const, codes, np.where(np.isnan(const_values), 0, const_values))
+
+        # only the values above are computed with numpy, the result structure
+        # (dimensions, coordinates and their order) is assembled by xarray
+        # itself and thereby matches a result of unstacking the group dimension
+        structure = data.drop_vars(["coeffs", "vars", "const"])
+        structure = structure.drop_dims(group_dim)
+        structure = structure.expand_dims({GROUP_DIM: unique_groups})
+
+        return structure.assign(
+            coeffs=(coeffs_dims, coeffs),
+            vars=(vars_dims, vars),
+            const=((GROUP_DIM, *const_dims), const),
+        )
+
+    def _sum_by_unstack(self, group: pd.Series) -> Dataset:
+        """
+        Sum groups by unstacking the group dimension into a padded helper
+        dimension and summing over it.
+
+        Equivalent to :meth:`_sum_by_scatter` but goes through xarray's
+        unstack/stack machinery, which also supports chunked (dask) data.
+        """
+        group_dim = group.index.name
+        arrays = [group, group.groupby(group).cumcount()]
+        idx = pd.MultiIndex.from_arrays(arrays, names=[GROUP_DIM, GROUPED_TERM_DIM])
+        new_coords = Coordinates.from_pandas_multiindex(idx, group_dim)
+        # collapsing group_dim invalidates every coordinate aligned to it
+        names_to_drop = [
+            name for name, coord in self.data.coords.items() if group_dim in coord.dims
+        ]
+        ds = self.data.drop_vars(names_to_drop).assign_coords(new_coords)
+        ds = ds.unstack(group_dim, fill_value=LinearExpression._fill_value)
+        return LinearExpression._sum(ds, dim=GROUPED_TERM_DIM)
 
     def roll(self, **kwargs: Any) -> LinearExpression:
         """

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -378,6 +378,11 @@ class LinearExpressionGroupby:
         group_dim = group.index.name
         fill_value = LinearExpression._fill_value
 
+        # the scatter's core dims must each sit in a single chunk; unknown dims
+        # (e.g. TERM_DIM on const) are silently ignored by Dataset.chunk
+        if data.chunks:
+            data = data.chunk({group_dim: -1, TERM_DIM: -1})
+
         codes, unique_groups = pd.factorize(group, sort=True)
         if (codes == -1).any():
             raise ValueError(
@@ -406,16 +411,10 @@ class LinearExpressionGroupby:
             np.add.at(out, codes, np.where(np.isnan(moved), 0, moved))
             return np.moveaxis(out, 0, -1)
 
-        def single_chunk(da: DataArray) -> DataArray:
-            # the scatter's core dims must each sit in one chunk
-            if da.chunks is None:
-                return da
-            return da.chunk({d: -1 for d in (group_dim, TERM_DIM) if d in da.dims})
-
         def scatter(da: DataArray, fill: Any) -> DataArray:
             return xr.apply_ufunc(
                 scatter_terms,
-                single_chunk(da),
+                da,
                 kwargs={"fill": fill},
                 input_core_dims=[[group_dim, TERM_DIM]],
                 output_core_dims=[[GROUP_DIM, TERM_DIM]],
@@ -429,7 +428,7 @@ class LinearExpressionGroupby:
 
         const = xr.apply_ufunc(
             group_sum,
-            single_chunk(data.const),
+            data.const,
             input_core_dims=[[group_dim]],
             output_core_dims=[[GROUP_DIM]],
             exclude_dims={group_dim},

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -341,9 +341,17 @@ class LinearExpressionGroupby:
             # At this point, group is always a pandas Series
             assert isinstance(group, pd.Series)
 
-            if self._can_sum_by_scatter(group):
+            numpy_backed = all(
+                isinstance(self.data[k].data, np.ndarray)
+                for k in ("coeffs", "vars", "const")
+            )
+            if numpy_backed:
                 ds = self._sum_by_scatter(group)
             else:
+                logger.debug(
+                    "groupby-sum: non-numpy-backed (e.g. dask) data, "
+                    "falling back to the unstack kernel."
+                )
                 ds = self._sum_by_unstack(group)
 
             if int_map is not None:
@@ -365,32 +373,6 @@ class LinearExpressionGroupby:
 
         return self.map(func, **kwargs, shortcut=True)
 
-    def _can_sum_by_scatter(self, group: pd.Series) -> bool:
-        """
-        Whether :meth:`_sum_by_scatter` covers the structure of the data.
-
-        The scatter kernel requires numpy-backed arrays (chunked data cannot be
-        scattered into preallocated numpy arrays) and no coordinates tied to
-        the grouped dimension besides its own index. Everything else falls
-        back to :meth:`_sum_by_unstack`.
-        """
-        data = self.data
-        group_dim = group.index.name
-
-        numpy_backed = all(
-            isinstance(data[k].data, np.ndarray) for k in ("coeffs", "vars", "const")
-        )
-        if not numpy_backed:
-            return False
-
-        index = data.indexes.get(group_dim)
-        index_names = {group_dim, *(index.names if index is not None else ())}
-        return all(
-            coord.dims == (group_dim,) and name in index_names
-            for name, coord in data.coords.items()
-            if group_dim in coord.dims
-        )
-
     def _sum_by_scatter(self, group: pd.Series) -> Dataset:
         """
         Sum groups by scattering all terms directly into the final padded arrays.
@@ -403,8 +385,8 @@ class LinearExpressionGroupby:
         Only the term and constant values are computed with numpy; the result
         structure (dimensions, coordinates and their order) is assembled by
         xarray itself and thereby matches the result of unstacking the group
-        dimension. :meth:`_can_sum_by_scatter` decides whether the data is
-        simple enough for this kernel.
+        dimension. The caller dispatches here only for numpy-backed data
+        (chunked data uses :meth:`_sum_by_unstack`).
         """
         data = self.data
         group_dim = group.index.name
@@ -467,8 +449,9 @@ class LinearExpressionGroupby:
         Sum groups by unstacking the group dimension into a padded helper
         dimension and summing over it.
 
-        Equivalent to :meth:`_sum_by_scatter` but goes through xarray's
-        unstack/stack machinery, which also supports chunked (dask) data.
+        Equivalent to :meth:`_sum_by_scatter`, but goes through xarray's
+        unstack/stack machinery. It is the fallback for chunked (dask) data,
+        which cannot be scattered into preallocated numpy buffers.
         """
         group_dim = group.index.name
         arrays = [group, group.groupby(group).cumcount()]

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -268,7 +268,6 @@ class LinearExpressionGroupby:
     def map(
         self,
         func: Callable[..., Dataset],
-        shortcut: bool = False,
         args: tuple[()] = (),
         **kwargs: Any,
     ) -> LinearExpression:
@@ -279,8 +278,6 @@ class LinearExpressionGroupby:
         ----------
         func : callable
             The function to apply.
-        shortcut : bool, optional
-            Whether to use shortcut or not.
         args : tuple, optional
             The arguments to pass to the function.
         **kwargs
@@ -291,9 +288,7 @@ class LinearExpressionGroupby:
         LinearExpression
             The result of applying the function to the groupby object.
         """
-        return LinearExpression(
-            self.groupby.map(func, shortcut=shortcut, args=args, **kwargs), self.model
-        )
+        return LinearExpression(self.groupby.map(func, args=args, **kwargs), self.model)
 
     def sum(
         self, use_fallback: bool = False, observed: bool = False
@@ -369,7 +364,7 @@ class LinearExpressionGroupby:
             ds = ds.assign_coords({TERM_DIM: np.arange(len(ds._term))})
             return ds
 
-        return self.map(func, shortcut=True)
+        return self.map(func)
 
     def _grouped_sum(self, group: pd.Series) -> Dataset:
         """

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -275,19 +275,19 @@ class LinearExpressionGroupby:
         Sum the groupby object.
 
         There are two options to perform the summation over groups.
-        The first and faster option uses an internal reindexing mechanism, which
-        however ignores keyword arguments. This will be used when passing a
-        pandas object or a DataArray as group, and setting `use_fallack`
-        to False (default).
-        The second uses a mapping of xarray groups which performs slower but
-        also takes into account the keyword arguments.
+        The first and faster option is linopy's own scatter-based kernel, used
+        when passing a pandas object or a DataArray as group and leaving
+        `use_fallback` at its default of False. It ignores ``**kwargs``.
+        The second falls back to xarray's own groupby, which is slower but
+        forwards ``**kwargs`` to the per-group reduction.
 
         Parameters
         ----------
         use_fallback : bool
-            Whether to use the fallback implementation, which is a sort of default
-            xarray implementation. If set to False, the operation will be much
-            faster but keyword arguments are ignored. Defaults to False.
+            If False (default), use linopy's fast scatter-based groupby-sum;
+            ``**kwargs`` are ignored. If True, group the expression with
+            xarray's ``Dataset.groupby`` and sum each group individually, which
+            is slower but honours ``**kwargs``.
         observed : bool
             Only applies when grouping by a list of coordinate names. If True,
             keep the result stacked over the observed key combinations (a
@@ -296,7 +296,8 @@ class LinearExpressionGroupby:
             Defaults to False, mirroring xarray. Not supported together with
             `use_fallback`.
         **kwargs
-            Arbitrary keyword arguments.
+            Only used when ``use_fallback=True``; forwarded to the xarray
+            groupby reduction. Ignored on the fast path.
 
         Returns
         -------
@@ -369,10 +370,6 @@ class LinearExpressionGroupby:
         term dimension has size ``max_group_size * nterm`` and smaller groups are
         padded with fill values. Only the result arrays are allocated, keeping
         peak memory at input + result.
-
-        The scatter runs inside :func:`xarray.apply_ufunc`, so it covers numpy
-        and chunked (dask) data alike: for dask the grouped dimension is gathered
-        into a single chunk and the scatter is applied lazily.
         """
         data = self.data
         group_dim = group.index.name

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -196,6 +196,33 @@ def _unstack_multikey(ds: Dataset, dim: str) -> Dataset:
     return ds.unstack(dim, fill_value=LinearExpression._fill_value)
 
 
+def _encode_multikey_group(
+    frame: pd.DataFrame, index: pd.Index
+) -> tuple[pd.Series, tuple[dict, pd.Index]]:
+    """
+    Encode a multi-key group frame as a single integer-coded Series.
+
+    ``_grouped_sum`` groups by one key, so each row's tuple of key values is
+    mapped to an integer. The returned ``(int_map, columns)`` lets
+    :func:`_restore_multikey_index` rebuild the MultiIndex on the result.
+    """
+    index_name = frame.index.name
+    frame = frame.reindex(index)
+    frame.index.name = index_name
+    int_map = get_index_map(*frame.values.T)
+    coded = frame.apply(tuple, axis=1).map(int_map)
+    return coded, (int_map, frame.columns)
+
+
+def _restore_multikey_index(ds: Dataset, decode: tuple[dict, pd.Index]) -> Dataset:
+    """Rebuild the MultiIndex group dimension encoded by _encode_multikey_group."""
+    int_map, columns = decode
+    index = ds.indexes[GROUP_DIM].map({v: k for k, v in int_map.items()})
+    index.names = [str(col) for col in columns]
+    index.name = GROUP_DIM
+    return ds.assign_coords(Coordinates.from_pandas_multiindex(index, GROUP_DIM))
+
+
 @dataclass
 @forward_as_properties(groupby=["dims", "groups"])
 class LinearExpressionGroupby:
@@ -303,44 +330,34 @@ class LinearExpressionGroupby:
 
         group = _resolve_group(self.group, self.data)
 
-        # a list of coord names rides the fast path as a value frame
         multikey_frame = (
             None if use_fallback else _multikey_value_frame(group, self.data)
         )
         if multikey_frame is not None:
             group = multikey_frame
 
-        non_fallback_types = (pd.Series, pd.DataFrame, xr.DataArray)
-        if isinstance(group, non_fallback_types) and not use_fallback:
-            if isinstance(group, pd.DataFrame):
-                # dataframes do not have a name, so we need to set it
-                final_group_name = "group"
-            else:
-                final_group_name = getattr(group, "name", "group") or "group"
+        fast_path_types = (pd.Series, pd.DataFrame, xr.DataArray)
+        if isinstance(group, fast_path_types) and not use_fallback:
+            final_group_name = (
+                "group"
+                if isinstance(group, pd.DataFrame)
+                else getattr(group, "name", "group") or "group"
+            )
 
             if isinstance(group, DataArray):
                 group = group.to_pandas()
 
-            int_map = None
+            multikey_decode = None
             if isinstance(group, pd.DataFrame):
-                index_name = group.index.name
-                group = group.reindex(self.data.indexes[group.index.name])
-                group.index.name = index_name  # ensure name for multiindex
-                int_map = get_index_map(*group.values.T)
-                orig_group = group
-                group = group.apply(tuple, axis=1).map(int_map)
+                group, multikey_decode = _encode_multikey_group(
+                    group, self.data.indexes[group.index.name]
+                )
 
-            # At this point, group is always a pandas Series
             assert isinstance(group, pd.Series)
-
             ds = self._grouped_sum(group)
 
-            if int_map is not None:
-                index = ds.indexes[GROUP_DIM].map({v: k for k, v in int_map.items()})
-                index.names = [str(col) for col in orig_group.columns]
-                index.name = GROUP_DIM
-                new_coords = Coordinates.from_pandas_multiindex(index, GROUP_DIM)
-                ds = ds.assign_coords(new_coords)
+            if multikey_decode is not None:
+                ds = _restore_multikey_index(ds, multikey_decode)
 
             ds = ds.rename({GROUP_DIM: final_group_name})
             if multikey_frame is not None and not observed:
@@ -367,10 +384,9 @@ class LinearExpressionGroupby:
         group_dim = group.index.name
         fill_value = LinearExpression._fill_value
 
-        # the scatter's core dims must each sit in a single chunk; unknown dims
-        # (e.g. TERM_DIM on const) are silently ignored by Dataset.chunk
+        scatter_core_dims = {group_dim: -1, TERM_DIM: -1}
         if data.chunks:
-            data = data.chunk({group_dim: -1, TERM_DIM: -1})
+            data = data.chunk(scatter_core_dims)
 
         codes, unique_groups = pd.factorize(group, sort=True)
         if (codes == -1).any():
@@ -381,26 +397,27 @@ class LinearExpressionGroupby:
 
         n_groups = len(unique_groups)
         max_size = int(np.bincount(codes, minlength=n_groups).max()) if n_groups else 0
-        # position of each element within its group (order of appearance)
-        positions = pd.Series(codes).groupby(codes).cumcount().to_numpy()
+        position_in_group = pd.Series(codes).groupby(codes).cumcount().to_numpy()
         nterm = data.sizes[TERM_DIM]
 
         def scatter_terms(values: np.ndarray, fill: Any) -> np.ndarray:
-            # (..., n_elem, nterm) -> (..., n_groups, nterm * max_size); each
-            # member's nterm block is kept together, padding at the block's end
-            rest = values.shape[:-2]
-            out = np.full((*rest, n_groups, nterm, max_size), fill, dtype=values.dtype)
-            out[..., codes, :, positions] = np.moveaxis(values, -2, 0)
-            return out.reshape((*rest, n_groups, nterm * max_size))
+            """Place each member's term block into its group's padded slot."""
+            leading = values.shape[:-2]
+            blocks = np.full(
+                (*leading, n_groups, nterm, max_size), fill, dtype=values.dtype
+            )
+            blocks[..., codes, :, position_in_group] = np.moveaxis(values, -2, 0)
+            return blocks.reshape((*leading, n_groups, nterm * max_size))
 
         def group_sum(values: np.ndarray) -> np.ndarray:
-            # (..., n_elem) -> (..., n_groups), summing within groups, skipping NaN
-            moved = np.moveaxis(values, -1, 0)
-            out = np.zeros((n_groups, *moved.shape[1:]), dtype=values.dtype)
-            np.add.at(out, codes, np.where(np.isnan(moved), 0, moved))
-            return np.moveaxis(out, 0, -1)
+            """Sum values within each group along the last axis, skipping NaNs."""
+            by_element = np.moveaxis(values, -1, 0)
+            summed = np.zeros((n_groups, *by_element.shape[1:]), dtype=values.dtype)
+            np.add.at(summed, codes, np.where(np.isnan(by_element), 0, by_element))
+            return np.moveaxis(summed, 0, -1)
 
         def scatter(da: DataArray, fill: Any) -> DataArray:
+            """Run the term scatter over the core dims, lazily for dask arrays."""
             return xr.apply_ufunc(
                 scatter_terms,
                 da,

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -344,8 +344,6 @@ class LinearExpressionGroupby:
             if self._can_sum_by_scatter(group):
                 ds = self._sum_by_scatter(group)
             else:
-                # chunked (e.g. dask-backed) data or exotic coordinates on the
-                # grouped dimension: use xarray's unstack machinery
                 ds = self._sum_by_unstack(group)
 
             if int_map is not None:
@@ -404,8 +402,9 @@ class LinearExpressionGroupby:
 
         Only the term and constant values are computed with numpy; the result
         structure (dimensions, coordinates and their order) is assembled by
-        xarray. :meth:`_can_sum_by_scatter` decides whether the data is simple
-        enough for this kernel.
+        xarray itself and thereby matches the result of unstacking the group
+        dimension. :meth:`_can_sum_by_scatter` decides whether the data is
+        simple enough for this kernel.
         """
         data = self.data
         group_dim = group.index.name
@@ -453,9 +452,6 @@ class LinearExpressionGroupby:
         const = np.zeros((n_groups, *const_values.shape[1:]), dtype=const_values.dtype)
         np.add.at(const, codes, np.where(np.isnan(const_values), 0, const_values))
 
-        # only the values above are computed with numpy, the result structure
-        # (dimensions, coordinates and their order) is assembled by xarray
-        # itself and thereby matches a result of unstacking the group dimension
         structure = data.drop_vars(["coeffs", "vars", "const"])
         structure = structure.drop_dims(group_dim)
         structure = structure.expand_dims({GROUP_DIM: unique_groups})

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -269,25 +269,20 @@ class LinearExpressionGroupby:
         )
 
     def sum(
-        self, use_fallback: bool = False, observed: bool = False, **kwargs: Any
+        self, use_fallback: bool = False, observed: bool = False
     ) -> LinearExpression:
         """
-        Sum the groupby object.
+        Sum the expression over each group.
 
-        There are two options to perform the summation over groups.
-        The first and faster option is linopy's own scatter-based kernel, used
-        when passing a pandas object or a DataArray as group and leaving
-        `use_fallback` at its default of False. It ignores ``**kwargs``.
-        The second falls back to xarray's own groupby, which is slower but
-        forwards ``**kwargs`` to the per-group reduction.
+        Replaces the grouped dimension with one entry per group, each holding
+        the sum of its members' terms.
 
         Parameters
         ----------
         use_fallback : bool
-            If False (default), use linopy's fast scatter-based groupby-sum;
-            ``**kwargs`` are ignored. If True, group the expression with
-            xarray's ``Dataset.groupby`` and sum each group individually, which
-            is slower but honours ``**kwargs``.
+            Fall back to the previous, slower groupby-sum implementation, kept
+            as an escape hatch. Leave at False unless the default misbehaves.
+            Defaults to False.
         observed : bool
             Only applies when grouping by a list of coordinate names. If True,
             keep the result stacked over the observed key combinations (a
@@ -295,14 +290,11 @@ class LinearExpressionGroupby:
             dimension per key, which materialises the dense cartesian grid.
             Defaults to False, mirroring xarray. Not supported together with
             `use_fallback`.
-        **kwargs
-            Only used when ``use_fallback=True``; forwarded to the xarray
-            groupby reduction. Ignored on the fast path.
 
         Returns
         -------
         LinearExpression
-            The sum of the groupby object.
+            The summed expression, with one entry per group.
         """
         if observed and use_fallback:
             raise ValueError(
@@ -360,7 +352,7 @@ class LinearExpressionGroupby:
             ds = ds.assign_coords({TERM_DIM: np.arange(len(ds._term))})
             return ds
 
-        return self.map(func, **kwargs, shortcut=True)
+        return self.map(func, shortcut=True)
 
     def _grouped_sum(self, group: pd.Series) -> Dataset:
         """

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -268,6 +268,7 @@ class LinearExpressionGroupby:
     def map(
         self,
         func: Callable[..., Dataset],
+        shortcut: bool | None = None,
         args: tuple[()] = (),
         **kwargs: Any,
     ) -> LinearExpression:
@@ -278,6 +279,8 @@ class LinearExpressionGroupby:
         ----------
         func : callable
             The function to apply.
+        shortcut : bool, optional
+            Deprecated and ignored. Will be removed in linopy v1.
         args : tuple, optional
             The arguments to pass to the function.
         **kwargs
@@ -288,6 +291,12 @@ class LinearExpressionGroupby:
         LinearExpression
             The result of applying the function to the groupby object.
         """
+        if shortcut is not None:
+            warn(
+                "The `shortcut` argument is deprecated, no longer has any effect "
+                "and will be removed in linopy v1.",
+                FutureWarning,
+            )
         return LinearExpression(self.groupby.map(func, args=args, **kwargs), self.model)
 
     def sum(

--- a/test/test_linear_expression.py
+++ b/test/test_linear_expression.py
@@ -1908,6 +1908,130 @@ def test_linear_expression_groupby_from_variable(v: Variable) -> None:
     assert grouped.nterm == 10
 
 
+def test_linear_expression_groupby_skewed_unsorted_groups(v: Variable) -> None:
+    """
+    The scatter-based fast path must match the xarray fallback for groups that
+    are unsorted, non-contiguous and of very different sizes.
+    """
+    expr = 2 * v + 5
+    # 'b' appears 14 times, 'c' 5 times, 'a' once, scattered over the dimension
+    labels = ["b"] * 4 + ["c", "a"] + ["b"] * 5 + ["c"] * 4 + ["b"] * 5
+    groups = pd.Series(labels, index=v.indexes["dim_2"], name="letter")
+
+    grouped = expr.groupby(groups).sum()
+    fallback = expr.groupby(groups.to_xarray()).sum(use_fallback=True)
+
+    assert list(grouped.data.letter) == ["a", "b", "c"]
+    # padded to the largest group times the number of terms of the input
+    assert grouped.nterm == 14 * expr.nterm
+    assert_linequal(grouped, fallback)
+
+    # every group must carry exactly the variables of its members, the rest is fill
+    for letter in ["a", "b", "c"]:
+        members = np.where(np.array(labels) == letter)[0]
+        vars_of_group = grouped.data.vars.sel(letter=letter).values
+        assert set(vars_of_group[vars_of_group >= 0]) == set(v.labels.values[members])
+        assert (vars_of_group >= 0).sum() == len(members) * expr.nterm
+        assert grouped.const.sel(letter=letter).item() == 5 * len(members)
+
+
+def test_linear_expression_groupby_chunked(v: Variable) -> None:
+    """Chunked (dask-backed) expressions group via xarray's unstack machinery."""
+    pytest.importorskip("dask")
+    expr = 2 * v + 5
+    groups = pd.Series([1] * 12 + [2] * 8, index=v.indexes["dim_2"], name="group")
+
+    chunked = LinearExpression(expr.data.chunk({"dim_2": 5}), expr.model)
+    grouped_chunked = chunked.groupby(groups).sum()
+    grouped = expr.groupby(groups).sum()
+
+    assert grouped_chunked.nterm == grouped.nterm
+    assert_linequal(
+        LinearExpression(grouped_chunked.data.compute(), expr.model), grouped
+    )
+
+
+def test_linear_expression_groupby_with_nan_groups(v: Variable) -> None:
+    expr = 1 * v
+    groups = pd.Series([1.0, np.nan] * 10, index=v.indexes["dim_2"], name="with_nans")
+    with pytest.raises(ValueError, match="NaN"):
+        expr.groupby(groups).sum()
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "skewed_int_groups",
+        "multidim_with_const",
+        "nan_const",
+        "masked_vars",
+        "quadratic",
+        "single_group",
+        "identity_groups",
+    ],
+)
+def test_linear_expression_groupby_scatter_equals_unstack(case: str) -> None:
+    """
+    Lock the two groupby-sum kernels together.
+
+    The fast path of groupby(...).sum() scatters terms into numpy arrays
+    (_sum_by_scatter); the xarray unstack implementation (_sum_by_unstack) is
+    kept for chunked data and exotic coordinates. Both must stay
+    interchangeable — if an xarray/pandas update changes the unstack output or
+    an edge case diverges, this fails.
+    """
+    m = Model()
+    rng = np.random.default_rng(0)
+    idx = pd.RangeIndex(60, name="elem")
+    skewed = pd.Series(rng.choice(8, 60, p=[0.5] + [0.5 / 7] * 7), index=idx, name="g")
+    groups = skewed
+
+    if case == "skewed_int_groups":
+        x = m.add_variables(coords=[idx], name="x")
+        expr: LinearExpression | QuadraticExpression = 3 * x - 2 * x + 7
+    elif case == "multidim_with_const":
+        other = pd.Index(list("abc"), name="other")
+        y = m.add_variables(coords=[other, idx], name="y")
+        const = xr.DataArray(rng.normal(size=(3, 60)), coords=[other, idx])
+        expr = 2 * y + 1 * y + const
+    elif case == "nan_const":
+        x = m.add_variables(coords=[idx], name="x")
+        expr = 1 * x + np.where(np.arange(60) % 3, np.nan, 5.0)
+    elif case == "masked_vars":
+        mask = xr.DataArray(np.arange(60) % 4 != 0, coords=[idx])
+        x = m.add_variables(coords=[idx], name="x", mask=mask)
+        expr = 1 * x
+    elif case == "quadratic":
+        x = m.add_variables(coords=[idx], name="x")
+        expr = x * x + 2 * x
+    elif case == "single_group":
+        x = m.add_variables(coords=[idx], name="x")
+        expr = 1 * x
+        groups = pd.Series(1, index=idx, name="g")
+    else:  # identity_groups
+        x = m.add_variables(coords=[idx], name="x")
+        expr = 1 * x
+        groups = pd.Series(np.arange(60), index=idx, name="g")
+
+    gb = expr.groupby(groups)
+    assert gb._can_sum_by_scatter(groups)
+    scatter = LinearExpression(gb._sum_by_scatter(groups).rename(_group="g"), m)
+    unstack = LinearExpression(gb._sum_by_unstack(groups).rename(_group="g"), m)
+
+    # identical structure: dims, dim order, coordinates
+    assert scatter.data.coeffs.dims == unstack.data.coeffs.dims
+    assert scatter.data.const.dims == unstack.data.const.dims
+    assert list(scatter.data.coords) == list(unstack.data.coords)
+    for name in scatter.data.coords:
+        assert_equal(scatter.data[name], unstack.data[name])
+
+    # identical values: vars and coeffs bit-exact, including padding positions
+    np.testing.assert_array_equal(scatter.vars.values, unstack.vars.values)
+    np.testing.assert_array_equal(scatter.coeffs.values, unstack.coeffs.values)
+    # constants may differ by floating-point summation order
+    np.testing.assert_allclose(scatter.const.values, unstack.const.values, rtol=1e-12)
+
+
 def test_linear_expression_rolling(v: Variable) -> None:
     expr = 1 * v
     rolled = expr.rolling(dim_2=2).sum()

--- a/test/test_linear_expression.py
+++ b/test/test_linear_expression.py
@@ -1954,11 +1954,8 @@ def groupby_ctx() -> SimpleNamespace:
     )
 
 
-# Each case maps a structure to (expr, groups) from `groupby_ctx`. The skewed
-# group puts ~half the elements in group 0 and spreads 1..7 over the rest.
-
-# Structures the xarray ``use_fallback=True`` path reproduces, so the scatter
-# kernel is validated by comparing against it directly.
+# (expr, groups) builders keyed by structure; `c` is the groupby_ctx fixture.
+# Cases the old use_fallback=True engine also reproduces.
 FALLBACK_SUM_CASES = {
     "skewed_int_groups": lambda c: (3 * c.x - 2 * c.x + 7, c.skewed),
     "multidim_with_const": lambda c: (2 * c.y + 1 * c.y + c.const, c.skewed),
@@ -1974,17 +1971,16 @@ FALLBACK_SUM_CASES = {
     "multiindex_dim": lambda c: (c.stacked, c.mi_groups),
 }
 
-# Structures the fallback cannot reproduce -- it errors on the `_factor` axis of
-# quadratics, and diverges on masked multi-dim vars and coordinates tied to the
-# grouped dim -- so the scatter kernel is checked from first principles instead.
-FIRST_PRINCIPLES_SUM_CASES = {
+# Cases the fallback cannot reproduce (errors on quadratics' _factor axis;
+# diverges on masked multi-dim vars and grouped-dim coords).
+FALLBACK_UNSUPPORTED_SUM_CASES = {
     "quadratic": lambda c: (c.x * c.x + 2 * c.x, c.skewed),
     "quadratic_multidim_const": lambda c: (c.y * c.y + 2 * c.y + c.const, c.skewed),
     "masked_multidim": lambda c: (5 * c.my - 2 * c.my, c.skewed),
     "aux_coords_on_group_dim": lambda c: (c.y_aux, c.skewed),
 }
 
-GROUPBY_SUM_CASES = {**FALLBACK_SUM_CASES, **FIRST_PRINCIPLES_SUM_CASES}
+GROUPBY_SUM_CASES = {**FALLBACK_SUM_CASES, **FALLBACK_UNSUPPORTED_SUM_CASES}
 
 
 def _term_multisets(
@@ -2228,9 +2224,10 @@ class TestGroupbySumKernel:
         self, groupby_ctx: SimpleNamespace, case: str, backend: str
     ) -> None:
         """
-        The scatter kernel must match the xarray ``use_fallback=True`` groupby,
-        on both numpy and dask backends. The fallback oracle always runs on
-        numpy; ``FIRST_PRINCIPLES_SUM_CASES`` holds the cases it cannot validate.
+        Equivalence guard: on the cases the old engine reproduces, the scatter
+        kernel must match ``use_fallback=True``, on both numpy and dask backends.
+        The fallback oracle always runs on numpy. Correctness itself is covered
+        by ``test_grouped_sum_from_first_principles``.
         """
         if backend == "dask":
             pytest.importorskip("dask")
@@ -2246,18 +2243,18 @@ class TestGroupbySumKernel:
         assert_linequal(scatter, fallback)
 
     @pytest.mark.parametrize("backend", ["numpy", "dask"])
-    @pytest.mark.parametrize("case", FIRST_PRINCIPLES_SUM_CASES)
+    @pytest.mark.parametrize("case", GROUPBY_SUM_CASES)
     def test_grouped_sum_from_first_principles(
         self, groupby_ctx: SimpleNamespace, case: str, backend: str
     ) -> None:
         """
-        Verify the cases the fallback cannot validate (quadratic, masked
-        multi-dim, auxiliary coords): each group's terms and constant must match
-        its members, from first principles, on both numpy and dask backends.
+        The authoritative correctness check, over every case: each group's terms
+        and constant must match its members, verified from first principles with
+        no reference implementation, on both numpy and dask backends.
         """
         if backend == "dask":
             pytest.importorskip("dask")
-        expr, groups = FIRST_PRINCIPLES_SUM_CASES[case](groupby_ctx)
+        expr, groups = GROUPBY_SUM_CASES[case](groupby_ctx)
         _assert_grouped_sum_correct(expr, groups, chunked=backend == "dask")
 
 

--- a/test/test_linear_expression.py
+++ b/test/test_linear_expression.py
@@ -8,7 +8,6 @@ Created on Wed Mar 17 17:06:36 2021.
 from __future__ import annotations
 
 import warnings
-from collections import Counter
 from types import SimpleNamespace
 from typing import Any
 
@@ -28,7 +27,7 @@ from linopy import (
     Variable,
     merge,
 )
-from linopy.constants import FACTOR_DIM, HELPER_DIMS, TERM_DIM
+from linopy.constants import HELPER_DIMS, TERM_DIM
 from linopy.expressions import ScalarLinearExpression
 from linopy.testing import assert_linequal, assert_quadequal
 from linopy.variables import ScalarVariable
@@ -1921,7 +1920,6 @@ def groupby_ctx() -> SimpleNamespace:
     a, b = pd.Index(range(12), name="a"), pd.Index(list("vwxyz"), name="b")
 
     const = xr.DataArray(rng.normal(size=(3, 60)), coords=[other, idx])
-    y = m.add_variables(coords=[other, idx], name="y")
     yab = m.add_variables(coords=[a, b], name="yab")
     stacked = LinearExpression((2 * yab + 1 * yab).data.stack(elem=["a", "b"]), m)
     skewed = pd.Series(rng.choice(8, 60, p=[0.5] + [0.5 / 7] * 7), index=idx, name="g")
@@ -1929,23 +1927,14 @@ def groupby_ctx() -> SimpleNamespace:
     return SimpleNamespace(
         m=m,
         x=m.add_variables(coords=[idx], name="x"),
-        y=y,
+        y=m.add_variables(coords=[other, idx], name="y"),
         y3=m.add_variables(coords=[p, q, idx], name="y3"),
         mx=m.add_variables(
             coords=[idx], name="mx", mask=xr.DataArray(np.arange(60) % 4 != 0, [idx])
         ),
-        my=m.add_variables(
-            coords=[other, idx],
-            name="my",
-            mask=xr.DataArray(rng.random((3, 60)) > 0.25, [other, idx]),
-        ),
         const=const,
         nan_const=const.where(rng.random((3, 60)) > 0.3),
         nan_vec=np.where(np.arange(60) % 3, np.nan, 5.0),
-        y_aux=(2 * y + 1 * y).assign_coords(
-            carrier=("elem", rng.choice(list("PQ"), 60)),
-            tag=(("other", "elem"), rng.integers(0, 9, (3, 60))),
-        ),
         stacked=stacked,
         skewed=skewed,
         one_group=pd.Series(1, index=idx, name="g"),
@@ -1971,90 +1960,32 @@ FALLBACK_SUM_CASES = {
     "multiindex_dim": lambda c: (c.stacked, c.mi_groups),
 }
 
-# Cases the fallback cannot reproduce (errors on quadratics' _factor axis;
-# diverges on masked multi-dim vars and grouped-dim coords).
-FALLBACK_UNSUPPORTED_SUM_CASES = {
-    "quadratic": lambda c: (c.x * c.x + 2 * c.x, c.skewed),
-    "quadratic_multidim_const": lambda c: (c.y * c.y + 2 * c.y + c.const, c.skewed),
-    "masked_multidim": lambda c: (5 * c.my - 2 * c.my, c.skewed),
-    "aux_coords_on_group_dim": lambda c: (c.y_aux, c.skewed),
-}
 
-GROUPBY_SUM_CASES = {**FALLBACK_SUM_CASES, **FALLBACK_UNSUPPORTED_SUM_CASES}
-
-
-def _term_multisets(
-    ds: xr.Dataset, row_dim: str, labels: list, loop_dims: list
-) -> dict:
+def _grouped_sum_on_backend(
+    expr: LinearExpression, groups: pd.Series, backend: str
+) -> LinearExpression:
     """
-    Map ``(group label, slice over loop dims)`` to a multiset of live terms.
+    Group-sum ``expr`` on the numpy or the lazy (dask) kernel via the public API.
 
-    A term is a coefficient paired with its sorted variable labels (one label for
-    a linear term, two for a quadratic factor pair); fill terms (all labels -1)
-    are skipped. Rows sharing a group label are merged, so the same helper
-    summarises the per-element input and the per-group result.
+    For dask the input is chunked with :meth:`LinearExpression.chunk`; the grouped
+    result stays lazy until the tests read ``.vars``/``.coeffs``/``.const`` values.
     """
-    coeffs = ds.coeffs.transpose(row_dim, *loop_dims, TERM_DIM).values
-    var_dims = [row_dim, *loop_dims, TERM_DIM]
-    if FACTOR_DIM in ds.vars.dims:
-        var_dims.append(FACTOR_DIM)
-    vars_ = ds.vars.transpose(*var_dims).values
-    if FACTOR_DIM not in ds.vars.dims:
-        vars_ = vars_[..., None]
-
-    terms: dict = {}
-    for r in range(coeffs.shape[0]):
-        for loop in np.ndindex(*coeffs.shape[1:-1]):
-            bucket = terms.setdefault((labels[r], loop), Counter())
-            cs, vs = coeffs[(r, *loop)], vars_[(r, *loop)]
-            for t in range(cs.shape[0]):
-                factors = tuple(sorted(int(f) for f in vs[t]))
-                if all(f == -1 for f in factors):
-                    continue
-                bucket[(round(float(cs[t]), 9), factors)] += 1
-    return terms
-
-
-def _assert_grouped_sum_correct(
-    expr: LinearExpression, groups: pd.Series, *, chunked: bool = False
-) -> None:
-    """
-    Verify ``groupby(...).sum()`` from first principles, without a reference
-    implementation.
-
-    For every group and every slice over the non-grouped dimensions, the result's
-    live terms must be exactly the multiset of its members' terms, and its
-    constant the members' NaN-skipping sum. With ``chunked=True`` the same check
-    runs against dask-backed input, exercising the lazy kernel.
-    """
-    group_dim = groups.index.name
-    gname = groups.name
-    if chunked:
-        expr = LinearExpression(expr.data.chunk({group_dim: 17}), expr.model)
-    in_ds = expr.data
-    out_ds = expr.groupby(groups).sum().data
-    loop_dims = [d for d in in_ds.coeffs.dims if d not in (group_dim, TERM_DIM)]
-
-    expected = _term_multisets(in_ds, group_dim, list(groups.values), loop_dims)
-    actual = _term_multisets(out_ds, gname, list(out_ds[gname].values), loop_dims)
-    assert actual == expected
-
-    const_loop = [d for d in in_ds.const.dims if d != group_dim]
-    in_const = np.nan_to_num(in_ds.const.transpose(group_dim, *const_loop).values)
-    out_const = out_ds.const.transpose(gname, *const_loop).values
-    member_of = np.asarray(groups.values)
-    for i, g in enumerate(out_ds[gname].values):
-        np.testing.assert_allclose(
-            in_const[member_of == g].sum(0), out_const[i], rtol=1e-9, atol=1e-12
-        )
+    if backend == "dask":
+        pytest.importorskip("dask")
+        expr = expr.chunk({groups.index.name: 2})
+    grouped = expr.groupby(groups).sum()
+    if backend == "dask":
+        assert grouped.vars.chunks is not None  # stayed lazy until values are read
+    return grouped
 
 
 class TestGroupbySumKernel:
     """
     ``groupby(...).sum()`` builds the padded result with a single
     :func:`xarray.apply_ufunc` kernel (``_grouped_sum``) over numpy and chunked
-    (dask) data. These tests verify that kernel from first principles and cover
-    the structural edge cases.
+    (dask) data. The cases the old engine also reproduces are guarded against
+    ``use_fallback=True``; the ones it cannot (quadratics, masked multi-dim vars,
+    coords on the grouped dim) get concrete, hand-pinned layout tests.
     """
 
     def test_skewed_unsorted_groups(self, v: Variable) -> None:
@@ -2226,36 +2157,126 @@ class TestGroupbySumKernel:
         """
         Equivalence guard: on the cases the old engine reproduces, the scatter
         kernel must match ``use_fallback=True``, on both numpy and dask backends.
-        The fallback oracle always runs on numpy. Correctness itself is covered
-        by ``test_grouped_sum_from_first_principles``.
+        The fallback oracle always runs on numpy.
         """
-        if backend == "dask":
-            pytest.importorskip("dask")
         expr, groups = FALLBACK_SUM_CASES[case](groupby_ctx)
         fallback = expr.groupby(groups).sum(use_fallback=True)
-        if backend == "dask":
-            expr = LinearExpression(
-                expr.data.chunk({groups.index.name: 17}), expr.model
-            )
-        scatter = expr.groupby(groups).sum()
-        if backend == "dask":
-            scatter = LinearExpression(scatter.data.compute(), expr.model)
+        scatter = _grouped_sum_on_backend(expr, groups, backend)
         assert_linequal(scatter, fallback)
 
     @pytest.mark.parametrize("backend", ["numpy", "dask"])
-    @pytest.mark.parametrize("case", GROUPBY_SUM_CASES)
-    def test_grouped_sum_from_first_principles(
-        self, groupby_ctx: SimpleNamespace, case: str, backend: str
-    ) -> None:
+    def test_masked_multidim_drops_masked_members(self, backend: str) -> None:
         """
-        The authoritative correctness check, over every case: each group's terms
-        and constant must match its members, verified from first principles with
-        no reference implementation, on both numpy and dask backends.
+        A masked member drops out of its group (its variable never appears),
+        while live members scatter as usual, across unsorted, non-contiguous
+        groups. The fallback diverges here, so the expected live-variable sets
+        are pinned by hand; runs on numpy and the lazy (dask) kernel.
         """
-        if backend == "dask":
-            pytest.importorskip("dask")
-        expr, groups = GROUPBY_SUM_CASES[case](groupby_ctx)
-        _assert_grouped_sum_correct(expr, groups, chunked=backend == "dask")
+        m = Model()
+        other = pd.Index(["a", "b"], name="other")
+        idx = pd.RangeIndex(5, name="elem")
+        # mask out (a, elem 2), (b, elem 0) and (b, elem 4)
+        mask = xr.DataArray(
+            [[True, True, False, True, True], [False, True, True, True, False]],
+            coords=[other, idx],
+        )
+        my = m.add_variables(coords=[other, idx], name="my", mask=mask)
+        # unsorted, non-contiguous groups: g0 = {1, 3}, g1 = {0, 2, 4}
+        groups = pd.Series([1, 0, 1, 0, 1], index=idx, name="g")
+        lab = my.labels.values  # (other, elem), masked positions are -1
+
+        grouped = _grouped_sum_on_backend(5 * my - 2 * my, groups, backend)
+        assert list(grouped.coords["g"].values) == [0, 1]
+
+        vars_ = grouped.vars.transpose("g", "other", "_term")
+
+        def live(g: int, o: str) -> set:
+            v = vars_.sel(g=g, other=o).values
+            return set(v[v >= 0].tolist())
+
+        # masked members contribute no variable to their group's block
+        assert live(0, "a") == {lab[0, 1], lab[0, 3]}
+        assert live(0, "b") == {lab[1, 1], lab[1, 3]}
+        assert live(1, "a") == {lab[0, 0], lab[0, 4]}  # elem 2 masked out
+        assert live(1, "b") == {lab[1, 2]}  # elems 0 and 4 masked out
+        # ``5*my - 2*my`` gives every live member one 5-term and one -2-term
+        live_coeffs = grouped.coeffs.where(grouped.vars >= 0).values
+        live_coeffs = live_coeffs[~np.isnan(live_coeffs)]
+        assert (
+            (live_coeffs == 5.0).sum()
+            == (live_coeffs == -2.0).sum()
+            == (live_coeffs.size // 2)
+        )
+
+    @pytest.mark.parametrize("backend", ["numpy", "dask"])
+    def test_aux_coords_on_group_dim_dropped(self, backend: str) -> None:
+        """
+        Non-dimension coordinates aligned to the grouped dimension are dropped
+        (they no longer have a meaning once members are collapsed), while coords
+        on the surviving dimensions are kept. The fallback diverges here; runs on
+        numpy and the lazy (dask) kernel.
+        """
+        m = Model()
+        other = pd.Index(["a", "b"], name="other")
+        idx = pd.RangeIndex(4, name="elem")
+        y = m.add_variables(coords=[other, idx], name="y")
+        expr = (2 * y + 1 * y).assign_coords(
+            carrier=("elem", ["P", "Q", "P", "P"]),  # on the grouped dim -> dropped
+            tag=(("other", "elem"), [[10, 11, 12, 13], [20, 21, 22, 23]]),  # dropped
+        )
+        groups = pd.Series([0, 0, 1, 0], index=idx, name="g")
+        lab = y.labels.values  # (other, elem)
+
+        grouped = _grouped_sum_on_backend(expr, groups, backend)
+        assert "carrier" not in grouped.coords
+        assert "tag" not in grouped.coords
+        assert "other" in grouped.coords  # the surviving dim is untouched
+        assert list(grouped.coords["g"].values) == [0, 1]
+
+        # group 0 holds members 0, 1, 3 in order; group 1 holds member 2 then fill
+        m0 = [0, 1, 3]
+        exp_vars = [
+            [list(lab[o, m0]) * 2 for o in (0, 1)],
+            [[lab[o, 2], -1, -1] * 2 for o in (0, 1)],
+        ]
+        np.testing.assert_array_equal(
+            grouped.vars.transpose("g", "other", "_term").values, exp_vars
+        )
+
+    @pytest.mark.parametrize("backend", ["numpy", "dask"])
+    def test_exact_padded_layout_quadratic_with_const(self, backend: str) -> None:
+        """
+        Pin a mixed quadratic + linear + constant layout: the ``_factor`` axis
+        carries ``-1`` for the linear term's missing second factor, padding fills
+        the short group, and the per-group constant is the members' sum. Runs on
+        numpy and the lazy (dask) kernel.
+        """
+        m = Model()
+        idx = pd.RangeIndex(4, name="elem")
+        x = m.add_variables(coords=[idx], name="x")
+        y = m.add_variables(coords=[idx], name="y")
+        groups = pd.Series([0, 0, 1, 0], index=idx, name="g")
+        lx, ly = x.labels.values, y.labels.values
+
+        grouped = _grouped_sum_on_backend(x * y + 2 * x + 7, groups, backend)
+        assert set(grouped.vars.dims) == {"g", "_factor", "_term"}
+        assert grouped.nterm == 6  # max group size (3) * input nterm (2)
+
+        # group 0 holds members 0, 1, 3; group 1 holds member 2 then fill. Term
+        # block 0 is the quadratic x*y, block 1 the linear 2*x (2nd factor -1)
+        m0 = [0, 1, 3]
+        exp_vars = [
+            [[*lx[m0], *lx[m0]], [*ly[m0], -1, -1, -1]],
+            [[lx[2], -1, -1, lx[2], -1, -1], [ly[2], -1, -1, -1, -1, -1]],
+        ]
+        np.testing.assert_array_equal(
+            grouped.vars.transpose("g", "_factor", "_term").values, exp_vars
+        )
+        np.testing.assert_array_equal(
+            grouped.coeffs.transpose("g", "_term").values,
+            [[1.0, 1, 1, 2, 2, 2], [1, np.nan, np.nan, 2, np.nan, np.nan]],
+        )
+        np.testing.assert_array_equal(grouped.const.values, [21.0, 7.0])
 
 
 def test_linear_expression_rolling(v: Variable) -> None:

--- a/test/test_linear_expression.py
+++ b/test/test_linear_expression.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import warnings
 from collections import Counter
-from collections.abc import Callable
 from types import SimpleNamespace
 from typing import Any
 
@@ -1957,26 +1956,35 @@ def groupby_ctx() -> SimpleNamespace:
 
 # Each case maps a structure to (expr, groups) from `groupby_ctx`. The skewed
 # group puts ~half the elements in group 0 and spreads 1..7 over the rest.
-GROUPBY_SUM_CASES = {
+
+# Structures the xarray ``use_fallback=True`` path reproduces, so the scatter
+# kernel is validated by comparing against it directly.
+FALLBACK_SUM_CASES = {
     "skewed_int_groups": lambda c: (3 * c.x - 2 * c.x + 7, c.skewed),
     "multidim_with_const": lambda c: (2 * c.y + 1 * c.y + c.const, c.skewed),
     "nan_const": lambda c: (1 * c.x + c.nan_vec, c.skewed),
     "masked_vars": lambda c: (1 * c.mx, c.skewed),
-    "quadratic": lambda c: (c.x * c.x + 2 * c.x, c.skewed),
     "single_group": lambda c: (1 * c.x, c.one_group),
     "identity_groups": lambda c: (1 * c.x, c.identity),
-    # combined structures exercising several features at once
     "multidim_const_nan": lambda c: (
         2 * c.y - 3 * c.y + 1 * c.y + c.nan_const,
         c.skewed,
     ),
     "three_dims": lambda c: (4 * c.y3 + 1 * c.y3, c.skewed),
-    "quadratic_multidim_const": lambda c: (c.y * c.y + 2 * c.y + c.const, c.skewed),
-    "masked_multidim": lambda c: (5 * c.my - 2 * c.my, c.skewed),
-    # both collapse the grouped dim, dropping every coordinate tied to it
-    "aux_coords_on_group_dim": lambda c: (c.y_aux, c.skewed),
     "multiindex_dim": lambda c: (c.stacked, c.mi_groups),
 }
+
+# Structures the fallback cannot reproduce -- it errors on the `_factor` axis of
+# quadratics, and diverges on masked multi-dim vars and coordinates tied to the
+# grouped dim -- so the scatter kernel is checked from first principles instead.
+FIRST_PRINCIPLES_SUM_CASES = {
+    "quadratic": lambda c: (c.x * c.x + 2 * c.x, c.skewed),
+    "quadratic_multidim_const": lambda c: (c.y * c.y + 2 * c.y + c.const, c.skewed),
+    "masked_multidim": lambda c: (5 * c.my - 2 * c.my, c.skewed),
+    "aux_coords_on_group_dim": lambda c: (c.y_aux, c.skewed),
+}
+
+GROUPBY_SUM_CASES = {**FALLBACK_SUM_CASES, **FIRST_PRINCIPLES_SUM_CASES}
 
 
 def _term_multisets(
@@ -2215,25 +2223,41 @@ class TestGroupbySumKernel:
         assert dict(grouped.data.sizes) == {"g": 0, "_term": 0}
 
     @pytest.mark.parametrize("backend", ["numpy", "dask"])
-    @pytest.mark.parametrize(
-        "build",
-        GROUPBY_SUM_CASES.values(),
-        ids=GROUPBY_SUM_CASES.keys(),
-    )
-    def test_grouped_sum_correct(
-        self,
-        build: Callable[[SimpleNamespace], tuple[LinearExpression, pd.Series]],
-        groupby_ctx: SimpleNamespace,
-        backend: str,
+    @pytest.mark.parametrize("case", FALLBACK_SUM_CASES)
+    def test_grouped_sum_matches_fallback(
+        self, groupby_ctx: SimpleNamespace, case: str, backend: str
     ) -> None:
         """
-        Each group's terms and constant must match its members, from first
-        principles, on both numpy and dask backends. See ``GROUPBY_SUM_CASES``
-        for the structures covered.
+        The scatter kernel must match the xarray ``use_fallback=True`` groupby,
+        on both numpy and dask backends. The fallback oracle always runs on
+        numpy; ``FIRST_PRINCIPLES_SUM_CASES`` holds the cases it cannot validate.
         """
         if backend == "dask":
             pytest.importorskip("dask")
-        expr, groups = build(groupby_ctx)
+        expr, groups = FALLBACK_SUM_CASES[case](groupby_ctx)
+        fallback = expr.groupby(groups).sum(use_fallback=True)
+        if backend == "dask":
+            expr = LinearExpression(
+                expr.data.chunk({groups.index.name: 17}), expr.model
+            )
+        scatter = expr.groupby(groups).sum()
+        if backend == "dask":
+            scatter = LinearExpression(scatter.data.compute(), expr.model)
+        assert_linequal(scatter, fallback)
+
+    @pytest.mark.parametrize("backend", ["numpy", "dask"])
+    @pytest.mark.parametrize("case", FIRST_PRINCIPLES_SUM_CASES)
+    def test_grouped_sum_from_first_principles(
+        self, groupby_ctx: SimpleNamespace, case: str, backend: str
+    ) -> None:
+        """
+        Verify the cases the fallback cannot validate (quadratic, masked
+        multi-dim, auxiliary coords): each group's terms and constant must match
+        its members, from first principles, on both numpy and dask backends.
+        """
+        if backend == "dask":
+            pytest.importorskip("dask")
+        expr, groups = FIRST_PRINCIPLES_SUM_CASES[case](groupby_ctx)
         _assert_grouped_sum_correct(expr, groups, chunked=backend == "dask")
 
 

--- a/test/test_linear_expression.py
+++ b/test/test_linear_expression.py
@@ -7,8 +7,8 @@ Created on Wed Mar 17 17:06:36 2021.
 
 from __future__ import annotations
 
-import logging
 import warnings
+from collections import Counter
 from collections.abc import Callable
 from types import SimpleNamespace
 from typing import Any
@@ -29,7 +29,7 @@ from linopy import (
     Variable,
     merge,
 )
-from linopy.constants import HELPER_DIMS, TERM_DIM
+from linopy.constants import FACTOR_DIM, HELPER_DIMS, TERM_DIM
 from linopy.expressions import ScalarLinearExpression
 from linopy.testing import assert_linequal, assert_quadequal
 from linopy.variables import ScalarVariable
@@ -1912,8 +1912,8 @@ def test_linear_expression_groupby_from_variable(v: Variable) -> None:
 
 
 @pytest.fixture
-def scatter_ctx() -> SimpleNamespace:
-    """Shared 60-element building blocks for the scatter-vs-unstack case table."""
+def groupby_ctx() -> SimpleNamespace:
+    """Shared 60-element building blocks for the groupby-sum case table."""
     m = Model()
     rng = np.random.default_rng(0)
     idx = pd.RangeIndex(60, name="elem")
@@ -1955,9 +1955,9 @@ def scatter_ctx() -> SimpleNamespace:
     )
 
 
-# Each case maps a structure to (expr, groups) from `scatter_ctx`. The skewed
+# Each case maps a structure to (expr, groups) from `groupby_ctx`. The skewed
 # group puts ~half the elements in group 0 and spreads 1..7 over the rest.
-SCATTER_EQUALS_UNSTACK_CASES = {
+GROUPBY_SUM_CASES = {
     "skewed_int_groups": lambda c: (3 * c.x - 2 * c.x + 7, c.skewed),
     "multidim_with_const": lambda c: (2 * c.y + 1 * c.y + c.const, c.skewed),
     "nan_const": lambda c: (1 * c.x + c.nan_vec, c.skewed),
@@ -1979,37 +1979,84 @@ SCATTER_EQUALS_UNSTACK_CASES = {
 }
 
 
-class TestGroupbySumScatterKernel:
+def _term_multisets(
+    ds: xr.Dataset, row_dim: str, labels: list, loop_dims: list
+) -> dict:
     """
-    ``groupby(...).sum()`` takes a scatter fast path (``_sum_by_scatter``) for
-    numpy-backed expressions and falls back to the xarray unstack machinery
-    (``_sum_by_unstack``) for chunked data and exotic coordinates. These tests
-    pin the two kernels together and cover the structural edge cases.
+    Map ``(group label, slice over loop dims)`` to a multiset of live terms.
+
+    A term is a coefficient paired with its sorted variable labels (one label for
+    a linear term, two for a quadratic factor pair); fill terms (all labels -1)
+    are skipped. Rows sharing a group label are merged, so the same helper
+    summarises the per-element input and the per-group result.
     """
+    coeffs = ds.coeffs.transpose(row_dim, *loop_dims, TERM_DIM).values
+    var_dims = [row_dim, *loop_dims, TERM_DIM]
+    if FACTOR_DIM in ds.vars.dims:
+        var_dims.append(FACTOR_DIM)
+    vars_ = ds.vars.transpose(*var_dims).values
+    if FACTOR_DIM not in ds.vars.dims:
+        vars_ = vars_[..., None]
 
-    @staticmethod
-    def _assert_kernels_identical(gb: Any, groups: pd.Series, m: Model) -> None:
-        """Force both kernels and assert they produce the same expression."""
-        scatter = LinearExpression(gb._sum_by_scatter(groups).rename(_group="g"), m)
-        unstack = LinearExpression(gb._sum_by_unstack(groups).rename(_group="g"), m)
+    terms: dict = {}
+    for r in range(coeffs.shape[0]):
+        for loop in np.ndindex(*coeffs.shape[1:-1]):
+            bucket = terms.setdefault((labels[r], loop), Counter())
+            cs, vs = coeffs[(r, *loop)], vars_[(r, *loop)]
+            for t in range(cs.shape[0]):
+                factors = tuple(sorted(int(f) for f in vs[t]))
+                if all(f == -1 for f in factors):
+                    continue
+                bucket[(round(float(cs[t]), 9), factors)] += 1
+    return terms
 
-        assert scatter.data.coeffs.dims == unstack.data.coeffs.dims
-        assert scatter.data.const.dims == unstack.data.const.dims
-        assert list(scatter.data.coords) == list(unstack.data.coords)
-        for name in scatter.data.coords:
-            assert_equal(scatter.data[name], unstack.data[name])
 
-        np.testing.assert_array_equal(scatter.vars.values, unstack.vars.values)
-        np.testing.assert_array_equal(scatter.coeffs.values, unstack.coeffs.values)
-        # constants may differ only by floating-point summation order
+def _assert_grouped_sum_correct(
+    expr: LinearExpression, groups: pd.Series, *, chunked: bool = False
+) -> None:
+    """
+    Verify ``groupby(...).sum()`` from first principles, without a reference
+    implementation.
+
+    For every group and every slice over the non-grouped dimensions, the result's
+    live terms must be exactly the multiset of its members' terms, and its
+    constant the members' NaN-skipping sum. With ``chunked=True`` the same check
+    runs against dask-backed input, exercising the lazy kernel.
+    """
+    group_dim = groups.index.name
+    gname = groups.name
+    if chunked:
+        expr = LinearExpression(expr.data.chunk({group_dim: 17}), expr.model)
+    in_ds = expr.data
+    out_ds = expr.groupby(groups).sum().data
+    loop_dims = [d for d in in_ds.coeffs.dims if d not in (group_dim, TERM_DIM)]
+
+    expected = _term_multisets(in_ds, group_dim, list(groups.values), loop_dims)
+    actual = _term_multisets(out_ds, gname, list(out_ds[gname].values), loop_dims)
+    assert actual == expected
+
+    const_loop = [d for d in in_ds.const.dims if d != group_dim]
+    in_const = np.nan_to_num(in_ds.const.transpose(group_dim, *const_loop).values)
+    out_const = out_ds.const.transpose(gname, *const_loop).values
+    member_of = np.asarray(groups.values)
+    for i, g in enumerate(out_ds[gname].values):
         np.testing.assert_allclose(
-            scatter.const.values, unstack.const.values, rtol=1e-12
+            in_const[member_of == g].sum(0), out_const[i], rtol=1e-9, atol=1e-12
         )
+
+
+class TestGroupbySumKernel:
+    """
+    ``groupby(...).sum()`` builds the padded result with a single
+    :func:`xarray.apply_ufunc` kernel (``_grouped_sum``) over numpy and chunked
+    (dask) data. These tests verify that kernel from first principles and cover
+    the structural edge cases.
+    """
 
     def test_skewed_unsorted_groups(self, v: Variable) -> None:
         """
-        The scatter-based fast path must match the xarray fallback for groups
-        that are unsorted, non-contiguous and of very different sizes.
+        The kernel must match the xarray fallback for groups that are unsorted,
+        non-contiguous and of very different sizes.
         """
         expr = 2 * v + 5
         # 'b' appears 14 times, 'c' 5 times, 'a' once, scattered over the dimension
@@ -2033,18 +2080,21 @@ class TestGroupbySumScatterKernel:
             assert (vars_of_group >= 0).sum() == len(members) * expr.nterm
             assert grouped.const.sel(letter=letter).item() == 5 * len(members)
 
-    def test_chunked_uses_unstack(
-        self, v: Variable, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """Chunked (dask-backed) expressions group via xarray's unstack path."""
+    @pytest.mark.parametrize("chunks", [{"dim_2": 5}, {"dim_2": 5, "_term": 1}])
+    def test_chunked_runs_lazily(self, v: Variable, chunks: dict) -> None:
+        """
+        The kernel handles chunked (dask) data, staying lazy until computed. It
+        gathers both the grouped and term dimensions into single chunks, so a
+        split ``_term`` (a core dim of the scatter) is handled too.
+        """
         pytest.importorskip("dask")
-        expr = 2 * v + 5
+        expr = 2 * v + 3 * v + 5  # nterm 2, so `_term` can be split
         groups = pd.Series([1] * 12 + [2] * 8, index=v.indexes["dim_2"], name="group")
 
-        chunked = LinearExpression(expr.data.chunk({"dim_2": 5}), expr.model)
-        with caplog.at_level(logging.DEBUG, logger="linopy.expressions"):
-            grouped_chunked = chunked.groupby(groups).sum()
-        assert "falling back to the unstack kernel" in caplog.text
+        chunked = LinearExpression(expr.data.chunk(chunks), expr.model)
+        grouped_chunked = chunked.groupby(groups).sum()
+        # the result stays a lazy dask graph until explicitly computed
+        assert grouped_chunked.data.vars.chunks is not None
 
         grouped = expr.groupby(groups).sum()
         assert grouped_chunked.nterm == grouped.nterm
@@ -2060,8 +2110,101 @@ class TestGroupbySumScatterKernel:
         with pytest.raises(ValueError, match="NaN"):
             expr.groupby(groups).sum()
 
+    def test_exact_padded_layout(self) -> None:
+        """
+        Pin the concrete padded layout the property checks abstract away: member
+        order within a group, fill at the end of a short group's block, the
+        ``(g, _term)`` dim order, and the per-group constant sum.
+        """
+        m = Model()
+        idx = pd.RangeIndex(4, name="elem")
+        x = m.add_variables(coords=[idx], name="x")
+        groups = pd.Series([0, 0, 1, 0], index=idx, name="g")
+
+        grouped = (2 * x + 5).groupby(groups).sum()
+        lab = x.labels.values
+
+        assert grouped.data.vars.dims == ("g", "_term")
+        assert list(grouped.data.g.values) == [0, 1]
+        assert grouped.nterm == 3  # max group size (3) * input nterm (1)
+        # group 0 holds members 0, 1, 3 in order; group 1 holds member 2 then fill
+        np.testing.assert_array_equal(
+            grouped.data.vars.values, [[lab[0], lab[1], lab[3]], [lab[2], -1, -1]]
+        )
+        np.testing.assert_array_equal(
+            grouped.data.coeffs.values, [[2.0, 2.0, 2.0], [2.0, np.nan, np.nan]]
+        )
+        np.testing.assert_array_equal(grouped.const.values, [15.0, 5.0])
+
+    def test_exact_padded_layout_multidim(self) -> None:
+        """
+        Anchor the layout with a non-grouped dim and two input terms: the
+        ``(nterm, max_size)`` interleaving and per-slice padding must hold.
+        """
+        m = Model()
+        other = pd.Index(list("ab"), name="other")
+        idx = pd.RangeIndex(4, name="elem")
+        y = m.add_variables(coords=[other, idx], name="y")
+        groups = pd.Series([0, 0, 1, 0], index=idx, name="g")
+
+        grouped = (2 * y + 3 * y + 1).groupby(groups).sum()
+        lab = y.labels.values  # (other, elem)
+
+        assert set(grouped.data.vars.dims) == {"g", "other", "_term"}
+        # the non-grouped coord survives; the group coord holds the sorted keys
+        assert list(grouped.data.other.values) == ["a", "b"]
+        assert list(grouped.data.g.values) == [0, 1]
+        assert grouped.nterm == 6  # max group size (3) * input nterm (2)
+        # group 0 holds members 0, 1, 3 in order; group 1 holds member 2 then fill
+        m0 = [0, 1, 3]
+        exp_vars = [
+            [list(lab[o, m0]) * 2 for o in (0, 1)],
+            [[lab[o, 2], -1, -1] * 2 for o in (0, 1)],
+        ]
+        np.testing.assert_array_equal(
+            grouped.data.vars.transpose("g", "other", "_term").values, exp_vars
+        )
+        term, pad = [2.0, 2, 2, 3, 3, 3], [2.0, np.nan, np.nan, 3, np.nan, np.nan]
+        np.testing.assert_array_equal(
+            grouped.data.coeffs.transpose("g", "other", "_term").values,
+            [[term, term], [pad, pad]],
+        )
+        np.testing.assert_array_equal(
+            grouped.data.const.transpose("g", "other").values, [[3.0, 3], [1, 1]]
+        )
+
+    def test_exact_padded_layout_quadratic(self) -> None:
+        """
+        Anchor the layout for a quadratic: the ``_factor`` axis must scatter
+        through to the padded result alongside the term positions.
+        """
+        m = Model()
+        idx = pd.RangeIndex(4, name="elem")
+        x = m.add_variables(coords=[idx], name="x")
+        y = m.add_variables(coords=[idx], name="y")
+        groups = pd.Series([0, 0, 1, 0], index=idx, name="g")
+
+        grouped = (x * y).groupby(groups).sum()
+        lx, ly = x.labels.values, y.labels.values
+
+        assert set(grouped.data.vars.dims) == {"g", "_factor", "_term"}
+        assert grouped.nterm == 3
+        # factor 0 carries x, factor 1 carries y; members 0, 1, 3 then fill
+        m0 = [0, 1, 3]
+        exp_vars = [
+            [list(lx[m0]), list(ly[m0])],
+            [[lx[2], -1, -1], [ly[2], -1, -1]],
+        ]
+        np.testing.assert_array_equal(
+            grouped.data.vars.transpose("g", "_factor", "_term").values, exp_vars
+        )
+        np.testing.assert_array_equal(
+            grouped.data.coeffs.transpose("g", "_term").values,
+            [[1.0, 1, 1], [1, np.nan, np.nan]],
+        )
+
     def test_empty_groups(self) -> None:
-        """An empty group dimension scatters into an empty, well-formed result."""
+        """An empty group dimension produces an empty, well-formed result."""
         m = Model()
         idx = pd.RangeIndex(0, name="elem")
         x = m.add_variables(coords=[idx], name="x")
@@ -2071,28 +2214,27 @@ class TestGroupbySumScatterKernel:
         assert grouped.nterm == 0
         assert dict(grouped.data.sizes) == {"g": 0, "_term": 0}
 
+    @pytest.mark.parametrize("backend", ["numpy", "dask"])
     @pytest.mark.parametrize(
         "build",
-        SCATTER_EQUALS_UNSTACK_CASES.values(),
-        ids=SCATTER_EQUALS_UNSTACK_CASES.keys(),
+        GROUPBY_SUM_CASES.values(),
+        ids=GROUPBY_SUM_CASES.keys(),
     )
-    def test_scatter_equals_unstack(
+    def test_grouped_sum_correct(
         self,
         build: Callable[[SimpleNamespace], tuple[LinearExpression, pd.Series]],
-        scatter_ctx: SimpleNamespace,
+        groupby_ctx: SimpleNamespace,
+        backend: str,
     ) -> None:
         """
-        Lock the two groupby-sum kernels together.
-
-        The fast path scatters terms into numpy arrays (``_sum_by_scatter``);
-        the unstack implementation (``_sum_by_unstack``) is kept for chunked
-        data. Both must stay interchangeable — if an xarray/pandas update
-        changes the unstack output or an edge case diverges, this fails. See
-        ``SCATTER_EQUALS_UNSTACK_CASES`` for the structures covered.
+        Each group's terms and constant must match its members, from first
+        principles, on both numpy and dask backends. See ``GROUPBY_SUM_CASES``
+        for the structures covered.
         """
-        expr, groups = build(scatter_ctx)
-        gb = expr.groupby(groups)
-        self._assert_kernels_identical(gb, groups, scatter_ctx.m)
+        if backend == "dask":
+            pytest.importorskip("dask")
+        expr, groups = build(groupby_ctx)
+        _assert_grouped_sum_correct(expr, groups, chunked=backend == "dask")
 
 
 def test_linear_expression_rolling(v: Variable) -> None:

--- a/test/test_linear_expression.py
+++ b/test/test_linear_expression.py
@@ -1958,6 +1958,18 @@ def test_linear_expression_groupby_with_nan_groups(v: Variable) -> None:
         expr.groupby(groups).sum()
 
 
+def test_linear_expression_groupby_empty_groups() -> None:
+    """An empty group dimension scatters into an empty, well-formed result."""
+    m = Model()
+    idx = pd.RangeIndex(0, name="elem")
+    x = m.add_variables(coords=[idx], name="x")
+    groups = pd.Series([], index=idx, name="g", dtype=int)
+
+    grouped = (1 * x).groupby(groups).sum()
+    assert grouped.nterm == 0
+    assert dict(grouped.data.sizes) == {"g": 0, "_term": 0}
+
+
 @pytest.mark.parametrize(
     "case",
     [

--- a/test/test_linear_expression.py
+++ b/test/test_linear_expression.py
@@ -2001,7 +2001,7 @@ class TestGroupbySumKernel:
         grouped = expr.groupby(groups).sum()
         fallback = expr.groupby(groups.to_xarray()).sum(use_fallback=True)
 
-        assert list(grouped.data.letter) == ["a", "b", "c"]
+        assert list(grouped.coords["letter"].values) == ["a", "b", "c"]
         # padded to the largest group times the number of terms of the input
         assert grouped.nterm == 14 * expr.nterm
         assert_linequal(grouped, fallback)
@@ -2009,7 +2009,7 @@ class TestGroupbySumKernel:
         # every group carries exactly the variables of its members, rest is fill
         for letter in ["a", "b", "c"]:
             members = np.where(np.array(labels) == letter)[0]
-            vars_of_group = grouped.data.vars.sel(letter=letter).values
+            vars_of_group = grouped.vars.sel(letter=letter).values
             present = set(vars_of_group[vars_of_group >= 0])
             assert present == set(v.labels.values[members])
             assert (vars_of_group >= 0).sum() == len(members) * expr.nterm
@@ -2020,22 +2020,20 @@ class TestGroupbySumKernel:
         """
         The kernel handles chunked (dask) data, staying lazy until computed. It
         gathers both the grouped and term dimensions into single chunks, so a
-        split ``_term`` (a core dim of the scatter) is handled too.
+        split ``_term`` (a core dim of the scatter) is handled too -- a case the
+        group-dim chunking in ``_grouped_sum_on_backend`` does not exercise.
         """
         pytest.importorskip("dask")
         expr = 2 * v + 3 * v + 5  # nterm 2, so `_term` can be split
         groups = pd.Series([1] * 12 + [2] * 8, index=v.indexes["dim_2"], name="group")
 
-        chunked = LinearExpression(expr.data.chunk(chunks), expr.model)
-        grouped_chunked = chunked.groupby(groups).sum()
-        # the result stays a lazy dask graph until explicitly computed
-        assert grouped_chunked.data.vars.chunks is not None
+        grouped_chunked = expr.chunk(chunks).groupby(groups).sum()
+        # the result stays a lazy dask graph until its values are read
+        assert grouped_chunked.vars.chunks is not None
 
         grouped = expr.groupby(groups).sum()
         assert grouped_chunked.nterm == grouped.nterm
-        assert_linequal(
-            LinearExpression(grouped_chunked.data.compute(), expr.model), grouped
-        )
+        assert_linequal(grouped_chunked, grouped)
 
     def test_nan_groups_raise(self, v: Variable) -> None:
         expr = 1 * v
@@ -2059,15 +2057,15 @@ class TestGroupbySumKernel:
         grouped = (2 * x + 5).groupby(groups).sum()
         lab = x.labels.values
 
-        assert grouped.data.vars.dims == ("g", "_term")
-        assert list(grouped.data.g.values) == [0, 1]
+        assert grouped.vars.dims == ("g", "_term")
+        assert list(grouped.coords["g"].values) == [0, 1]
         assert grouped.nterm == 3  # max group size (3) * input nterm (1)
         # group 0 holds members 0, 1, 3 in order; group 1 holds member 2 then fill
         np.testing.assert_array_equal(
-            grouped.data.vars.values, [[lab[0], lab[1], lab[3]], [lab[2], -1, -1]]
+            grouped.vars.values, [[lab[0], lab[1], lab[3]], [lab[2], -1, -1]]
         )
         np.testing.assert_array_equal(
-            grouped.data.coeffs.values, [[2.0, 2.0, 2.0], [2.0, np.nan, np.nan]]
+            grouped.coeffs.values, [[2.0, 2.0, 2.0], [2.0, np.nan, np.nan]]
         )
         np.testing.assert_array_equal(grouped.const.values, [15.0, 5.0])
 
@@ -2085,10 +2083,10 @@ class TestGroupbySumKernel:
         grouped = (2 * y + 3 * y + 1).groupby(groups).sum()
         lab = y.labels.values  # (other, elem)
 
-        assert set(grouped.data.vars.dims) == {"g", "other", "_term"}
+        assert set(grouped.vars.dims) == {"g", "other", "_term"}
         # the non-grouped coord survives; the group coord holds the sorted keys
-        assert list(grouped.data.other.values) == ["a", "b"]
-        assert list(grouped.data.g.values) == [0, 1]
+        assert list(grouped.coords["other"].values) == ["a", "b"]
+        assert list(grouped.coords["g"].values) == [0, 1]
         assert grouped.nterm == 6  # max group size (3) * input nterm (2)
         # group 0 holds members 0, 1, 3 in order; group 1 holds member 2 then fill
         m0 = [0, 1, 3]
@@ -2097,15 +2095,15 @@ class TestGroupbySumKernel:
             [[lab[o, 2], -1, -1] * 2 for o in (0, 1)],
         ]
         np.testing.assert_array_equal(
-            grouped.data.vars.transpose("g", "other", "_term").values, exp_vars
+            grouped.vars.transpose("g", "other", "_term").values, exp_vars
         )
         term, pad = [2.0, 2, 2, 3, 3, 3], [2.0, np.nan, np.nan, 3, np.nan, np.nan]
         np.testing.assert_array_equal(
-            grouped.data.coeffs.transpose("g", "other", "_term").values,
+            grouped.coeffs.transpose("g", "other", "_term").values,
             [[term, term], [pad, pad]],
         )
         np.testing.assert_array_equal(
-            grouped.data.const.transpose("g", "other").values, [[3.0, 3], [1, 1]]
+            grouped.const.transpose("g", "other").values, [[3.0, 3], [1, 1]]
         )
 
     def test_exact_padded_layout_quadratic(self) -> None:
@@ -2122,7 +2120,7 @@ class TestGroupbySumKernel:
         grouped = (x * y).groupby(groups).sum()
         lx, ly = x.labels.values, y.labels.values
 
-        assert set(grouped.data.vars.dims) == {"g", "_factor", "_term"}
+        assert set(grouped.vars.dims) == {"g", "_factor", "_term"}
         assert grouped.nterm == 3
         # factor 0 carries x, factor 1 carries y; members 0, 1, 3 then fill
         m0 = [0, 1, 3]
@@ -2131,10 +2129,10 @@ class TestGroupbySumKernel:
             [[lx[2], -1, -1], [ly[2], -1, -1]],
         ]
         np.testing.assert_array_equal(
-            grouped.data.vars.transpose("g", "_factor", "_term").values, exp_vars
+            grouped.vars.transpose("g", "_factor", "_term").values, exp_vars
         )
         np.testing.assert_array_equal(
-            grouped.data.coeffs.transpose("g", "_term").values,
+            grouped.coeffs.transpose("g", "_term").values,
             [[1.0, 1, 1], [1, np.nan, np.nan]],
         )
 
@@ -2147,7 +2145,7 @@ class TestGroupbySumKernel:
 
         grouped = (1 * x).groupby(groups).sum()
         assert grouped.nterm == 0
-        assert dict(grouped.data.sizes) == {"g": 0, "_term": 0}
+        assert dict(grouped.sizes) == {"g": 0, "_term": 0}
 
     @pytest.mark.parametrize("backend", ["numpy", "dask"])
     @pytest.mark.parametrize("case", FALLBACK_SUM_CASES)

--- a/test/test_linear_expression.py
+++ b/test/test_linear_expression.py
@@ -7,7 +7,10 @@ Created on Wed Mar 17 17:06:36 2021.
 
 from __future__ import annotations
 
+import logging
 import warnings
+from collections.abc import Callable
+from types import SimpleNamespace
 from typing import Any
 
 import numpy as np
@@ -1908,140 +1911,188 @@ def test_linear_expression_groupby_from_variable(v: Variable) -> None:
     assert grouped.nterm == 10
 
 
-def test_linear_expression_groupby_skewed_unsorted_groups(v: Variable) -> None:
-    """
-    The scatter-based fast path must match the xarray fallback for groups that
-    are unsorted, non-contiguous and of very different sizes.
-    """
-    expr = 2 * v + 5
-    # 'b' appears 14 times, 'c' 5 times, 'a' once, scattered over the dimension
-    labels = ["b"] * 4 + ["c", "a"] + ["b"] * 5 + ["c"] * 4 + ["b"] * 5
-    groups = pd.Series(labels, index=v.indexes["dim_2"], name="letter")
-
-    grouped = expr.groupby(groups).sum()
-    fallback = expr.groupby(groups.to_xarray()).sum(use_fallback=True)
-
-    assert list(grouped.data.letter) == ["a", "b", "c"]
-    # padded to the largest group times the number of terms of the input
-    assert grouped.nterm == 14 * expr.nterm
-    assert_linequal(grouped, fallback)
-
-    # every group must carry exactly the variables of its members, the rest is fill
-    for letter in ["a", "b", "c"]:
-        members = np.where(np.array(labels) == letter)[0]
-        vars_of_group = grouped.data.vars.sel(letter=letter).values
-        assert set(vars_of_group[vars_of_group >= 0]) == set(v.labels.values[members])
-        assert (vars_of_group >= 0).sum() == len(members) * expr.nterm
-        assert grouped.const.sel(letter=letter).item() == 5 * len(members)
-
-
-def test_linear_expression_groupby_chunked(v: Variable) -> None:
-    """Chunked (dask-backed) expressions group via xarray's unstack machinery."""
-    pytest.importorskip("dask")
-    expr = 2 * v + 5
-    groups = pd.Series([1] * 12 + [2] * 8, index=v.indexes["dim_2"], name="group")
-
-    chunked = LinearExpression(expr.data.chunk({"dim_2": 5}), expr.model)
-    grouped_chunked = chunked.groupby(groups).sum()
-    grouped = expr.groupby(groups).sum()
-
-    assert grouped_chunked.nterm == grouped.nterm
-    assert_linequal(
-        LinearExpression(grouped_chunked.data.compute(), expr.model), grouped
-    )
-
-
-def test_linear_expression_groupby_with_nan_groups(v: Variable) -> None:
-    expr = 1 * v
-    groups = pd.Series([1.0, np.nan] * 10, index=v.indexes["dim_2"], name="with_nans")
-    with pytest.raises(ValueError, match="NaN"):
-        expr.groupby(groups).sum()
-
-
-def test_linear_expression_groupby_empty_groups() -> None:
-    """An empty group dimension scatters into an empty, well-formed result."""
-    m = Model()
-    idx = pd.RangeIndex(0, name="elem")
-    x = m.add_variables(coords=[idx], name="x")
-    groups = pd.Series([], index=idx, name="g", dtype=int)
-
-    grouped = (1 * x).groupby(groups).sum()
-    assert grouped.nterm == 0
-    assert dict(grouped.data.sizes) == {"g": 0, "_term": 0}
-
-
-@pytest.mark.parametrize(
-    "case",
-    [
-        "skewed_int_groups",
-        "multidim_with_const",
-        "nan_const",
-        "masked_vars",
-        "quadratic",
-        "single_group",
-        "identity_groups",
-    ],
-)
-def test_linear_expression_groupby_scatter_equals_unstack(case: str) -> None:
-    """
-    Lock the two groupby-sum kernels together.
-
-    The fast path of groupby(...).sum() scatters terms into numpy arrays
-    (_sum_by_scatter); the xarray unstack implementation (_sum_by_unstack) is
-    kept for chunked data and exotic coordinates. Both must stay
-    interchangeable — if an xarray/pandas update changes the unstack output or
-    an edge case diverges, this fails.
-    """
+@pytest.fixture
+def scatter_ctx() -> SimpleNamespace:
+    """Shared 60-element building blocks for the scatter-vs-unstack case table."""
     m = Model()
     rng = np.random.default_rng(0)
     idx = pd.RangeIndex(60, name="elem")
+    other = pd.Index(list("abc"), name="other")
+    p, q = pd.Index(list("pq"), name="p"), pd.Index([10, 20, 30], name="q")
+    a, b = pd.Index(range(12), name="a"), pd.Index(list("vwxyz"), name="b")
+
+    const = xr.DataArray(rng.normal(size=(3, 60)), coords=[other, idx])
+    y = m.add_variables(coords=[other, idx], name="y")
+    yab = m.add_variables(coords=[a, b], name="yab")
+    stacked = LinearExpression((2 * yab + 1 * yab).data.stack(elem=["a", "b"]), m)
     skewed = pd.Series(rng.choice(8, 60, p=[0.5] + [0.5 / 7] * 7), index=idx, name="g")
-    groups = skewed
 
-    if case == "skewed_int_groups":
-        x = m.add_variables(coords=[idx], name="x")
-        expr: LinearExpression | QuadraticExpression = 3 * x - 2 * x + 7
-    elif case == "multidim_with_const":
-        other = pd.Index(list("abc"), name="other")
-        y = m.add_variables(coords=[other, idx], name="y")
-        const = xr.DataArray(rng.normal(size=(3, 60)), coords=[other, idx])
-        expr = 2 * y + 1 * y + const
-    elif case == "nan_const":
-        x = m.add_variables(coords=[idx], name="x")
-        expr = 1 * x + np.where(np.arange(60) % 3, np.nan, 5.0)
-    elif case == "masked_vars":
-        mask = xr.DataArray(np.arange(60) % 4 != 0, coords=[idx])
-        x = m.add_variables(coords=[idx], name="x", mask=mask)
-        expr = 1 * x
-    elif case == "quadratic":
-        x = m.add_variables(coords=[idx], name="x")
-        expr = x * x + 2 * x
-    elif case == "single_group":
-        x = m.add_variables(coords=[idx], name="x")
-        expr = 1 * x
-        groups = pd.Series(1, index=idx, name="g")
-    else:  # identity_groups
-        x = m.add_variables(coords=[idx], name="x")
-        expr = 1 * x
-        groups = pd.Series(np.arange(60), index=idx, name="g")
+    return SimpleNamespace(
+        m=m,
+        x=m.add_variables(coords=[idx], name="x"),
+        y=y,
+        y3=m.add_variables(coords=[p, q, idx], name="y3"),
+        mx=m.add_variables(
+            coords=[idx], name="mx", mask=xr.DataArray(np.arange(60) % 4 != 0, [idx])
+        ),
+        my=m.add_variables(
+            coords=[other, idx],
+            name="my",
+            mask=xr.DataArray(rng.random((3, 60)) > 0.25, [other, idx]),
+        ),
+        const=const,
+        nan_const=const.where(rng.random((3, 60)) > 0.3),
+        nan_vec=np.where(np.arange(60) % 3, np.nan, 5.0),
+        y_aux=(2 * y + 1 * y).assign_coords(
+            carrier=("elem", rng.choice(list("PQ"), 60)),
+            tag=(("other", "elem"), rng.integers(0, 9, (3, 60))),
+        ),
+        stacked=stacked,
+        skewed=skewed,
+        one_group=pd.Series(1, index=idx, name="g"),
+        identity=pd.Series(np.arange(60), index=idx, name="g"),
+        mi_groups=skewed.set_axis(stacked.data.indexes["elem"]),
+    )
 
-    gb = expr.groupby(groups)
-    assert gb._can_sum_by_scatter(groups)
-    scatter = LinearExpression(gb._sum_by_scatter(groups).rename(_group="g"), m)
-    unstack = LinearExpression(gb._sum_by_unstack(groups).rename(_group="g"), m)
 
-    # identical structure: dims, dim order, coordinates
-    assert scatter.data.coeffs.dims == unstack.data.coeffs.dims
-    assert scatter.data.const.dims == unstack.data.const.dims
-    assert list(scatter.data.coords) == list(unstack.data.coords)
-    for name in scatter.data.coords:
-        assert_equal(scatter.data[name], unstack.data[name])
+# Each case maps a structure to (expr, groups) from `scatter_ctx`. The skewed
+# group puts ~half the elements in group 0 and spreads 1..7 over the rest.
+SCATTER_EQUALS_UNSTACK_CASES = {
+    "skewed_int_groups": lambda c: (3 * c.x - 2 * c.x + 7, c.skewed),
+    "multidim_with_const": lambda c: (2 * c.y + 1 * c.y + c.const, c.skewed),
+    "nan_const": lambda c: (1 * c.x + c.nan_vec, c.skewed),
+    "masked_vars": lambda c: (1 * c.mx, c.skewed),
+    "quadratic": lambda c: (c.x * c.x + 2 * c.x, c.skewed),
+    "single_group": lambda c: (1 * c.x, c.one_group),
+    "identity_groups": lambda c: (1 * c.x, c.identity),
+    # combined structures exercising several features at once
+    "multidim_const_nan": lambda c: (
+        2 * c.y - 3 * c.y + 1 * c.y + c.nan_const,
+        c.skewed,
+    ),
+    "three_dims": lambda c: (4 * c.y3 + 1 * c.y3, c.skewed),
+    "quadratic_multidim_const": lambda c: (c.y * c.y + 2 * c.y + c.const, c.skewed),
+    "masked_multidim": lambda c: (5 * c.my - 2 * c.my, c.skewed),
+    # both collapse the grouped dim, dropping every coordinate tied to it
+    "aux_coords_on_group_dim": lambda c: (c.y_aux, c.skewed),
+    "multiindex_dim": lambda c: (c.stacked, c.mi_groups),
+}
 
-    # identical values: vars and coeffs bit-exact, including padding positions
-    np.testing.assert_array_equal(scatter.vars.values, unstack.vars.values)
-    np.testing.assert_array_equal(scatter.coeffs.values, unstack.coeffs.values)
-    # constants may differ by floating-point summation order
-    np.testing.assert_allclose(scatter.const.values, unstack.const.values, rtol=1e-12)
+
+class TestGroupbySumScatterKernel:
+    """
+    ``groupby(...).sum()`` takes a scatter fast path (``_sum_by_scatter``) for
+    numpy-backed expressions and falls back to the xarray unstack machinery
+    (``_sum_by_unstack``) for chunked data and exotic coordinates. These tests
+    pin the two kernels together and cover the structural edge cases.
+    """
+
+    @staticmethod
+    def _assert_kernels_identical(gb: Any, groups: pd.Series, m: Model) -> None:
+        """Force both kernels and assert they produce the same expression."""
+        scatter = LinearExpression(gb._sum_by_scatter(groups).rename(_group="g"), m)
+        unstack = LinearExpression(gb._sum_by_unstack(groups).rename(_group="g"), m)
+
+        assert scatter.data.coeffs.dims == unstack.data.coeffs.dims
+        assert scatter.data.const.dims == unstack.data.const.dims
+        assert list(scatter.data.coords) == list(unstack.data.coords)
+        for name in scatter.data.coords:
+            assert_equal(scatter.data[name], unstack.data[name])
+
+        np.testing.assert_array_equal(scatter.vars.values, unstack.vars.values)
+        np.testing.assert_array_equal(scatter.coeffs.values, unstack.coeffs.values)
+        # constants may differ only by floating-point summation order
+        np.testing.assert_allclose(
+            scatter.const.values, unstack.const.values, rtol=1e-12
+        )
+
+    def test_skewed_unsorted_groups(self, v: Variable) -> None:
+        """
+        The scatter-based fast path must match the xarray fallback for groups
+        that are unsorted, non-contiguous and of very different sizes.
+        """
+        expr = 2 * v + 5
+        # 'b' appears 14 times, 'c' 5 times, 'a' once, scattered over the dimension
+        labels = ["b"] * 4 + ["c", "a"] + ["b"] * 5 + ["c"] * 4 + ["b"] * 5
+        groups = pd.Series(labels, index=v.indexes["dim_2"], name="letter")
+
+        grouped = expr.groupby(groups).sum()
+        fallback = expr.groupby(groups.to_xarray()).sum(use_fallback=True)
+
+        assert list(grouped.data.letter) == ["a", "b", "c"]
+        # padded to the largest group times the number of terms of the input
+        assert grouped.nterm == 14 * expr.nterm
+        assert_linequal(grouped, fallback)
+
+        # every group carries exactly the variables of its members, rest is fill
+        for letter in ["a", "b", "c"]:
+            members = np.where(np.array(labels) == letter)[0]
+            vars_of_group = grouped.data.vars.sel(letter=letter).values
+            present = set(vars_of_group[vars_of_group >= 0])
+            assert present == set(v.labels.values[members])
+            assert (vars_of_group >= 0).sum() == len(members) * expr.nterm
+            assert grouped.const.sel(letter=letter).item() == 5 * len(members)
+
+    def test_chunked_uses_unstack(
+        self, v: Variable, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Chunked (dask-backed) expressions group via xarray's unstack path."""
+        pytest.importorskip("dask")
+        expr = 2 * v + 5
+        groups = pd.Series([1] * 12 + [2] * 8, index=v.indexes["dim_2"], name="group")
+
+        chunked = LinearExpression(expr.data.chunk({"dim_2": 5}), expr.model)
+        with caplog.at_level(logging.DEBUG, logger="linopy.expressions"):
+            grouped_chunked = chunked.groupby(groups).sum()
+        assert "falling back to the unstack kernel" in caplog.text
+
+        grouped = expr.groupby(groups).sum()
+        assert grouped_chunked.nterm == grouped.nterm
+        assert_linequal(
+            LinearExpression(grouped_chunked.data.compute(), expr.model), grouped
+        )
+
+    def test_nan_groups_raise(self, v: Variable) -> None:
+        expr = 1 * v
+        groups = pd.Series(
+            [1.0, np.nan] * 10, index=v.indexes["dim_2"], name="with_nans"
+        )
+        with pytest.raises(ValueError, match="NaN"):
+            expr.groupby(groups).sum()
+
+    def test_empty_groups(self) -> None:
+        """An empty group dimension scatters into an empty, well-formed result."""
+        m = Model()
+        idx = pd.RangeIndex(0, name="elem")
+        x = m.add_variables(coords=[idx], name="x")
+        groups = pd.Series([], index=idx, name="g", dtype=int)
+
+        grouped = (1 * x).groupby(groups).sum()
+        assert grouped.nterm == 0
+        assert dict(grouped.data.sizes) == {"g": 0, "_term": 0}
+
+    @pytest.mark.parametrize(
+        "build",
+        SCATTER_EQUALS_UNSTACK_CASES.values(),
+        ids=SCATTER_EQUALS_UNSTACK_CASES.keys(),
+    )
+    def test_scatter_equals_unstack(
+        self,
+        build: Callable[[SimpleNamespace], tuple[LinearExpression, pd.Series]],
+        scatter_ctx: SimpleNamespace,
+    ) -> None:
+        """
+        Lock the two groupby-sum kernels together.
+
+        The fast path scatters terms into numpy arrays (``_sum_by_scatter``);
+        the unstack implementation (``_sum_by_unstack``) is kept for chunked
+        data. Both must stay interchangeable — if an xarray/pandas update
+        changes the unstack output or an edge case diverges, this fails. See
+        ``SCATTER_EQUALS_UNSTACK_CASES`` for the structures covered.
+        """
+        expr, groups = build(scatter_ctx)
+        gb = expr.groupby(groups)
+        self._assert_kernels_identical(gb, groups, scatter_ctx.m)
 
 
 def test_linear_expression_rolling(v: Variable) -> None:


### PR DESCRIPTION
I use apply_ufunc to make this dask capable. As we dont have the reference unstack implementation anymore, i introduced quite a heavy testing part (fast though), as I find the apply_ufunc version harder to understand personally. Happy to strip it down.

> [!NOTE]
> The following content was generated by AI.

**Stacked on #793.** Until #793 merges, this PR's diff includes its commit too — review only the top commit `perf(groupby): unify scatter kernel ...`.

## What this does

#793 split groupby-sum into a numpy kernel and a dask `unstack` fallback. This
collapses them into a **single** kernel (`_grouped_sum`) wrapped in
`xarray.apply_ufunc`:

- numpy-backed data scatters terms into the padded result arrays as before;
- chunked (dask) data runs the *same* scatter lazily via `dask="parallelized"`,
  after gathering the grouped dimension into a single chunk (which unstacking
  required too).

This removes the last `pd.MultiIndex`/`unstack` usage in groupby-sum, drops the
numpy-vs-dask branch in `sum()`, and keeps peak memory at input + result on both
backends. Multi-key / DataFrame grouping and its `MultiIndex` result are
unaffected — that logic sits above the kernel (existing tests cover it).

## Tests

The kernel is verified **from first principles** — for every group and every
slice over the non-grouped dims, the result's live terms must equal the multiset
of its members' terms and the constant their NaN-skipping sum — across every
case shape on **both numpy and dask** backends. Three explicit anchors pin the
exact padded layout (member order, fill position, `(nterm, max_size)`
interleaving, and the `_factor` axis) for the linear, multidim and quadratic
cases.

<details>
<summary>Benchmark (300k elem × 8 dim × 1000 groups, numpy)</summary>

| kernel | mean time | peak memory |
| --- | --- | --- |
| `_sum_by_scatter` (#793) | 46.5 ms | 114.6 MiB |
| `_sum_by_unstack` (#793 dask path) | 49.9 ms | 254.8 MiB |
| **apply_ufunc (this PR)** | 48.3 ms | **114.6 MiB** |

The unified kernel matches the scatter kernel's memory and time; the old dask
path cost 2.2× peak.

</details>

## Notes

- Touches only `linopy/expressions.py` and the groupby kernel tests; full
  `test_linear_expression` + `test_quadratic_expression` pass (366), broader
  suite green.
- Gathering `group_dim` into one chunk is unavoidable for a scatter (a group's
  members can sit in any chunk) and is exactly what the old unstack path forced.