### PR TITLE
perf(v1): skip no-op reindex_like in Variable.to_linexpr

### DIFF
--- a/linopy/semantics.py
+++ b/linopy/semantics.py
@@ -365,6 +365,24 @@ def first_mismatched_dim(a: DataArray, b: DataArray) -> tuple[str, Any, Any] | N
     return None
 
 
+def reindex_like_if_needed(
+    arr: DataArray, ref: DataArray, fill_value: Any
+) -> DataArray:
+    """
+    ``arr.reindex_like(ref, fill_value=...)`` without the copy when already aligned.
+
+    ``broadcast_to_coords`` leaves an operand spanning ``ref``'s dims but with
+    fresh index objects (equal, not identical), so a plain ``reindex_like`` would
+    deep-copy the whole array to no effect on the exact-match hot path. Skip it
+    when every ``ref`` dim is present and ``first_mismatched_dim`` finds no
+    disagreement — the same shared-dim check the alignment rules use, so ``None``
+    means the reindex changes nothing.
+    """
+    if set(ref.dims) <= set(arr.dims) and first_mismatched_dim(ref, arr) is None:
+        return arr
+    return arr.reindex_like(ref, fill_value=fill_value)
+
+
 def conform_merge_dims(
     datasets: Sequence[Dataset], concat_dim: str
 ) -> tuple[list[Dataset], tuple[str, Any, Any] | None, tuple[str, Any, Any] | None]:

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -72,6 +72,7 @@ from linopy.semantics import (
     enforce_aux_conflict,
     first_mismatched_dim,
     is_v1,
+    reindex_like_if_needed,
     warn_legacy,
 )
 from linopy.types import (
@@ -368,7 +369,7 @@ class Variable:
             # arithmetic works. A dense variable has none, so the
             # mask/where/const collapse to no-ops (skipped below).
             has_absence = bool((self.labels == -1).any())
-            coefficient = coefficient.reindex_like(self.labels, fill_value=np.nan)
+            coefficient = reindex_like_if_needed(coefficient, self.labels, np.nan)
             if has_absence:
                 absent = self.labels == -1
                 coefficient = coefficient.where(~absent)
@@ -381,7 +382,7 @@ class Variable:
             has_absence = bool((self.labels == -1).any())
             if has_absence:
                 warn_legacy(_legacy_masked_variable_message(self.name))
-            coefficient = coefficient.reindex_like(self.labels, fill_value=0)
+            coefficient = reindex_like_if_needed(coefficient, self.labels, 0)
             coefficient = coefficient.fillna(0)
         ds = Dataset({"coeffs": coefficient, "vars": self.labels}).expand_dims(
             TERM_DIM, -1


### PR DESCRIPTION
_TODO: your own intent/motivation here._

> [!NOTE]
> The following content was generated by AI.

## The regression

CodSpeed flagged one benchmark, and only one:

| Mode | Benchmark | BASE (master) | HEAD | Δ |
|---|---|---|---|---|
| Memory | `test_op[var_mul_array_match]` | 212.3 KB | 306.1 KB | −30.6% |

Measured locally (memray, GRID 3×4×1000, legacy = CodSpeed default), the
regression is isolated to that single op — every other var/expr op is
byte-identical to master:

| op | master | branch (before) |
|---|---|---|
| var_mul_scalar | 209.2 | 209.2 |
| **var_mul_array_match** | **217.0** | **310.8** |
| var_mul_array_bcast | 998.1 | 998.1 |
| var_add_array_match | 390.6 | 390.7 |

## Root cause

The new alignment module leaves `broadcast_to_coords(coeff, coords=self.coords)`
spanning the variable's dims but carrying **fresh index objects** — equal to
`self.labels`'s indexes, not the same object. The next line,
`coefficient.reindex_like(self.labels)`, then deep-copies the entire
coefficient (one full float64 array, ~94 KiB here) to produce a byte-identical
result. On old master the coefficient shared `labels`'s index, so the same
`reindex_like` short-circuited.

It only shows on `var_mul_array_match` because that is the one path where the
coefficient is already exactly aligned — for scalar and broadcast operands the
reindex/broadcast does real work either way.

## Fix

`reindex_like_if_needed(arr, ref, fill_value)` skips the copy when every `ref`
dim is present and `first_mismatched_dim` (the shared-dim index check the
alignment rules already use) reports no disagreement. A reordered or subset
coefficient still reindexes — legacy aligns, v1 raises §8 — so behavior is
unchanged; only the redundant copy is dropped.

## Measurements (memray)

| op | before | after | master |
|---|---|---|---|
| var_mul_array_match (legacy) | 310.8 | **217.0** | 217.0 |
| var_mul_array_bcast (legacy) | 998.1 | **593.3** | 998.1 |
| var_mul_array_match (v1) | 187.6 | **106.4** | — |
| var_mul_array_bcast (v1) | 469.9 | **124.0** | — |

Legacy `var_mul_array_match` is back to exact master parity; the redundant
reindex was also inflating the broadcast path, so that improves too.

## Tests

Full suite passes under both semantics: **7813 passed, 605 skipped**
(`pytest test/`). Aligned coeff skips the reindex; reordered/subset coeff
still reindexes (legacy `[10, 0, 20, 0]`, v1 raises `ValueError`).

Stacks on #836 (which fixed the v1 side of `to_linexpr`).
