### PR TITLE
fix: widen Variable.sum dim parameter type to DimsLike

### DIFF
--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -1122,7 +1122,7 @@ class Variable:
         check_has_nulls_polars(df, name=f"{self.type} {self.name}")
         return df
 
-    def sum(self, dim: str | None = None, **kwargs: Any) -> LinearExpression:
+    def sum(self, dim: DimsLike | None = None, **kwargs: Any) -> LinearExpression:
         """
         Sum the variables over all or a subset of dimensions.
 


### PR DESCRIPTION
The `dim` argument in `Variable.sum` has a too strict type declaration. It also accepts `Iterable[Hashable]` because it passes the `dim` argument to `BaseExpression.sum`. I adapted the type of `Variable.sum` to fix this imprecision.

## Changes proposed in this Pull Request

- fix: change `Variable.sum` method parameter type to `DimsLike`

## Checklist

- [x] AI-generated content is marked (see [`AGENTS.md`](../blob/master/AGENTS.md)).
- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
