### PR TITLE
fix(gurobi): dispose the solver model before the env on close

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -522,6 +522,7 @@ Solvers
    :toctree: generated/
 
    solvers.available_solvers
+   solvers.Solver
    solvers.CBC
    solvers.COPT
    solvers.Cplex

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -522,7 +522,6 @@ Solvers
    :toctree: generated/
 
    solvers.available_solvers
-   solvers.Solver
    solvers.CBC
    solvers.COPT
    solvers.Cplex

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -39,6 +39,7 @@ Upcoming Version
 * Freezing an empty constraint group (e.g. an empty ``isel`` slice) no longer raises ``ValueError: cannot reshape array of size 0``. ``Model(freeze_constraints=True)`` and ``Constraint.freeze()`` now round-trip zero-row constraints losslessly.
 * ``Variable.where`` no longer raises ``ValueError: exact match required for all data variable names`` once a solution is attached (after ``Model.solve``) or the variable is fixed. The fill value now covers auxiliary data variables (``solution``, stashed bounds) instead of only ``labels``/``lower``/``upper``.
 * ``linopy.testing.assert_linequal`` now aligns dimension order before comparing, so mathematically identical expressions built in different orders (e.g. ``x + y`` versus ``y + x``, which inherit different dimension orders from xarray broadcasting) are correctly treated as equal. Genuinely different expressions still fail.
+* ``Solver.close()`` (also triggered by ``model.solver = None`` and the next ``solve()`` call) now explicitly disposes the ``gurobipy`` model before the environment. Previously the model was only dereferenced, so a user-held ``model.solver_model`` reference silently kept the Gurobi license acquired after ``close()``. (https://github.com/PyPSA/linopy/issues/459)
 
 Version 0.8.0
 -------------

--- a/linopy/io.py
+++ b/linopy/io.py
@@ -757,7 +757,14 @@ def to_gurobipy(
         set_names=set_names,
         env=env,
     )
-    return solver.solver_model
+    gm = solver.solver_model
+    # the caller owns the returned model: detach it (and its env) from the
+    # solver so teardown does not dispose it; gurobipy frees the underlying
+    # env once the caller drops the model
+    if solver._env_stack is not None:
+        solver._env_stack.pop_all()
+    solver.close()
+    return gm
 
 
 def to_highspy(

--- a/linopy/io.py
+++ b/linopy/io.py
@@ -757,14 +757,7 @@ def to_gurobipy(
         set_names=set_names,
         env=env,
     )
-    gm = solver.solver_model
-    # the caller owns the returned model: detach it (and its env) from the
-    # solver so teardown does not dispose it; gurobipy frees the underlying
-    # env once the caller drops the model
-    if solver._env_stack is not None:
-        solver._env_stack.pop_all()
-    solver.close()
-    return gm
+    return solver._detach_solver_model()
 
 
 def to_highspy(

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -1819,6 +1819,16 @@ class Model:
         status : tuple
             Tuple containing the status and termination condition of the
             optimization process.
+
+        Notes
+        -----
+        After solving, the solver stays attached as ``model.solver`` for
+        post-solve introspection (``model.solver_model``,
+        ``compute_infeasibilities()``). For solvers with limited licenses
+        (e.g. Gurobi) this means the license remains acquired until the
+        solver is released: call ``model.solver.close()`` (or assign
+        ``model.solver = None``) to free it explicitly. It is also released
+        on the next ``solve()`` call and when the model is garbage-collected.
         """
         if mock_solve:
             return self._mock_solve(

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -1824,11 +1824,12 @@ class Model:
         -----
         After solving, the solver stays attached as ``model.solver`` for
         post-solve introspection (``model.solver_model``,
-        ``compute_infeasibilities()``). For solvers with limited licenses
-        (e.g. Gurobi) this means the license remains acquired until the
-        solver is released: call ``model.solver.close()`` (or assign
-        ``model.solver = None``) to free it explicitly. It is also released
-        on the next ``solve()`` call and when the model is garbage-collected.
+        ``compute_infeasibilities()``) and reuse, e.g. persistent in-place
+        re-solves. For solvers with limited licenses (e.g. Gurobi) this
+        means the license remains acquired until the solver is released:
+        call ``model.solver.close()`` (or assign ``model.solver = None``)
+        to free it explicitly. It is also released on the next ``solve()``
+        call and when the model is garbage-collected.
         """
         if mock_solve:
             return self._mock_solve(

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -25,7 +25,7 @@ from enum import Enum, auto
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as package_version
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar, Generic, NamedTuple, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, NamedTuple, Self, TypeVar
 
 import numpy as np
 import pandas as pd
@@ -683,7 +683,7 @@ class Solver(ABC, Generic[EnvType]):
         options: dict[str, Any] | None = None,
         track_updates: bool = False,
         **build_kwargs: Any,
-    ) -> Solver:
+    ) -> Self:
         """Instantiate and build the solver against ``model``."""
         instance = cls(
             model=model,

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -1957,6 +1957,18 @@ class Gurobi(Solver["gurobipy.Env | dict[str, Any] | None"]):
         assert self._env_stack is not None
         return self._env_stack.enter_context(m)
 
+    def _detach_solver_model(self) -> gurobipy.Model:
+        """
+        Hand ownership of the gurobipy model to the caller: unregister it from
+        the solver's teardown so ``close()`` does not dispose it. gurobipy
+        frees the underlying env once the caller drops the model.
+        """
+        m = self.solver_model
+        if self._env_stack is not None:
+            self._env_stack.pop_all()
+        self.close()
+        return m
+
     def _build_direct(
         self,
         explicit_coordinate_names: bool = False,

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -1948,6 +1948,15 @@ class Gurobi(Solver["gurobipy.Env | dict[str, Any] | None"]):
         self.env = resolved
         return resolved
 
+    def _register_solver_model(self, m: gurobipy.Model) -> gurobipy.Model:
+        """
+        Register the gurobipy model on the env stack so ``close()`` disposes
+        it before the env — required for the license to be released even while
+        user code still holds a ``solver_model`` reference.
+        """
+        assert self._env_stack is not None
+        return self._env_stack.enter_context(m)
+
     def _build_direct(
         self,
         explicit_coordinate_names: bool = False,
@@ -1964,7 +1973,7 @@ class Gurobi(Solver["gurobipy.Env | dict[str, Any] | None"]):
             explicit_coordinate_names=explicit_coordinate_names,
             set_names=set_names,
         )
-        self.solver_model = m
+        self.solver_model = self._register_solver_model(m)
         self.io_api = "direct"
         self.sense = model.sense
         self._cache_model_labels(model)
@@ -2159,7 +2168,7 @@ class Gurobi(Solver["gurobipy.Env | dict[str, Any] | None"]):
 
         env_ = self._resolve_env(env)
         m = gurobipy.read(problem_fn_, env=env_)
-        self.solver_model = m
+        self.solver_model = self._register_solver_model(m)
         self.io_api = io_api
 
         return self._solve(

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -1113,12 +1113,10 @@ class Solver(ABC, Generic[EnvType]):
 
     def close(self) -> None:
         """
-        Release the native solver state.
+        Dispose the native solver model and env, releasing any held license.
 
-        Disposes the native solver model and any solver environment created
-        by this instance, releasing the resources tied to them — including
-        the solver license, where the solver holds one. A user-supplied
-        environment is left untouched.
+        Only resources created by this instance are disposed; a
+        user-supplied environment is left untouched.
 
         Idempotent, and called automatically when a new ``solve()`` replaces
         this solver, when ``model.solver`` is reassigned (e.g. to ``None``),

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -1112,6 +1112,20 @@ class Solver(ABC, Generic[EnvType]):
         raise NotImplementedError
 
     def close(self) -> None:
+        """
+        Release the native solver state.
+
+        Disposes the native solver model and any solver environment created
+        by this instance, releasing the resources tied to them — including
+        the solver license, where the solver holds one. A user-supplied
+        environment is left untouched.
+
+        Idempotent, and called automatically when a new ``solve()`` replaces
+        this solver, when ``model.solver`` is reassigned (e.g. to ``None``),
+        and on garbage collection. After closing, post-solve introspection
+        (``solver_model``, ``compute_infeasibilities()``) and persistent
+        re-solves are no longer available.
+        """
         if self._env_stack is not None:
             self._env_stack.close()
         self.env = None

--- a/test/test_solvers.py
+++ b/test/test_solvers.py
@@ -221,6 +221,11 @@ def test_solver_close_releases_state(simple_model: Model, solver: str) -> None:
 def test_gurobi_close_disposes_held_solver_model(
     simple_model: Model, io_api: str
 ) -> None:
+    """
+    close() must dispose the gurobipy model even while a reference to it is
+    held: a merely dereferenced model keeps the underlying env — and with it
+    the license — acquired until garbage collection.
+    """
     import gurobipy
 
     simple_model.solve("gurobi", io_api=io_api)
@@ -229,9 +234,6 @@ def test_gurobi_close_disposes_held_solver_model(
 
     simple_model.solver = None
 
-    # the gurobipy model must be disposed even while `held` keeps it alive:
-    # a merely dereferenced model keeps the underlying env — and with it the
-    # license — acquired until garbage collection
     with pytest.raises(gurobipy.GurobiError, match="freed"):
         _ = held.NumVars
 

--- a/test/test_solvers.py
+++ b/test/test_solvers.py
@@ -214,6 +214,28 @@ def test_solver_close_releases_state(simple_model: Model, solver: str) -> None:
     assert solver_instance.env is None
 
 
+@pytest.mark.skipif(
+    "gurobi" not in set(solvers.licensed_solvers), reason="Gurobi is not installed"
+)
+@pytest.mark.parametrize("io_api", ["direct", "lp"])
+def test_gurobi_close_disposes_held_solver_model(
+    simple_model: Model, io_api: str
+) -> None:
+    import gurobipy
+
+    simple_model.solve("gurobi", io_api=io_api)
+    held = simple_model.solver_model
+    assert isinstance(held.NumVars, int)
+
+    simple_model.solver = None
+
+    # the gurobipy model must be disposed even while `held` keeps it alive:
+    # a merely dereferenced model keeps the underlying env — and with it the
+    # license — acquired until garbage collection
+    with pytest.raises(gurobipy.GurobiError, match="freed"):
+        _ = held.NumVars
+
+
 free_mps_problem = """NAME               sample_mip
 ROWS
  N  obj


### PR DESCRIPTION
I treid to verify that the gurobi license issue #459 is fully solved. As far as i can see its not perfect yet. I also took the opportunity to make the .close() more discoverable!

> [!NOTE]
> The following content was generated by AI (Claude Code).

Follow-up to #459. The env has been context-managed since the license-leak audit, but `Solver.close()` only *dereferenced* the `gurobipy.Model` — it disposed the env first and relied on refcount GC to free the model. Since Gurobi keeps the underlying environment (and with it the license) alive until every model created from it is freed, any user-held `model.solver_model` reference silently kept the license acquired after `close()` / `model.solver = None`.

**What changed**

- `Gurobi` now registers the `gurobipy.Model` on the env `ExitStack` (as Xpress and Mosek already do). `close()` unwinds LIFO, disposing the model before the env — the ordering the Gurobi docs require — and explicit `dispose()` releases the license even while user code still holds a reference.
- `to_gurobipy()` detaches the built model from its throwaway solver so the caller keeps ownership (its teardown would otherwise now dispose the returned model).
- `Model.solve()` docstring documents when the license is released: `model.solver.close()`, `model.solver = None`, the next `solve()` call, or model GC.

**Compatibility with older gurobipy**

The fix relies on `gurobipy.Model` supporting the context-manager protocol. Env and Model have been context managers since Gurobi 9.0, and the oldest gurobipy with wheels for Python 3.11 (linopy's floor) is 10.0 — so every installable combination is covered. Verified identical behavior (context protocol + `Model has already been freed` on disposed access) on gurobipy 12.0.1 and 13.0.2.

**Proof it was a footgun**

The new test `test_gurobi_close_disposes_held_solver_model` holds a `solver_model` reference across `close()` and asserts the model is disposed. On `master` it fails — the held model is still fully queryable, i.e. the license is still acquired.

<details>
<summary>Empirical demonstration (gurobipy 13.0.2)</summary>

```python
import contextlib
import gurobipy as gp

stack = contextlib.ExitStack()
env = stack.enter_context(gp.Env())
m = gp.Model(env=env)
m.addVar(); m.update()

held = m          # user-held reference, e.g. model.solver_model
stack.close()     # disposes the env — what Solver.close() did on master

print(held.NumVars)   # -> 1: model (and license) still alive
held.dispose()        # only now is everything released
```

New test against `master` (pre-fix):

```
FAILED test/test_solvers.py::test_gurobi_close_disposes_held_solver_model[direct]
1 failed, 5 passed, 100 deselected in 1.31s
```

With the fix: `19 passed` (`-k "close or gurobi"`), and the full gurobi/persistent sweep passes (`523 passed, 11 skipped`).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
