### PR TITLE
fix: GLPK objective parsing

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -29,6 +29,7 @@ Upcoming Version
 
 **Bug fixes**
 
+* Fix GLPK objective parsing. (https://github.com/PyPSA/linopy/pull/818)
 * LP file export now honors bounds tightened below ``[0, 1]`` on a binary variable via the ``.lower``/``.upper`` setters after creation (e.g. ``upper = 0``). Previously such bounds were written only by ``io_api="direct"`` and dropped by ``io_api="lp"``. (https://github.com/PyPSA/linopy/issues/776)
 * Freezing an empty constraint group (e.g. an empty ``isel`` slice) no longer raises ``ValueError: cannot reshape array of size 0``. ``Model(freeze_constraints=True)`` and ``Constraint.freeze()`` now round-trip zero-row constraints losslessly.
 * ``Variable.where`` no longer raises ``ValueError: exact match required for all data variable names`` once a solution is attached (after ``Model.solve``) or the variable is fixed. The fill value now covers auxiliary data variables (``solution``, stashed bounds) instead of only ``labels``/``lower``/``upper``.

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -1374,16 +1374,16 @@ class GLPK(Solver[None]):
         options for the given solver
     """
 
-    _OBJECTIVE_TOKEN: ClassVar[re.Pattern[str]] = re.compile(
-        r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?"
-    )
-
     display_name: ClassVar[str] = "GLPK"
     features: ClassVar[frozenset[SolverFeature]] = frozenset(
         {
             SolverFeature.INTEGER_VARIABLES,
             SolverFeature.READ_MODEL_FROM_FILE,
         }
+    )
+
+    _OBJECTIVE_TOKEN: ClassVar[re.Pattern[str]] = re.compile(
+        r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?"
     )
 
     @classmethod

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -1472,7 +1472,13 @@ class GLPK(Solver[None]):
         info_io = io.StringIO("".join(read_until_break(f))[:-2])
         info = pd.read_csv(info_io, sep=":", index_col=0, header=None)[1]
         condition = info.Status.lower().strip()
-        objective = float(re.sub(r"[^0-9\.\+\-e]+", "", info.Objective))
+        match = re.search(
+            r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?",
+            info.Objective,
+        )
+        if match is None:
+            raise ValueError(f"Could not parse objective value: {info.Objective!r}")
+        objective = float(match.group(0))
 
         termination_condition = CONDITION_MAP.get(condition, condition)
         status = Status.from_termination_condition(termination_condition)

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -1367,10 +1367,23 @@ class CBC(Solver[None]):
 class GLPK(Solver[None]):
     """
     Solver subclass for the GLPK solver.
+
+    Attributes
+    ----------
+    **solver_options
+        options for the given solver
     """
 
     _OBJECTIVE_TOKEN: ClassVar[re.Pattern[str]] = re.compile(
         r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?"
+    )
+
+    display_name: ClassVar[str] = "GLPK"
+    features: ClassVar[frozenset[SolverFeature]] = frozenset(
+        {
+            SolverFeature.INTEGER_VARIABLES,
+            SolverFeature.READ_MODEL_FROM_FILE,
+        }
     )
 
     @classmethod
@@ -1388,20 +1401,6 @@ class GLPK(Solver[None]):
         if match is None:
             raise ValueError(f"Could not parse objective value: {text!r}")
         return float(match.group(0))
-
-    Attributes
-    ----------
-    **solver_options
-        options for the given solver
-    """
-
-    display_name: ClassVar[str] = "GLPK"
-    features: ClassVar[frozenset[SolverFeature]] = frozenset(
-        {
-            SolverFeature.INTEGER_VARIABLES,
-            SolverFeature.READ_MODEL_FROM_FILE,
-        }
-    )
 
     @classmethod
     @functools.cache

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -1367,6 +1367,27 @@ class CBC(Solver[None]):
 class GLPK(Solver[None]):
     """
     Solver subclass for the GLPK solver.
+    """
+
+    _OBJECTIVE_TOKEN: ClassVar[re.Pattern[str]] = re.compile(
+        r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?"
+    )
+
+    @classmethod
+    def _parse_objective(cls, text: str) -> float:
+        """
+        Extract the objective value from a GLPK ``Objective:`` line.
+
+        GLPK reports the objective as ``<name> = <value> (MINimum)``. Anchoring
+        on the ``=`` drops the objective name before matching the first
+        float/scientific-notation token, so surrounding text can no longer
+        corrupt the parsed value.
+        """
+        _, _, tail = text.rpartition("=")
+        match = cls._OBJECTIVE_TOKEN.search(tail)
+        if match is None:
+            raise ValueError(f"Could not parse objective value: {text!r}")
+        return float(match.group(0))
 
     Attributes
     ----------
@@ -1472,13 +1493,7 @@ class GLPK(Solver[None]):
         info_io = io.StringIO("".join(read_until_break(f))[:-2])
         info = pd.read_csv(info_io, sep=":", index_col=0, header=None)[1]
         condition = info.Status.lower().strip()
-        match = re.search(
-            r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?",
-            info.Objective,
-        )
-        if match is None:
-            raise ValueError(f"Could not parse objective value: {info.Objective!r}")
-        objective = float(match.group(0))
+        objective = self._parse_objective(info.Objective)
 
         termination_condition = CONDITION_MAP.get(condition, condition)
         status = Status.from_termination_condition(termination_condition)

--- a/test/test_solvers.py
+++ b/test/test_solvers.py
@@ -570,7 +570,6 @@ class TestAssignResultWiring:
         assert m.solver is None
 
 
-
 @pytest.mark.parametrize(
     "objective_text, expected",
     [

--- a/test/test_solvers.py
+++ b/test/test_solvers.py
@@ -570,6 +570,42 @@ class TestAssignResultWiring:
         assert m.solver is None
 
 
+
+@pytest.mark.parametrize(
+    "objective_text, expected",
+    [
+        (" obj = 1234.56 (MINimum)", 1234.56),
+        (" obj = 0 (MINimum)", 0.0),
+        (" obj = -3.5 (MAXimum)", -3.5),
+        (" obj = +42 (MINimum)", 42.0),
+        (" obj = .5 (MINimum)", 0.5),
+        (" obj = 1.5e+06 (MAXimum)", 1.5e6),
+        (" obj = -2E-3 (MINimum)", -2e-3),
+        (" net_present_value = 1234.5 (MINimum)", 1234.5),
+        (" obj1 = 1234.56 (MINimum)", 1234.56),
+        (" c2e = -7.5e2 (MAXimum)", -750.0),
+        ("  3.5 (MINimum)", 3.5),
+        ("  -1.5e3 (MAXimum)", -1500.0),
+        ("  0 (MINimum)", 0.0),
+    ],
+)
+def test_parse_glpk_objective(objective_text: str, expected: float) -> None:
+    assert solvers.GLPK._parse_objective(objective_text) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    "objective_text",
+    [
+        " obj = (MINimum)",
+        " unbounded",
+        "",
+    ],
+)
+def test_parse_glpk_objective_no_value_raises(objective_text: str) -> None:
+    with pytest.raises(ValueError, match="Could not parse objective value"):
+        solvers.GLPK._parse_objective(objective_text)
+
+
 mosek_installed = pytest.importorskip("mosek", reason="Mosek is not installed")
 
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

While working at https://github.com/open-energy-transition/solver-benchmark/pull/490 I noticed an issue in GLPK result parsing: linopy currently removes all characters except those in scientific notation and `e` characters are preserved in the surrounding text, raising a ValueError. In this PR the first valid floating-point/scientific-notation token  using a regular expression is extracted and the error is now raised if no objective value can be parsed.

## Motivation

While benchmarking GLPK through Linopy, we encountered parsing failures caused by objective strings containing additional text. This change makes the parser robust to such cases while preserving the existing behavior for valid objective values.

## Checklist

- [ ] AI-generated content is marked (see [`AGENTS.md`](../blob/master/AGENTS.md)).
- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [ ] I consent to the release of this PR's code under the MIT license.
