### PR TITLE
feat(v1): warn on reordered constants under legacy; spec groupers

### DIFF
--- a/arithmetics-design/convention.md
+++ b/arithmetics-design/convention.md
@@ -252,7 +252,20 @@ Further reductions (`mean`, `resample`, `coarsen`) are not in linopy yet; they
 are added under v1 only ([#703]) — as new operations with no legacy behaviour —
 and follow this same skip-absent rule.
 
+**Groupers.** A `groupby` grouper — a Series, DataArray, DataFrame, or the name
+of an attached coordinate — labels each position of the grouped dimension. It
+aligns to that dimension by §8: the grouper's index must carry the grouped
+dimension's labels, and a differing label *set* or the same labels in a
+different *order* raises. The grouper is never matched by position and never
+silently reindexed ([#827]). Under legacy the fast path matches positionally; v1
+validates and raises, whichever grouper type is used.
+
+A multi-key grouper (a list of coordinate names, or a DataFrame) groups by the
+tuple of keys. The result is a flat `group` dimension carrying the keys as
+auxiliary coordinates; the stacked `group` MultiIndex is legacy-only (§11).
+
 <!-- references -->
+[#827]: https://github.com/PyPSA/linopy/issues/827
 [#732]: https://github.com/PyPSA/linopy/pull/732
 [#737]: https://github.com/PyPSA/linopy/pull/737
 [#736]: https://github.com/PyPSA/linopy/issues/736

--- a/arithmetics-design/open-items.md
+++ b/arithmetics-design/open-items.md
@@ -8,8 +8,10 @@ tracks the concrete items per stage.
 
 The one open **design** decision — [#744] MultiIndex storage — is **resolved**:
 v1 disallows first-class `pd.MultiIndex` (a flat dim + auxiliary level coords),
-implemented in [#803]. No open arithmetic-rule questions remain; everything left
-is rollout + cleanup.
+implemented in [#803]. §8 alignment was subsequently tightened to full
+`join="exact"` — a pure reorder raises rather than reindexing ([#831]) — and
+grouper alignment made strict to match ([#827]). Everything left is rollout +
+cleanup.
 
 ## Stage 1 — release v1 (opt-in)
 
@@ -29,6 +31,14 @@ here ([`goals.md`] step 1: *warn on legacy, raise on v1*).
   "no silent change" guarantee ([`goals.md`] transitioning goal #3): shipping v1
   with a gap would silently change any model that opts in. Includes #803's
   MultiIndex rejects and the multi-key-`groupby`-flat change as new fork sites.
+  The reorder→raise change ([#831]) added its own fork sites: reordered constant
+  operands now warn under legacy (they were silently reindexed) — done for
+  `+`/`-`/`*`/`/`/rhs; still verify no other reorder-reindex path stays silent.
+- [ ] **Land grouper strict alignment on the branch** — [#827]'s fix ([#830],
+  check-and-raise on a reordered/mismatched grouper) is on `master`; it reaches
+  #717 when master merges in. The **Groupers** rule in [`convention.md`] §13
+  documents the target; until #830 lands here the fast path still matches a
+  reordered grouper positionally.
 - [ ] Changelog note — v1 available via `options['semantics'] = 'v1'`; legacy
   remains the default; link [`convention.md`].
 
@@ -64,11 +74,17 @@ here ([`goals.md`] step 1: *warn on legacy, raise on v1*).
   on it).
 - [x] **Legacy warnings live from the opt-in release** → yes; the transition
   surface is complete at stage 1, not deferred.
+- [x] **§8 is full `join="exact"`** → a pure reorder (same labels, different
+  order) raises, not reindexes ([#831]); the reindexing named joins still
+  resolve it. Groupers align strictly the same way ([#827]/[#830]).
 - [ ] **When v1 becomes the default** — pick the release; gated on the migration
   guide.
 
 <!-- references -->
 [#744]: https://github.com/PyPSA/linopy/issues/744
+[#827]: https://github.com/PyPSA/linopy/issues/827
+[#830]: https://github.com/PyPSA/linopy/pull/830
+[#831]: https://github.com/PyPSA/linopy/pull/831
 [#714]: https://github.com/PyPSA/linopy/issues/714
 [#717]: https://github.com/PyPSA/linopy/pull/717
 [#803]: https://github.com/PyPSA/linopy/pull/803

--- a/linopy/alignment.py
+++ b/linopy/alignment.py
@@ -732,12 +732,16 @@ def _label_input(
     )
 
 
-def _reindex_reordered_dims(arr: DataArray, expected: dict[Hashable, Any]) -> DataArray:
+def _reindex_reordered_dims(
+    arr: DataArray, expected: dict[Hashable, Any], warn: bool = False
+) -> DataArray:
     """
     Reindex shared dims whose values match ``expected`` in a different order.
 
     Disagreeing value *sets* are left for downstream xarray alignment;
-    only a pure reordering of the same values is conformed here.
+    only a pure reordering of the same values is conformed here. With
+    ``warn=True`` (the legacy arithmetic path) each conformed reorder emits a
+    ``LinopySemanticsWarning`` — v1 raises on it instead of reindexing.
     """
     for dim, coord_values in expected.items():
         if dim not in arr.dims or isinstance(arr.indexes.get(dim), pd.MultiIndex):
@@ -749,6 +753,18 @@ def _reindex_reordered_dims(arr: DataArray, expected: dict[Hashable, Any]) -> Da
         if len(actual_idx) == len(expected_idx) and set(actual_idx) == set(
             expected_idx
         ):
+            if warn:
+                from linopy.semantics import (
+                    _legacy_const_reorder_message,
+                    warn_legacy,
+                )
+
+                warn_legacy(
+                    _legacy_const_reorder_message(
+                        str(dim), expected_idx.values, actual_idx.values
+                    ),
+                    stacklevel=6,
+                )
             arr = arr.reindex({dim: expected_idx})
     return arr
 
@@ -813,6 +829,7 @@ def _broadcast_to_coords(
     dims: DimsLike | None = None,
     *,
     reindex_reordered: bool = True,
+    warn_reorder: bool = False,
     **kwargs: Any,
 ) -> tuple[DataArray, list[_LevelProjection]]:
     """
@@ -841,7 +858,7 @@ def _broadcast_to_coords(
 
     arr, projections = _project_onto_multiindex_levels(arr, expected)
     if reindex_reordered:  # False on the v1 arithmetic path, so a reorder hits §8 exact
-        arr = _reindex_reordered_dims(arr, expected)
+        arr = _reindex_reordered_dims(arr, expected, warn=warn_reorder)
     arr = _expand_missing_dims(arr, expected)
     arr = _order_like_coords(arr, expected)
     return arr, projections
@@ -878,6 +895,7 @@ def broadcast_to_coords(
     *,
     strict: bool = True,
     label: str | None = None,
+    warn_reorder: bool = False,
     **kwargs: Any,
 ) -> DataArray:
     """
@@ -937,7 +955,12 @@ def broadcast_to_coords(
         from linopy.semantics import is_v1
 
         da, projections = _broadcast_to_coords(
-            arr, coords, dims, reindex_reordered=not is_v1(), **kwargs
+            arr,
+            coords,
+            dims,
+            reindex_reordered=not is_v1(),
+            warn_reorder=warn_reorder,
+            **kwargs,
         )
         _enforce_implicit_projections(projections)
         return da

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -914,7 +914,9 @@ class BaseExpression(ABC):
             if isinstance(other, float) and np.isnan(other):
                 check_user_nan()
             return self.assign(const=self.const + other)
-        da = broadcast_to_coords(other, coords=self.coords, strict=False)
+        da = broadcast_to_coords(
+            other, coords=self.coords, strict=False, warn_reorder=True
+        )
         if da.isnull().any():
             check_user_nan()
         self_const, da, needs_data_reindex = self._align_constant(
@@ -940,7 +942,9 @@ class BaseExpression(ABC):
             if isinstance(other, float) and np.isnan(other):
                 check_user_nan()
             return self.assign(const=self.const.fillna(0) + other)
-        da = broadcast_to_coords(other, coords=self.coords, strict=False)
+        da = broadcast_to_coords(
+            other, coords=self.coords, strict=False, warn_reorder=True
+        )
         if da.isnull().any():
             check_user_nan()
         self_const, da, needs_data_reindex = self._align_constant(
@@ -982,7 +986,9 @@ class BaseExpression(ABC):
         # §5: user NaN raised before we get here.
         if isinstance(other, float) and np.isnan(other):
             check_user_nan(op_kind=op_kind)
-        factor = broadcast_to_coords(other, coords=self.coords, strict=False)
+        factor = broadcast_to_coords(
+            other, coords=self.coords, strict=False, warn_reorder=True
+        )
         if factor.isnull().any():
             check_user_nan(op_kind=op_kind)
         self_const, factor, needs_data_reindex = self._align_constant(
@@ -1013,7 +1019,9 @@ class BaseExpression(ABC):
         # factor → fill_value (0 for mul, 1 for div), coeffs/const → 0.
         if isinstance(other, float) and np.isnan(other):
             check_user_nan(op_kind=op_kind)
-        factor = broadcast_to_coords(other, coords=self.coords, strict=False)
+        factor = broadcast_to_coords(
+            other, coords=self.coords, strict=False, warn_reorder=True
+        )
         if factor.isnull().any():
             check_user_nan(op_kind=op_kind)
         self_const, factor, needs_data_reindex = self._align_constant(
@@ -1534,7 +1542,9 @@ class BaseExpression(ABC):
             # through ``sub`` into the RHS and reaches downstream
             # auto-mask handling as "no constraint at this row" (§12).
             if isinstance(rhs, CONSTANT_TYPES):
-                rhs = broadcast_to_coords(rhs, coords=self.coords, strict=False)
+                rhs = broadcast_to_coords(
+                    rhs, coords=self.coords, strict=False, warn_reorder=True
+                )
                 extra_dims = set(rhs.dims) - set(self.coord_dims)
                 if extra_dims:
                     logger.warning(
@@ -1558,7 +1568,9 @@ class BaseExpression(ABC):
         # part of normal arithmetic, so we restore the original NaN mask
         # afterward).
         if isinstance(rhs, CONSTANT_TYPES):
-            rhs = broadcast_to_coords(rhs, coords=self.coords, strict=False)
+            rhs = broadcast_to_coords(
+                rhs, coords=self.coords, strict=False, warn_reorder=True
+            )
 
             extra_dims = set(rhs.dims) - set(self.coord_dims)
             if extra_dims:

--- a/linopy/semantics.py
+++ b/linopy/semantics.py
@@ -165,6 +165,18 @@ def _legacy_coord_reorder_message(context: str, dim: str, left: Any, right: Any)
     )
 
 
+def _legacy_const_reorder_message(dim: str, left: Any, right: Any) -> str:
+    """Same labels, different order — reindexed by label by legacy; v1 raises."""
+    return (
+        "Coordinate order mismatch in this operator's constant operand: the same"
+        " labels in a different order were reindexed by label by legacy. Under v1"
+        " this raises ValueError (§8)."
+        f"\n  Dim:       {dim!r}: left={_short_repr(left)}, right={_short_repr(right)}"
+        "\n  Resolve:   `.sel(...)` / `.reindex(...)` / `.sortby(...)` to align"
+        "\n             or pass an explicit `join=` argument." + _OPT_IN_HINT
+    )
+
+
 def _legacy_aux_conflict_message(name: str, left: Any, right: Any, kind: str) -> str:
     """
     Conflicting aux coord silently dropped by xarray under legacy.

--- a/test/test_legacy_violations.py
+++ b/test/test_legacy_violations.py
@@ -913,6 +913,44 @@ class TestExactAlignmentMerge:
         )
 
     @pytest.mark.legacy
+    def test_reordered_constant_warns_and_reindexes_legacy(
+        self, m: Model, unsilenced: None
+    ) -> None:
+        # The const path reindexes a reordered constant *by label* under legacy
+        # (unlike the positional merge path), so the result is unchanged — but v1
+        # raises on it, so legacy must warn about the divergence.
+        e = pd.Index(["costs", "penalty"], name="e")
+        er = pd.Index(["penalty", "costs"], name="e")
+        x = m.add_variables(coords=[e], name="x")
+        with pytest.warns(LinopySemanticsWarning) as record:
+            expr = 1 * x + pd.Series([1.0, 100.0], index=er)  # penalty=1, costs=100
+        # reindexed by label: the "costs" slot got 100, not the leading 1
+        assert float(expr.const.sel(e="costs")) == 100.0
+        msg = next(
+            str(w.message) for w in record if w.category is LinopySemanticsWarning
+        )
+        assert msg == (
+            "Coordinate order mismatch in this operator's constant operand: the "
+            "same labels in a different order were reindexed by label by legacy. "
+            "Under v1 this raises ValueError (§8)."
+            "\n  Dim:       'e': left=['costs', 'penalty'], "
+            "right=['penalty', 'costs']"
+            "\n  Resolve:   `.sel(...)` / `.reindex(...)` / `.sortby(...)` to align"
+            "\n             or pass an explicit `join=` argument."
+            "\n  Opt in:    linopy.options['semantics'] = 'v1'"
+            "\n  Silence:   warnings.filterwarnings('ignore', "
+            "category=LinopySemanticsWarning)"
+        )
+
+    @pytest.mark.v1
+    def test_reordered_constant_raises_v1(self, m: Model) -> None:
+        e = pd.Index(["costs", "penalty"], name="e")
+        er = pd.Index(["penalty", "costs"], name="e")
+        x = m.add_variables(coords=[e], name="x")
+        with pytest.raises(ValueError, match="Coordinate mismatch on shared dimension"):
+            _ = 1 * x + pd.Series([1.0, 100.0], index=er)
+
+    @pytest.mark.legacy
     def test_var_plus_var_reordered_pairs_positionally_legacy(self, m: Model) -> None:
         """
         Legacy preserves master's #550 behaviour: var+var with reordered


### PR DESCRIPTION
<!-- TODO(@FBumann): replace this line with your own intent/motivation, in your own words. -->

> [!NOTE]
> The following was generated by AI.

Two follow-ups to the §8-exact work (#831/#834), found while auditing `open-items.md`.

## Gap 1 — reordered constants didn't warn under legacy

The "no silent change" guarantee (Stage 1 in `open-items.md`) requires every v1 behaviour-change to **warn under legacy**. After #831 made a pure reorder **raise** under v1, most paths warned — but reordered *constant* operands slipped through:

| reorder case | legacy warned "v1 will raise"? (before) |
|---|---|
| `coeff * x`, `x + expr` (merge) | ✅ |
| `x + array`, `x - array`, `x * array`, `x / array`, `expr <= array` | ❌ |

The const/broadcast path silently *reindexes* a reordered constant **by label** under legacy (via `_reindex_reordered_dims`), so no mismatch was detected and no warning fired — while v1 raises. This introduced a silent legacy→v1 divergence.

**Fix:** a `warn_reorder` flag threaded `broadcast_to_coords → _reindex_reordered_dims`, set at the 6 arithmetic const/rhs call sites. When legacy conforms a reordered constant it now emits a `LinopySemanticsWarning` (new `_legacy_const_reorder_message`, accurately saying legacy *reindexes by label* — the const path is not positional like merge). The legacy **result is unchanged** (still reindex-by-label); coeff/merge keep their single existing warning (no double-warn); bounds/`mask=` (`strict=True` construction) stay silent, since there `coords` is the source of truth. Verified: every reorder path warns exactly once under legacy, raises under v1.

## Groupers — strict alignment now in the spec

`convention.md` covered operand alignment (§8) but said nothing about **grouper** alignment. Added a **Groupers** paragraph under §13: a `groupby` grouper aligns to the grouped dimension by §8 — a differing label set *or* a reorder raises, never positional matching or silent reindex (#827). Also notes multi-key groupers → flat `group` dim + key aux coords (stacked MultiIndex is legacy-only, §11).

The implementation is #830 (check-and-raise), already on `master`; it reaches this branch when master merges in. `open-items.md` now tracks that landing, records the §8-exact decision, and notes the reorder→raise transition-surface additions.

Full suite green; ruff/mypy clean.
