### PR TITLE
perf: drop explicit zeros from the constraint matrix (#814)

### DIFF
--- a/linopy/matrices.py
+++ b/linopy/matrices.py
@@ -22,10 +22,20 @@ if TYPE_CHECKING:
 
 
 def _stack(csrs: list) -> scipy.sparse.csr_array | None:
-    """Vertically stack CSR blocks, or None when there are none."""
+    """
+    Vertically stack CSR blocks, or None when there are none.
+
+    Explicit zeros are dropped: expressions that broadcast against a dense
+    coordinate store one coefficient per pair, most of them zero, and a zero
+    coefficient never changes a constraint. Keeping them only inflates the
+    stored nnz handed to the solvers/writers (e.g. ``highspy.addRows`` scales
+    with stored nnz), so we prune them once, centrally, for every backend.
+    """
     if not csrs:
         return None
-    return cast(scipy.sparse.csr_array, scipy.sparse.vstack(csrs, format="csr"))
+    stacked = cast(scipy.sparse.csr_array, scipy.sparse.vstack(csrs, format="csr"))
+    stacked.eliminate_zeros()
+    return stacked
 
 
 def _concat(arrays: list, dtype: type | None = None) -> ndarray:

--- a/test/test_matrices.py
+++ b/test/test_matrices.py
@@ -68,6 +68,27 @@ def test_matrices_duplicated_variables() -> None:
     assert np.isin(np.unique(np.array(A)), [0.0, 2.0]).all()
 
 
+def test_matrices_drops_explicit_zeros() -> None:
+    # https://github.com/PyPSA/linopy/issues/814
+    # Expressions that broadcast against a dense coordinate store one coefficient
+    # per pair, most of them structurally zero. Those must not reach A, whose
+    # stored nnz drives the direct-solver handoff (e.g. highspy.addRows).
+    m = Model()
+
+    x = m.add_variables(coords=[range(4)], name="x")
+    coeff = xr.DataArray(
+        np.eye(4), dims=["j", "i"], coords={"j": range(4), "i": range(4)}
+    )
+    m.add_constraints((coeff * x.rename(dim_0="i")).sum("i") <= 1, name="c")
+
+    A = m.matrices.A
+    assert A is not None
+    # 4 structural nonzeros on the diagonal; the 12 broadcast zeros are dropped.
+    assert A.nnz == 4
+    assert not (A.data == 0).any()
+    assert np.array_equal(A.todense(), np.eye(4))
+
+
 def test_matrices_float_c() -> None:
     # https://github.com/PyPSA/linopy/issues/200
     m = Model()


### PR DESCRIPTION
This opportunity was discovered while exploring the regression introduced by highspy==1.15
Depeneding on the model, this is quite a impressive improvement. But id only merge it after someone tested it with real world models and maybe also hardened tests with other solvers.

Closes #814.

> [!NOTE]
> The following was generated by AI.

## What & why

Expressions that broadcast against a dense coordinate (e.g. a `bus × line`
incidence block) store one coefficient per coordinate pair, most of them
structurally zero. Those explicit zeros were carried into `model.matrices.A`
and handed to every solver. `highspy.Highs.addRows` — and the other direct
backends' matrix loaders — scale with *stored* nnz, so the handoff spent most
of its work describing zeros (`sparse_network(250)`: 1.5M stored entries for
18k structural nonzeros, 98.8% zeros).

## Change

Prune explicit zeros once, centrally, in `matrices._stack` via
`eliminate_zeros()`. This covers both `A` and `indicator_A`, so **all**
consumers benefit — HiGHS, gurobi, xpress, copt, mosek and the LP/MPS
writers — not just HiGHS. A zero coefficient never changes a constraint, so
the result is mathematically identical; row count (and thus `clabels`
alignment) is preserved, and the `dual`/`sol` paths recompute independently of
`A`.

Chose the central `matrices` layer over the per-backend `_build_solver_model`
patch from the issue precisely so every backend and writer shares the win.

## Tests

- New `test_matrices_drops_explicit_zeros` asserts a dense-broadcast constraint
  yields only structural nonzeros (stored-vs-structural nnz regression).
- Existing `test_matrices.py` and `test_solvers.py` pass unchanged.

<details>
<summary>Expected addRows speedup (from #813 standalone repro)</summary>

| highspy | explicit zeros (1.5M nnz) | eliminate_zeros (18k nnz) | speedup |
| ------- | ------------------------- | ------------------------- | ------- |
| 1.13.1  | ~13 ms | ~1.6 ms | ~8× |
| 1.15.0  | ~51 ms | ~1.7 ms | ~30× |

Side effect: makes linopy insensitive to the #813 highspy `addRows` regression.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)