### PR TITLE
fix(v1): make coeff * x reorder-exact, purge stale reorder-tolerant text

### DIFF
--- a/arithmetics-design/convention.md
+++ b/arithmetics-design/convention.md
@@ -163,9 +163,8 @@ resolve it. Several primitives bring operands into agreement:
   `options["semantics"]` setting — under v1 that is `exact`, so passing
   `join="exact"` is the explicit spelling of the v1 default, not a stricter
   mode. `override` is the old positional behavior — still available, but now
-  opt-in
-  and named rather than triggered by a size coincidence. It still requires the
-  shared dimensions to match in size: a genuine size mismatch raises rather
+  opt-in and named rather than triggered by a size coincidence. It still
+  requires the shared dimensions to match in size: a genuine size mismatch raises rather
   than relabelling mismatched data, so reach for a label join (`inner` /
   `outer` / `left` / `right`) when the sizes really differ.
 - `.reindex()` / `.reindex_like()` conform an operand to a target index

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -768,7 +768,7 @@ class BaseExpression(ABC):
         join : str, optional
             Alignment method. If None, the default is determined by
             ``options["semantics"]`` — under ``v1`` shared dimensions must
-            carry the same label set (a pure reorder aligns by label), the
+            carry identical labels (same order; a reorder raises), the
             legacy size-aware behavior under ``legacy``.
 
         Returns
@@ -1069,9 +1069,9 @@ class BaseExpression(ABC):
         join : str, optional
             How to align coordinates. One of "outer", "inner", "left",
             "right", "exact", "override". When None (default), follows the
-            semantics setting: under v1, shared dimensions must carry the
-            same label set — a pure reorder aligns by label, a differing set
-            raises; under legacy, positional alignment.
+            semantics setting: under v1, shared dimensions must carry
+            identical labels (same labels, same order) — a reorder or a
+            differing set raises; under legacy, positional alignment.
         """
         if join is None:
             return self.__add__(other)
@@ -1099,9 +1099,9 @@ class BaseExpression(ABC):
         join : str, optional
             How to align coordinates. One of "outer", "inner", "left",
             "right", "exact", "override". When None (default), follows the
-            semantics setting: under v1, shared dimensions must carry the
-            same label set — a pure reorder aligns by label, a differing set
-            raises; under legacy, positional alignment.
+            semantics setting: under v1, shared dimensions must carry
+            identical labels (same labels, same order) — a reorder or a
+            differing set raises; under legacy, positional alignment.
         """
         return self.add(-other, join=join)
 
@@ -1120,9 +1120,9 @@ class BaseExpression(ABC):
         join : str, optional
             How to align coordinates. One of "outer", "inner", "left",
             "right", "exact", "override". When None (default), follows the
-            semantics setting: under v1, shared dimensions must carry the
-            same label set — a pure reorder aligns by label, a differing set
-            raises; under legacy, positional alignment.
+            semantics setting: under v1, shared dimensions must carry
+            identical labels (same labels, same order) — a reorder or a
+            differing set raises; under legacy, positional alignment.
         """
         if join is None:
             return self.__mul__(other)
@@ -1147,9 +1147,9 @@ class BaseExpression(ABC):
         join : str, optional
             How to align coordinates. One of "outer", "inner", "left",
             "right", "exact", "override". When None (default), follows the
-            semantics setting: under v1, shared dimensions must carry the
-            same label set — a pure reorder aligns by label, a differing set
-            raises; under legacy, positional alignment.
+            semantics setting: under v1, shared dimensions must carry
+            identical labels (same labels, same order) — a reorder or a
+            differing set raises; under legacy, positional alignment.
         """
         if join is None:
             return self.__div__(other)
@@ -1176,9 +1176,9 @@ class BaseExpression(ABC):
         join : str, optional
             How to align coordinates. One of "outer", "inner", "left",
             "right", "exact", "override". When None (default), follows the
-            semantics setting: under v1, shared dimensions must carry the
-            same label set — a pure reorder aligns by label, a differing set
-            raises; under legacy, positional alignment.
+            semantics setting: under v1, shared dimensions must carry
+            identical labels (same labels, same order) — a reorder or a
+            differing set raises; under legacy, positional alignment.
         """
         return self.to_constraint(LESS_EQUAL, rhs, join=join)
 
@@ -1197,9 +1197,9 @@ class BaseExpression(ABC):
         join : str, optional
             How to align coordinates. One of "outer", "inner", "left",
             "right", "exact", "override". When None (default), follows the
-            semantics setting: under v1, shared dimensions must carry the
-            same label set — a pure reorder aligns by label, a differing set
-            raises; under legacy, positional alignment.
+            semantics setting: under v1, shared dimensions must carry
+            identical labels (same labels, same order) — a reorder or a
+            differing set raises; under legacy, positional alignment.
         """
         return self.to_constraint(GREATER_EQUAL, rhs, join=join)
 
@@ -1218,9 +1218,9 @@ class BaseExpression(ABC):
         join : str, optional
             How to align coordinates. One of "outer", "inner", "left",
             "right", "exact", "override". When None (default), follows the
-            semantics setting: under v1, shared dimensions must carry the
-            same label set — a pure reorder aligns by label, a differing set
-            raises; under legacy, positional alignment.
+            semantics setting: under v1, shared dimensions must carry
+            identical labels (same labels, same order) — a reorder or a
+            differing set raises; under legacy, positional alignment.
         """
         return self.to_constraint(EQUAL, rhs, join=join)
 
@@ -1481,9 +1481,9 @@ class BaseExpression(ABC):
         join : str, optional
             How to align coordinates. One of "outer", "inner", "left",
             "right", "exact", "override". When None (default), follows the
-            semantics setting: under v1, shared dimensions must carry the
-            same label set — a pure reorder aligns by label, a differing set
-            raises; under legacy, positional alignment.
+            semantics setting: under v1, shared dimensions must carry
+            identical labels (same labels, same order) — a reorder or a
+            differing set raises; under legacy, positional alignment.
 
         Returns
         -------

--- a/linopy/semantics.py
+++ b/linopy/semantics.py
@@ -153,11 +153,11 @@ def _legacy_coord_mismatch_message(
 
 
 def _legacy_coord_reorder_message(context: str, dim: str, left: Any, right: Any) -> str:
-    """Same labels, different order — aligned positionally by legacy; v1 reindexes."""
+    """Same labels, different order — aligned positionally by legacy; v1 raises."""
     return (
         f"Coordinate order mismatch in {context} aligned positionally by legacy."
-        " Under v1 the same labels in a different order align by label (a"
-        " reindex), giving a different result."
+        " Under v1 the same labels in a different order raise ValueError (§8);"
+        " reindex or sort one side to align by label."
         f"\n  Dim:       {dim!r}: left={_short_repr(left)}, right={_short_repr(right)}"
         "\n  Resolve:   `.sel(...)` / `.reindex(...)` to align"
         "\n             `.assign_coords(...)` to relabel one side"
@@ -343,16 +343,13 @@ def dim_coords_differ(a: DataArray, b: DataArray) -> bool:
     return first_mismatched_dim(a, b) is not None
 
 
-def first_mismatched_dim(
-    a: DataArray, b: DataArray, *, reorder_ok: bool = False
-) -> tuple[str, Any, Any] | None:
+def first_mismatched_dim(a: DataArray, b: DataArray) -> tuple[str, Any, Any] | None:
     """
     Return ``(dim, a_labels, b_labels)`` for the first shared dim that
     disagrees on coordinate labels OR size, or ``None`` if all agree.
 
-    With ``reorder_ok=True`` a *pure reorder* — the same label set in a
-    different order (same length) — is not a disagreement, matching §8:
-    reorders align by label and only a differing label *set* raises.
+    Label equality is order-sensitive (§8 exact): the same labels in a
+    different order are a mismatch, like a differing label *set*.
 
     Uses ``indexes[dim]`` (the bare pandas Index) rather than
     ``coords[dim]`` — a coord DataArray's ``equals`` compares attached
@@ -361,12 +358,8 @@ def first_mismatched_dim(
     """
     for dim in set(a.dims) & set(b.dims):
         if dim in a.indexes and dim in b.indexes:
-            ai, bi = a.indexes[dim], b.indexes[dim]
-            if ai.equals(bi):
-                continue
-            if reorder_ok and len(ai) == len(bi) and set(ai) == set(bi):
-                continue
-            return str(dim), ai.values, bi.values
+            if not a.indexes[dim].equals(b.indexes[dim]):
+                return str(dim), a.indexes[dim].values, b.indexes[dim].values
         elif a.sizes[dim] != b.sizes[dim]:
             return str(dim), None, None
     return None

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -340,24 +340,21 @@ class Variable:
             Linear expression with the variables and coefficients.
         """
         # §8: check on the raw coefficient, before broadcast aligns it away.
-        # A pure reorder aligns by label like every other operator (the
-        # broadcast + reindex_like below); only a differing label set raises.
+        # A reorder is a mismatch like any other (v1 exact); only the
+        # reindex_like below fills absence / broadcasts non-shared dims.
         if not np.isscalar(coefficient):
             coeff_da = as_dataarray(coefficient)
             enforce_aux_conflict([self.labels, coeff_da], stacklevel=4)
-            if is_v1():
-                mismatch = first_mismatched_dim(self.labels, coeff_da, reorder_ok=True)
-                if mismatch is not None:
+            mismatch = first_mismatched_dim(self.labels, coeff_da)
+            if mismatch is not None:
+                if is_v1():
                     raise ValueError(_shared_dim_mismatch_message(*mismatch))
-            else:
-                mismatch = first_mismatched_dim(self.labels, coeff_da)
-                if mismatch is not None:
-                    warn_legacy(
-                        _legacy_coord_mismatch_message(
-                            "this operator's constant operand", *mismatch
-                        ),
-                        stacklevel=4,
-                    )
+                warn_legacy(
+                    _legacy_coord_mismatch_message(
+                        "this operator's constant operand", *mismatch
+                    ),
+                    stacklevel=4,
+                )
         coefficient = broadcast_to_coords(coefficient, coords=self.coords, strict=False)
         # §5: user-supplied NaN in the coefficient must raise (v1) / warn
         # (legacy) — it's the multiplicative analogue of ``x + nan_data``
@@ -626,9 +623,9 @@ class Variable:
         join : str, optional
             How to align coordinates. One of "outer", "inner", "left",
             "right", "exact", "override". When None (default), follows the
-            semantics setting: under v1, shared dimensions must carry the
-            same label set — a pure reorder aligns by label, a differing set
-            raises; under legacy, positional alignment.
+            semantics setting: under v1, shared dimensions must carry
+            identical labels (same labels, same order) — a reorder or a
+            differing set raises; under legacy, positional alignment.
         """
         return self.to_linexpr().add(other, join=join)
 
@@ -645,9 +642,9 @@ class Variable:
         join : str, optional
             How to align coordinates. One of "outer", "inner", "left",
             "right", "exact", "override". When None (default), follows the
-            semantics setting: under v1, shared dimensions must carry the
-            same label set — a pure reorder aligns by label, a differing set
-            raises; under legacy, positional alignment.
+            semantics setting: under v1, shared dimensions must carry
+            identical labels (same labels, same order) — a reorder or a
+            differing set raises; under legacy, positional alignment.
         """
         return self.to_linexpr().sub(other, join=join)
 
@@ -664,9 +661,9 @@ class Variable:
         join : str, optional
             How to align coordinates. One of "outer", "inner", "left",
             "right", "exact", "override". When None (default), follows the
-            semantics setting: under v1, shared dimensions must carry the
-            same label set — a pure reorder aligns by label, a differing set
-            raises; under legacy, positional alignment.
+            semantics setting: under v1, shared dimensions must carry
+            identical labels (same labels, same order) — a reorder or a
+            differing set raises; under legacy, positional alignment.
         """
         return self.to_linexpr().mul(other, join=join)
 
@@ -683,9 +680,9 @@ class Variable:
         join : str, optional
             How to align coordinates. One of "outer", "inner", "left",
             "right", "exact", "override". When None (default), follows the
-            semantics setting: under v1, shared dimensions must carry the
-            same label set — a pure reorder aligns by label, a differing set
-            raises; under legacy, positional alignment.
+            semantics setting: under v1, shared dimensions must carry
+            identical labels (same labels, same order) — a reorder or a
+            differing set raises; under legacy, positional alignment.
         """
         return self.to_linexpr().div(other, join=join)
 
@@ -700,9 +697,9 @@ class Variable:
         join : str, optional
             How to align coordinates. One of "outer", "inner", "left",
             "right", "exact", "override". When None (default), follows the
-            semantics setting: under v1, shared dimensions must carry the
-            same label set — a pure reorder aligns by label, a differing set
-            raises; under legacy, positional alignment.
+            semantics setting: under v1, shared dimensions must carry
+            identical labels (same labels, same order) — a reorder or a
+            differing set raises; under legacy, positional alignment.
         """
         return self.to_linexpr().le(rhs, join=join)
 
@@ -717,9 +714,9 @@ class Variable:
         join : str, optional
             How to align coordinates. One of "outer", "inner", "left",
             "right", "exact", "override". When None (default), follows the
-            semantics setting: under v1, shared dimensions must carry the
-            same label set — a pure reorder aligns by label, a differing set
-            raises; under legacy, positional alignment.
+            semantics setting: under v1, shared dimensions must carry
+            identical labels (same labels, same order) — a reorder or a
+            differing set raises; under legacy, positional alignment.
         """
         return self.to_linexpr().ge(rhs, join=join)
 
@@ -734,9 +731,9 @@ class Variable:
         join : str, optional
             How to align coordinates. One of "outer", "inner", "left",
             "right", "exact", "override". When None (default), follows the
-            semantics setting: under v1, shared dimensions must carry the
-            same label set — a pure reorder aligns by label, a differing set
-            raises; under legacy, positional alignment.
+            semantics setting: under v1, shared dimensions must carry
+            identical labels (same labels, same order) — a reorder or a
+            differing set raises; under legacy, positional alignment.
         """
         return self.to_linexpr().eq(rhs, join=join)
 

--- a/test/test_legacy_violations.py
+++ b/test/test_legacy_violations.py
@@ -859,15 +859,13 @@ class TestExactAlignmentMerge:
         assert float(via_sel.const.sel(e="costs")) == 102.0
 
     @pytest.mark.v1
-    def test_coeff_times_var_reordered_aligns(self, m: Model) -> None:
-        # §8: a reordered coefficient aligns by label like +/-/merge; the
-        # multiply path no longer raises where the others reindex.
+    def test_coeff_times_var_reordered_raises(self, m: Model) -> None:
+        # §8 exact: a reordered coefficient raises like +/-/merge, not reindexed.
         ea = pd.Index(["costs", "penalty"], name="e")
         er = pd.Index(["penalty", "costs"], name="e")
         x = m.add_variables(coords=[ea], name="x")
-        expr = pd.Series([10.0, 20.0], index=er) * x  # penalty=10, costs=20
-        assert float(expr.coeffs.sel(e="costs").squeeze()) == 20.0
-        assert float(expr.coeffs.sel(e="penalty").squeeze()) == 10.0
+        with pytest.raises(ValueError, match="Coordinate mismatch on shared dimension"):
+            _ = pd.Series([10.0, 20.0], index=er) * x
 
     @pytest.mark.v1
     def test_coeff_times_var_label_set_mismatch_raises(self, m: Model) -> None:
@@ -902,7 +900,8 @@ class TestExactAlignmentMerge:
         assert msg == (
             "Coordinate order mismatch in merge along dim '_term' aligned "
             "positionally by legacy. Under v1 the same labels in a different "
-            "order align by label (a reindex), giving a different result."
+            "order raise ValueError (§8); reindex or sort one side to align "
+            "by label."
             "\n  Dim:       'e': left=['costs', 'penalty'], "
             "right=['penalty', 'costs']"
             "\n  Resolve:   `.sel(...)` / `.reindex(...)` to align"


### PR DESCRIPTION
<!-- TODO(@FBumann): replace this line with your own intent/motivation, in your own words. -->

> [!NOTE]
> The following was generated by AI.

Follow-up to #831. After #831 tightened §8 to full `join="exact"` (a pure reorder raises), one operator was left behind and a batch of stale text now contradicts the rule.

**Root cause.** #16d3d7b landed on the branch *between* #831 branching and merging. It made the `coeff * x` multiply path reorder-*tolerant* (align a reordered coefficient by label, via a new `reorder_ok` flag on `first_mismatched_dim`) and added docstrings, a legacy warning, and a test describing that tolerant behavior. #831 was a squash-merge whose diff never touched those lines, so both survived — leaving `coeff * x` as the **only** reorder-tolerant operator, and the surrounding prose asserting "a pure reorder aligns by label" against a §8 that now says it raises.

## What this fixes

- **`variables.py`** — drop `reorder_ok=True` on the coeff §8 check so a reordered coefficient raises like `+`/`-`/`<=`/merge; fix the comment and the 7 repeated `join` docstrings.
- **`semantics.py`** — revert the now-unused `reorder_ok` parameter on `first_mismatched_dim`; `_legacy_coord_reorder_message` now correctly says v1 **raises** (it claimed "v1 reindexes").
- **`expressions.py`** — fix the 8 `join` docstrings and the `_align_constant` docstring.
- **tests** — flip `test_coeff_times_var_reordered_aligns` → `test_coeff_times_var_reordered_raises`; update the pinned legacy-warning text.

After this, every operator is uniformly exact on a reorder; no code or doc still claims v1 reindexes a reorder.

Full suite green (7791 passed); ruff/mypy clean.
