### PR TITLE
perf(v1): skip mask/where/const for dense variables in to_linexpr

### DIFF
--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -365,10 +365,13 @@ class Variable:
         if is_v1():
             # Under v1 the LinearExpression must carry absence (NaN at
             # `labels == -1`) so §6 propagation through downstream
-            # arithmetic works.
+            # arithmetic works. A dense variable has none, so the
+            # mask/where/const collapse to no-ops (skipped below).
+            has_absence = bool((self.labels == -1).any())
             coefficient = coefficient.reindex_like(self.labels, fill_value=np.nan)
-            absent = self.labels == -1
-            coefficient = coefficient.where(~absent)
+            if has_absence:
+                absent = self.labels == -1
+                coefficient = coefficient.where(~absent)
         else:
             # LEGACY: warn if the variable carries absent slots — those
             # silently contribute 0 here, but v1 will propagate the
@@ -383,7 +386,7 @@ class Variable:
         ds = Dataset({"coeffs": coefficient, "vars": self.labels}).expand_dims(
             TERM_DIM, -1
         )
-        if is_v1():
+        if is_v1() and has_absence:
             const = DataArray(np.where(absent, np.nan, 0.0), coords=self.labels.coords)
             ds = ds.assign(const=const)
         return expressions.LinearExpression(ds, self.model)


### PR DESCRIPTION
_TODO: your own intent/motivation here._

> [!NOTE]
> The following content was generated by AI.

## What

`Variable.to_linexpr` under v1 unconditionally built an `absent` mask, a
`where(~absent)` copy, and an explicit full-size all-zero `const` array —
even for a fully-dense variable with no absent slots. On the isolated
`var * array` (exact-match) path these are all no-ops but still allocate
full-size temporaries.

This is the source of the remaining CodSpeed memory regression after #804/#816:

| Mode | Benchmark | BASE | HEAD | Δ |
|---|---|---|---|---|
| Memory | `test_op[var_mul_array_match]` | 212.3 KB | 306.1 KB | −30.6% |

and the small-model `test_build` peaks (knapsack-100 +19%, milp-10 +17%,
sparse_network-10 +16%, sos-10 +13%). Large models were already at parity —
the all-zero `const` is pruned at matrix assembly (#816), so *built models*
are byte-identical; the regression only shows on the isolated expression object.

## Fix

Gate the mask / `where` / `const` on `has_absence = (labels == -1).any()`.
Dense variables now build the same lean `coeffs`+`vars` expression as legacy;
masked variables still carry NaN at absent slots for §6 propagation.

## Measurements

Isolated `var * array` peak (memray, warmed):

| n | legacy | v1 before | v1 after |
|---|---|---|---|
| 5 000 | 123.9 KiB | 133.7 KiB | **78.1 KiB** |
| 20 000 | 490.1 KiB | 529.2 KiB | **312.5 KiB** |
| 200 000 | 4884.7 KiB | 5275.3 KiB | **3125.0 KiB** |

v1 now sits below legacy on this path.

## Tests

Full suite passes under both semantics: **7813 passed, 605 skipped**
(`pytest test/`). Dense/masked equivalence verified: masked `coeffs`
still `[0, nan, 2, nan]`.

<details>
<summary>Follow-up (not in this PR)</summary>

The v1 branch still runs `reindex_like(fill_value=nan)` even when the
coefficient already matches labels exactly (`first_mismatched_dim` returned
None). Skipping that no-op copy — mirroring `_align_constant`'s
`needs_data_reindex=False` path from #804 — would trim further.

</details>
