### PR TITLE
perf: fix v1 build-memory regressions (exact-join reindex + Variable×const routing)

### DIFF
--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -668,7 +668,12 @@ class BaseExpression(ABC):
         aligned : DataArray
             The aligned constant.
         needs_data_reindex : bool
-            Whether the expression's data needs reindexing.
+            Whether the expression's data needs reindexing. ``False`` whenever the
+            shared-dim indexes already agree — the ``override`` / ``left`` paths
+            and ``exact`` join once ``first_mismatched_dim`` confirms the match —
+            so the caller skips a full-dataset ``reindex_like`` deepcopy on the
+            hot multiply/add path. Only the label-changing joins (inner / outer /
+            right) return ``True``.
         """
         # §11: aux-coord conflict is independent of dim alignment — fires
         # on every join path. Gating it behind ``join is None`` (alongside
@@ -748,6 +753,7 @@ class BaseExpression(ABC):
             mismatch = first_mismatched_dim(self.const, other)
             if mismatch is not None:
                 raise ValueError(_shared_dim_mismatch_message(*mismatch))
+            return self.const, other, False
         self_const, aligned = xr.align(
             self.const,
             other,

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -31,7 +31,7 @@ from xarray.core.types import JoinOptions
 from xarray.core.utils import Frozen
 
 import linopy.expressions as expressions
-from linopy.alignment import broadcast_to_coords
+from linopy.alignment import as_dataarray, broadcast_to_coords
 from linopy.common import (
     LabelPositionIndex,
     LocIndexer,
@@ -64,8 +64,12 @@ from linopy.constants import (
     TERM_DIM,
 )
 from linopy.semantics import (
+    _legacy_coord_mismatch_message,
     _legacy_masked_variable_message,
+    _shared_dim_mismatch_message,
     check_user_nan,
+    enforce_aux_conflict,
+    first_mismatched_dim,
     is_v1,
     warn_legacy,
 )
@@ -334,6 +338,20 @@ class Variable:
         linopy.LinearExpression
             Linear expression with the variables and coefficients.
         """
+        # §8: check on the raw coefficient, before broadcast aligns it away.
+        if not np.isscalar(coefficient):
+            coeff_da = as_dataarray(coefficient)
+            enforce_aux_conflict([self.labels, coeff_da], stacklevel=4)
+            mismatch = first_mismatched_dim(self.labels, coeff_da)
+            if mismatch is not None:
+                if is_v1():
+                    raise ValueError(_shared_dim_mismatch_message(*mismatch))
+                warn_legacy(
+                    _legacy_coord_mismatch_message(
+                        "this operator's constant operand", *mismatch
+                    ),
+                    stacklevel=4,
+                )
         coefficient = broadcast_to_coords(coefficient, coords=self.coords, strict=False)
         # §5: user-supplied NaN in the coefficient must raise (v1) / warn
         # (legacy) — it's the multiplicative analogue of ``x + nan_data``
@@ -446,14 +464,7 @@ class Variable:
         try:
             if isinstance(other, Variable | ScalarVariable):
                 return self.to_linexpr() * other
-            # Scalars can take the fast path; for arrays / expressions go
-            # through the LinearExpression operator so semantics-aware
-            # alignment and NaN checks apply.
-            if np.isscalar(other):
-                if isinstance(other, float) and np.isnan(other):
-                    return self.to_linexpr() * other
-                return self.to_linexpr(other)
-            return self.to_linexpr() * other
+            return self.to_linexpr(other)
         except TypeError:
             return NotImplemented
 


### PR DESCRIPTION
<!-- Replace this line with your own intent. -->

> [!NOTE]
> AI-assisted (Claude Code): investigation, fixes, and this description; reviewed by me.

**Stacked on #717** (base `feat/arithmetic-convention`). Fixes the v1 build-memory regressions the semantics work introduced — including the ones **CodSpeed flags on #717** (`kvl_cycles`, `sparse_network`, `masked`, `sos`, `knapsack`).

## Two fixes
1. **Skip the no-op exact-join reindex** (`_align_constant`, v1). A plain `coeffs*expr` resolved `join="exact"` and reindexed the whole dataset (a full deepcopy) even though the factor was already broadcast to the expression's coords. Return `needs_data_reindex=False` when `first_mismatched_dim` confirms the exact match. → v1/master **1.31× → 1.01×**.
2. **Fold `Variable × constant` into one construction step** (both modes). `1a3f2be` rerouted `Variable.__mul__(DataArray)` through `to_linexpr() * other`, which materialises a unit `1*var` expression and *then* multiplies it — doubling peak on multiply-heavy builds in **both** semantics. Moved §5/§8/§11 into `to_linexpr(other)` so the one-step path is semantics-correct without the intermediate. → clears the CodSpeed regressions.

## Result — peak vs merge-base master `1dbde37`
**legacy/master 1.00× · v1/master 1.00×** — every build spec at parity in both modes. Full suite **7629 passed**; §5/§8/§11 alignment tests green under both semantics.

<details><summary>method</summary>

Attributed with pytest-benchmem (`--benchmark-memory-profile` + memray); the both-mode regression was `git bisect`-ed to `1a3f2be`; the master baseline was validated against CodSpeed #717's BASE numbers.
</details>
