### PR TITLE
feat(v1): tighten §8 alignment to full join="exact"

### DIFF
--- a/arithmetics-design/convention.md
+++ b/arithmetics-design/convention.md
@@ -127,25 +127,22 @@ array is treated as a scalar; a Python `list` is read as a numpy array
 (it carries values, not labels). Implemented in `linopy.alignment`
 ([#736]).
 
-### §8. Shared dimensions must carry the same labels
+### §8. Shared dimensions must carry identical labels
 
-If two operands share a dimension, their coordinate labels must be the same
-*set*, or the operator raises `ValueError`. Order is immaterial: the same
-labels in a different order are the same coordinate and align by label (a
-reindex), following "by label, never by position" above — only a difference in
-the label set raises.
+If two operands share a dimension, their coordinate labels must be *identical* —
+the same labels in the same order — or the operator raises `ValueError`. This is
+xarray's `arithmetic_join="exact"`. Both a difference in the label *set* and a
+pure *reorder* (the same labels in a different order) raise; linopy never
+silently reindexes one operand to the other. Either is resolved explicitly (§10).
 
-This is close to xarray's `arithmetic_join="exact"` — deliberately stricter
-than xarray's own default (`inner`) — but order-independent, where xarray's
-`exact` would reject a pure reorder. An inner join silently drops the
-non-overlapping labels, and in an optimization model a dropped coordinate is a
-dropped term or constraint: a silent wrong answer. Matching on the label set
-surfaces a real mismatch where it happens. (The [pyoframe] library uses the
-same model.)
-
-Because the rule is identical for every operator, the operator-alignment split
+The rule is identical for every operator, so the operator-alignment split
 ([#708]) — `*` aligning by label while `+`, `-`, `/` go by position —
 disappears.
+
+§8 governs *arithmetic between operands*. Conforming a single input to a target
+the caller has already fixed — a variable's bounds or `mask=` against its
+declared `coords`, `.reindex()` against an index — is not an operator and still
+reindexes a reordered-but-matching input by label.
 
 ### §9. Non-shared dimensions broadcast freely
 
@@ -174,6 +171,11 @@ resolve it. Several primitives bring operands into agreement:
   it renames positions whether or not they correspond, so the "made explicit"
   here is the caller's responsibility, not a safety check.
 - `linopy.align()` pre-aligns several operands at once.
+
+A pure reorder (§8) is resolved the same way: a reindexing join
+(`.add(other, join="outer")` / `inner` / `left` / `right`) realigns both sides by
+label, or bring one side into the other's order first — `other.sel(dim=…)`,
+`other.reindex_like(self)`, or `other.sortby(dim)` on a plain-array operand.
 
 Because no operator silently drops coordinates, the associativity break
 ([#711]) cannot occur: the operation that used to drop coordinates now raises.
@@ -212,9 +214,8 @@ values:
 
 An input that reconstructs the *entire* MultiIndex (all levels, every
 combination) is not a conflict — it is the same coordinate spelled
-differently, and aligns by tuple under §8, in any order. Order is
-immaterial here exactly as for a plain dimension: the same tuples in a
-different order are reordered to match, not rejected.
+differently, and aligns by tuple under §8: the tuples must match in the same
+order, a reorder raises (§10).
 
 (Legacy projects implicitly and warns — scenario B of the [#732]/[#737]
 discussion; the implicit projection is removed at 1.0.)
@@ -249,7 +250,6 @@ are added under v1 only ([#703]) — as new operations with no legacy behaviour 
 and follow this same skip-absent rule.
 
 <!-- references -->
-[pyoframe]: https://github.com/Bravos-Power/pyoframe
 [#732]: https://github.com/PyPSA/linopy/pull/732
 [#737]: https://github.com/PyPSA/linopy/pull/737
 [#736]: https://github.com/PyPSA/linopy/issues/736

--- a/linopy/alignment.py
+++ b/linopy/alignment.py
@@ -811,6 +811,8 @@ def _broadcast_to_coords(
     arr: Any,
     coords: CoordsLike | None = None,
     dims: DimsLike | None = None,
+    *,
+    reindex_reordered: bool = True,
     **kwargs: Any,
 ) -> tuple[DataArray, list[_LevelProjection]]:
     """
@@ -838,7 +840,8 @@ def _broadcast_to_coords(
         arr = _label_input(arr, expected, dims, **kwargs)
 
     arr, projections = _project_onto_multiindex_levels(arr, expected)
-    arr = _reindex_reordered_dims(arr, expected)
+    if reindex_reordered:  # False on the v1 arithmetic path, so a reorder hits §8 exact
+        arr = _reindex_reordered_dims(arr, expected)
     arr = _expand_missing_dims(arr, expected)
     arr = _order_like_coords(arr, expected)
     return arr, projections
@@ -930,8 +933,12 @@ def broadcast_to_coords(
     DataArray
         Broadcast against ``coords``.
     """
-    if not strict:
-        da, projections = _broadcast_to_coords(arr, coords, dims, **kwargs)
+    if not strict:  # arithmetic operands
+        from linopy.semantics import is_v1
+
+        da, projections = _broadcast_to_coords(
+            arr, coords, dims, reindex_reordered=not is_v1(), **kwargs
+        )
         _enforce_implicit_projections(projections)
         return da
 

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -2870,14 +2870,15 @@ def merge(
     data = [e.data if isinstance(e, linopy_types) else e for e in exprs]
     data = [fill_missing_coords(ds, fill_helper_dims=True) for ds in data]
 
-    # §8: v1 aligns a reorder by label and raises a dim mismatch (before the
-    # §11 aux check, else a MultiIndex mismatch reads as a level-coord
-    # conflict). Legacy keeps positional alignment and only warns.
+    # §8: v1 raises on a set-mismatch or reorder, legacy warns. Runs before the
+    # §11 aux check so a MultiIndex mismatch isn't read as a coord conflict.
     if join is None:
         data, mismatch, reorder = conform_merge_dims(data, concat_dim=dim)
         if is_v1():
             if mismatch is not None:
                 raise ValueError(_shared_dim_mismatch_message(*mismatch))
+            if reorder is not None:
+                raise ValueError(_shared_dim_mismatch_message(*reorder))
         elif mismatch is not None:  # LEGACY: remove at 1.0
             warn_legacy(
                 _legacy_coord_mismatch_message(f"merge along dim {dim!r}", *mismatch)

--- a/linopy/semantics.py
+++ b/linopy/semantics.py
@@ -372,13 +372,11 @@ def conform_merge_dims(
     the first operand's in a different order (same set, including a stacked
     MultiIndex's tuples) is a *reorder*; one whose label set differs is a
     *mismatch* — each reported as ``(dim, first_labels, other_labels)`` (first
-    found). Under v1, reorders are aligned to the first operand's order in the
-    returned data (via positional ``isel`` — ``reindex`` cannot reorder a
-    MultiIndex by tuple) and ``reorder`` is ``None``; the caller raises on
-    ``mismatch``. Under legacy, nothing is aligned and the caller warns:
-    ``reorder`` (v1 would align by label) or ``mismatch`` (v1 would raise).
-    Helper dims (``_term``, ``_factor``) and the concat dim are excluded; bare
-    dimension indexes are compared, so auxiliary coords stay §11's job.
+    found). Nothing is aligned in the returned data (§8: v1 treats a pure
+    reorder as a mismatch, exactly like `join="exact"`); the caller raises on
+    either under v1, and warns on either under legacy. Helper dims (``_term``,
+    ``_factor``) and the concat dim are excluded; bare dimension indexes are
+    compared, so auxiliary coords stay §11's job.
     """
     datasets = list(datasets)
     if len(datasets) < 2:
@@ -392,26 +390,21 @@ def conform_merge_dims(
     if not shared:
         return datasets, None, None
 
-    permute = is_v1()
-    out = [datasets[0]]
+    # §8: nothing is aligned — reorder and set-mismatch are only reported.
     mismatch: tuple[str, Any, Any] | None = None
     reorder: tuple[str, Any, Any] | None = None
     for i in range(1, len(datasets)):
-        plan: dict[Any, Any] = {}
         for d in shared:
             ref, idx = indexed[0][d], indexed[i][d]
             if ref.equals(idx):
                 continue
             positions = idx.get_indexer(ref) if len(idx) == len(ref) else None
             if positions is not None and (positions >= 0).all():
-                if permute:
-                    plan[d] = positions
-                elif reorder is None:
+                if reorder is None:
                     reorder = (str(d), ref.values, idx.values)
             elif mismatch is None:
                 mismatch = (str(d), ref.values, idx.values)
-        out.append(datasets[i].isel(plan) if plan else datasets[i])
-    return out, mismatch, reorder
+    return datasets, mismatch, reorder
 
 
 def conflicting_aux_coord(

--- a/test/test_legacy_violations.py
+++ b/test/test_legacy_violations.py
@@ -803,29 +803,25 @@ class TestExactAlignmentMerge:
         assert set(result.coord_dims) == {"time", "scenario"}
 
     @pytest.mark.v1
-    def test_var_plus_var_reordered_labels_align(self, m: Model) -> None:
+    def test_var_plus_var_reordered_labels_raises(self, m: Model) -> None:
+        # §8 exact: same labels in a different order is a mismatch, not a
+        # silent reindex — the reorder must be resolved explicitly.
         a = m.add_variables(coords=[pd.Index(["costs", "penalty"], name="e")], name="a")
         b = m.add_variables(coords=[pd.Index(["penalty", "costs"], name="e")], name="b")
-        result = (1 * a) + (1 * b)
-        assert list(result.indexes["e"]) == ["costs", "penalty"]
-        # The index alone is identical under legacy — assert the variable
-        # *pairing*: §8 sums a["costs"] with b["costs"], NOT b's leading
-        # (positional) entry b["penalty"].
-        costs = {int(v) for v in result.vars.sel(e="costs").values}
-        assert costs == {int(a.labels.sel(e="costs")), int(b.labels.sel(e="costs"))}
+        with pytest.raises(ValueError, match="Coordinate mismatch"):
+            (1 * a) + (1 * b)
 
     @pytest.mark.v1
-    def test_reordered_constants_pair_by_label_not_position(self, m: Model) -> None:
+    def test_reordered_constants_raise(self, m: Model) -> None:
         ea = pd.Index(["costs", "penalty"], name="e")
         eb = pd.Index(["penalty", "costs"], name="e")
         a = m.add_variables(coords=[ea], name="a") + pd.Series([100.0, 200.0], index=ea)
         b = m.add_variables(coords=[eb], name="b") + pd.Series([1.0, 2.0], index=eb)
-        result = a + b
-        assert float(result.const.sel(e="costs")) == 102.0
-        assert float(result.const.sel(e="penalty")) == 201.0
+        with pytest.raises(ValueError, match="Coordinate mismatch"):
+            a + b
 
     @pytest.mark.v1
-    def test_multi_operand_merge_reordered_pairs_by_label(self, m: Model) -> None:
+    def test_multi_operand_merge_reordered_raises(self, m: Model) -> None:
         ea = pd.Index(["x", "y", "z"], name="e")
         er = pd.Index(["z", "y", "x"], name="e")
         a = m.add_variables(coords=[ea], name="a") + pd.Series(
@@ -837,22 +833,30 @@ class TestExactAlignmentMerge:
         c = m.add_variables(coords=[ea], name="c") + pd.Series(
             [100, 200, 300.0], index=ea
         )
-        result = merge([a, b, c], cls=type(a))
-        assert float(result.const.sel(e="x")) == 131.0
-        assert float(result.const.sel(e="z")) == 313.0
+        with pytest.raises(ValueError, match="Coordinate mismatch"):
+            merge([a, b, c], cls=type(a))
 
     @pytest.mark.v1
-    def test_quadratic_merge_reordered_aligns(self, m: Model) -> None:
+    def test_quadratic_merge_reordered_raises(self, m: Model) -> None:
         ea = pd.Index(["x", "y", "z"], name="e")
         er = pd.Index(["z", "y", "x"], name="e")
         x = m.add_variables(coords=[ea], name="x")
         y = m.add_variables(coords=[er], name="y")
-        result = (x * x) + (y * y)
-        assert list(result.indexes["e"]) == ["x", "y", "z"]
-        # by-label: the "x" slot holds x["x"]**2 and y["x"]**2, so the only
-        # variable labels there are x["x"] and y["x"] — not y's leading y["z"].
-        labels = {int(v) for v in result.vars.sel(e="x").values.ravel() if v >= 0}
-        assert labels == {int(x.labels.sel(e="x")), int(y.labels.sel(e="x"))}
+        with pytest.raises(ValueError, match="Coordinate mismatch"):
+            (x * x) + (y * y)
+
+    @pytest.mark.v1
+    def test_reordered_escape_hatches_work(self, m: Model) -> None:
+        # §10: a reorder is resolved explicitly — via an aligning named join,
+        # or by selecting one side back into the other's order.
+        ea = pd.Index(["costs", "penalty"], name="e")
+        eb = pd.Index(["penalty", "costs"], name="e")
+        a = m.add_variables(coords=[ea], name="a") + pd.Series([100.0, 200.0], index=ea)
+        b = m.add_variables(coords=[eb], name="b") + pd.Series([1.0, 2.0], index=eb)
+        via_join = a.add(b, join="outer")
+        assert float(via_join.const.sel(e="costs")) == 102.0
+        via_sel = a + b.sel(e=a.indexes["e"])
+        assert float(via_sel.const.sel(e="costs")) == 102.0
 
     @pytest.mark.legacy
     def test_reordered_merge_positional_legacy(self, m: Model) -> None:
@@ -1844,14 +1848,16 @@ class TestAuxCoordConflict:
             v + w
 
     @pytest.mark.v1
-    def test_aux_conflict_survives_reordered_dim(self, m: Model) -> None:
+    def test_reordered_dim_raises_before_aux_check(self, m: Model) -> None:
+        # §8 runs before the §11 aux check: the reordered dim raises a
+        # "Coordinate mismatch"; the aux conflict it also carries is never reached.
         v = m.add_variables(
             lower=0, coords=[pd.Index(["x", "y", "z"], name="A")], name="v"
         ).assign_coords(B=("A", [1, 2, 3]))
         w = m.add_variables(
             lower=0, coords=[pd.Index(["z", "y", "x"], name="A")], name="w"
         ).assign_coords(B=("A", [1, 2, 3]))
-        with pytest.raises(ValueError, match="Auxiliary coordinate"):
+        with pytest.raises(ValueError, match="Coordinate mismatch"):
             v + w
 
     @pytest.mark.v1


### PR DESCRIPTION
This PR makes v1 more strict, by requiring extact coord matching on arithmetics. Previously it matched by label, reindexing safely.

> [!NOTE]
> The following was generated by AI.

Stacked on #717 (`feat/arithmetic-convention`). Tightens the v1 §8 alignment rule to **full** xarray `arithmetic_join="exact"`, and trims the spec text to a clean "what" (rationale moved here).

## What changes

Under **v1**, a shared dimension carrying the **same labels in a different order** now **raises `ValueError`** instead of being silently reindexed by label.

This closes a live inconsistency on the v1 branch ([#717 comment](https://github.com/PyPSA/linopy/pull/717#issuecomment-4981014662)): `coeff * x` already raised on a reorder, while `x + array`, `x - array`, `x <= array`, and expr+expr `merge` silently realigned. Same reorder, two behaviors — now uniformly exact. **Legacy is completely unchanged.**

## Why exact (rationale moved out of the spec)

- **"By label, never by position" cuts both ways.** It forbids pairing the *n*-th label of one operand with the *n*-th of the other — but it equally does not license *quietly reshuffling* one operand to match. A shared dim ordered differently on the two sides usually means the operands came from different pipelines; reindexing one to the other hides that, exact surfaces it.
- **Consistency across operators.** The old split (`coeff *` strict, `+`/`-`/`<=`/merge tolerant) is gone — one rule everywhere.
- **Precedent:** [pyoframe](https://github.com/Bravos-Power/pyoframe) uses the same exact-by-default model. It is deliberately stricter than xarray's own default (`inner`), which silently drops non-overlapping labels — in an optimization model a dropped coordinate is a dropped term/constraint, i.e. a silent wrong answer.

## Pros / cons on the algebraic laws — `x + a + b == x + b + a`

The interesting question for exact is what it does to commutativity/associativity. Verified empirically:

```python
options["semantics"] = "v1"
# same-order operands: all regroupings succeed and agree
(x + a) + b  ==  (x + b) + a  ==  x + (a + b)          # ✅ equal
# b reordered (same labels, different order):
(x + a) + b   -> ValueError
(x + b) + a   -> ValueError                             # both raise
```

**Pros**
- **No ordering-dependent divergence.** Every regrouping of the same operands lands in the *same state*: all succeed and agree, or all raise. The #711 associativity break — where a grouping silently drops coords and two algebraically-equal forms give different answers — becomes structurally impossible.
- **Deterministic result order.** The result always takes the first operand's coordinate order, independent of how the chain was grouped.
- **No hidden reindex** buried inside a long `+ … + …` chain.

**Cons**
- **Rejects valid-but-reordered operands.** `x + b` with `b`'s labels merely reordered raises, even though the by-label sum is unambiguous. So `x + a + b` can fail purely on ordering, forcing an explicit sort — where the old reorder-tolerant v1 would have computed the correct commutative result silently.
- **Friction** assembling expressions from differently-ordered sources. (Though — see below — this never actually occurred in the examples.)
- **Intentional asymmetry (Option A):** `join="outer"` still reindexes a reorder, so the *same* reorder is an error by default yet fine under an explicit join. We keep this: `exact` asserts identity; a `join=` combines by label, and resolving a reorder is a degenerate case of that.

## Is the reorder-tolerance load-bearing?

Measured it: instrumented both reorder-reindex sites and executed all 15 example notebooks → **zero** firings. Nothing in the documented examples relies on a silent reorder-reindex. (2 notebooks error on missing remote-solve credentials, unrelated.)

## Escape hatches

- `a.add(b, join="outer")` (or `inner`/`left`/`right`) — reindexes both sides by label;
- bring one side into order first — `b.sel(dim=a.indexes[dim])`, `b.reindex_like(a)`, or `b.sortby(dim)` on a plain-array operand.

**Construction-time alignment is *not* affected.** Conforming a variable's bounds / `mask=` to its declared `coords` still reindexes a reordered-but-matching input — there `coords` is the source of truth, not a second operand. Only *arithmetic between operands* goes exact.

**Reverses the v1 half of #550/#758** (reorder-align → reorder-raise); still fixes #550's original silent-wrong-answer by surfacing the mismatch. **No external migration cost:** v1 is pre-1.0 and opt-in; legacy (the default) is untouched.

## Implementation

- `alignment.py`: arithmetic operands (`strict=False`) pass `conform_reorder=not is_v1()`, so under v1 a reorder survives to the operator's exact check; `strict=True` (bounds/masks) keeps conforming.
- `semantics.conform_merge_dims`: no longer permutes a reorder under v1; reports it, and `merge()` raises on it like a set mismatch.
- Spec §8/§10/§11 tightened and trimmed to "what"; reorder tests flipped to assert-raises under v1, plus escape-hatch coverage.

Full suite green (7789 passed); ruff/mypy clean.
