### PR TITLE
docs: list SCIP in supported solvers (README, index)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Fri    0          4
 * [Cbc](https://projects.coin-or.org/Cbc)
 * [GLPK](https://www.gnu.org/software/glpk/)
 * [HiGHS](https://highs.dev/)
+* [SCIP](https://www.scipopt.org/)
 * [Gurobi](https://www.gurobi.com/)
 * [Xpress](https://www.fico.com/en/products/fico-xpress-solver)
 * [Cplex](https://www.ibm.com/de-de/analytics/cplex-optimizer)

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -43,6 +43,7 @@ flexible data-handling features:
    - `Cbc <https://projects.coin-or.org/Cbc>`__
    - `GLPK <https://www.gnu.org/software/glpk/>`__
    - `HiGHS <https://highs.dev/>`__
+   - `SCIP <https://www.scipopt.org/>`__
    - `MindOpt <https://solver.damo.alibaba.com/doc/en/html/index.html>`__
    - `Gurobi <https://www.gurobi.com/>`__
    - `Xpress <https://www.fico.com/en/fico-xpress-trial-and-licensing-options>`__


### PR DESCRIPTION
> [!NOTE]
> The following content was generated by AI (Claude Code).

Documentation-only fix for #416. SCIP is a fully supported solver
(`SolverName.SCIP`, `class SCIP(Solver)` in `linopy/solvers.py`) and is
already listed in `doc/prerequisites.rst`, but was missing from the two
public-facing "supported solvers" lists:

- `README.md`
- `doc/index.rst`

This adds SCIP to both, placed after HiGHS to match the ordering already
used in `prerequisites.rst`.

Closes #416.
