### PR TITLE
fix(v1): warn on legacy multi-key groupby MultiIndex; suggest reset_index

### DIFF
--- a/arithmetics-design/open-items.md
+++ b/arithmetics-design/open-items.md
@@ -33,7 +33,10 @@ here ([`goals.md`] step 1: *warn on legacy, raise on v1*).
   MultiIndex rejects and the multi-key-`groupby`-flat change as new fork sites.
   The reorder→raise change ([#831]) added its own fork sites: reordered constant
   operands now warn under legacy (they were silently reindexed) — done for
-  `+`/`-`/`*`/`/`/rhs; still verify no other reorder-reindex path stays silent.
+  `+`/`-`/`*`/`/`/rhs. A full audit (probe every §'s legacy→v1 divergence)
+  found one remaining silent site: `groupby([names]).sum(observed=True)` minted
+  the `group` MultiIndex without warning (only DataFrame groupers warned) — now
+  fixed. No other silent fork site found.
 - [ ] **Land grouper strict alignment on the branch** — [#827]'s fix ([#830],
   check-and-raise on a reordered/mismatched grouper) is on `master`; it reaches
   #717 when master merges in. The **Groupers** rule in [`convention.md`] §13

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -296,7 +296,6 @@ def _restore_multikey_index(
     ds: Dataset,
     decode: tuple[dict, pd.Index],
     stacked_survives: bool,
-    user_facing: bool,
 ) -> Dataset:
     """
     Rebuild the multi-key group labels encoded by _encode_multikey_group.
@@ -304,8 +303,9 @@ def _restore_multikey_index(
     Under v1 semantics a stacked result that survives (``stacked_survives``)
     keeps a flat group dimension with the key values as auxiliary coordinates.
     Otherwise the keys become a MultiIndex — either because the caller unstacks
-    it right after, or under legacy semantics, where a ``user_facing`` frame
-    grouper additionally warns about the deprecated MultiIndex result.
+    it right after (``stacked_survives`` is False), or under legacy semantics,
+    where a *surviving* ``group`` MultiIndex additionally warns about the
+    deprecated result, whichever grouper minted it.
     """
     int_map, columns = decode
     index = ds.indexes[GROUP_DIM].map({v: k for k, v in int_map.items()})
@@ -316,7 +316,7 @@ def _restore_multikey_index(
         return ds.assign_coords(
             {n: (GROUP_DIM, index.get_level_values(n)) for n in level_names}
         )
-    if user_facing:
+    if stacked_survives:  # legacy: the group MultiIndex survives into the result
         warn_legacy(_legacy_group_multiindex_message(level_names))
     return ds.assign_coords(Coordinates.from_pandas_multiindex(index, GROUP_DIM))
 
@@ -471,7 +471,6 @@ class LinearExpressionGroupby:
                     ds,
                     multikey_decode,
                     stacked_survives=multikey_frame is None or observed,
-                    user_facing=multikey_frame is None,
                 )
 
             ds = ds.rename({GROUP_DIM: final_group_name})

--- a/linopy/semantics.py
+++ b/linopy/semantics.py
@@ -233,13 +233,15 @@ def _legacy_group_multiindex_message(level_names: list[str]) -> str:
     """A multi-key groupby returns a stacked ``group`` MultiIndex under legacy."""
     levels = ", ".join(repr(n) for n in level_names)
     return (
-        f"A groupby with a frame grouper returned a stacked `group` MultiIndex over"
+        f"A multi-key groupby returned a stacked `group` MultiIndex over"
         f" ({levels})."
         " Under legacy the `group` dim is that MultiIndex, so `.sel(group=(...))` by"
         " tuple works. Under v1 the `group` dim is flat with those keys as ordinary"
         f" aux coords instead — select via `.groupby`/`.where` on {levels}, not a"
         " level tuple."
-        f"\n  Resolve:   replace `.sel(group=(...))` with selection on the"
+        f"\n  Convert:   `.reset_index('group')` turns this result into the v1"
+        f" flat `group` dim + {levels} aux coords."
+        f"\n  Resolve:   then replace `.sel(group=(...))` with selection on the"
         f" {levels} aux coord(s)." + _OPT_IN_HINT
     )
 

--- a/test/test_linear_expression.py
+++ b/test/test_linear_expression.py
@@ -26,6 +26,7 @@ from linopy import (
     QuadraticExpression,
     Variable,
     merge,
+    options,
 )
 from linopy.constants import HELPER_DIMS, TERM_DIM
 from linopy.expressions import ScalarLinearExpression
@@ -1480,6 +1481,42 @@ class TestMultiKeyFastPath:
         assert {"period", "season"} <= set(grouped.data.coords)
         assert grouped.sizes["group"] == 3
 
+    @pytest.mark.legacy
+    def test_namelist_observed_warns_legacy(self) -> None:
+        # `groupby([names]).sum(observed=True)` keeps the stacked `group` MI under
+        # legacy exactly like a DataFrame grouper — so it must warn too (v1 gives
+        # a flat dim, a silent divergence otherwise).
+        expr = self._expr([2020, 2020, 2030, 2030], list("wwws"))
+        with pytest.warns(LinopySemanticsWarning, match=r"stacked `group` MultiIndex"):
+            grouped = expr.groupby(["period", "season"]).sum(observed=True)
+        assert isinstance(grouped.data.indexes["group"], pd.MultiIndex)
+
+    @pytest.mark.v1
+    def test_namelist_observed_flat_v1(self) -> None:
+        expr = self._expr([2020, 2020, 2030, 2030], list("wwws"))
+        grouped = expr.groupby(["period", "season"]).sum(observed=True)
+        assert not isinstance(grouped.data.indexes["group"], pd.MultiIndex)
+        assert {"period", "season"} <= set(grouped.data.coords)
+
+    @pytest.mark.legacy
+    def test_group_multiindex_reset_index_matches_v1(self) -> None:
+        # The warning tells legacy users `.reset_index('group')` yields the v1
+        # shape — pin that it produces exactly the v1 flat result (same expr, so
+        # variable labels line up).
+        expr = self._expr([2020, 2020, 2030, 2030], list("wwws"))
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            legacy_mi = expr.groupby(["period", "season"]).sum(observed=True)
+        converted = legacy_mi.reset_index("group")
+        prev = options["semantics"]
+        try:
+            options["semantics"] = "v1"
+            v1_flat = expr.groupby(["period", "season"]).sum(observed=True)
+        finally:
+            options["semantics"] = prev
+        assert not isinstance(converted.data.indexes["group"], pd.MultiIndex)
+        assert_linequal(converted, v1_flat)
+
     def test_blowup_warns_when_sparse(self) -> None:
         # 200 observed combos, 200x200 grid -> nudge toward observed=True
         expr = self._expr(list(range(200)), list(range(200)))
@@ -1508,10 +1545,14 @@ class TestMultiKeyFastPath:
     def test_observed_silences_blowup_warning(self) -> None:
         expr = self._expr(list(range(200)), list(range(200)))
 
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")
+        # ``observed=True`` silences the dense-grid blowup warning; under legacy
+        # it still emits the deprecated-`group`-MultiIndex warning, which is not
+        # what this test is about, so assert on the blowup warning specifically.
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter("always")
             grouped = expr.groupby(["period", "season"]).sum(observed=True)
 
+        assert not any("dense" in str(w.message) for w in record)
         assert grouped.sizes["group"] == 200
 
     def test_observed_with_fallback_raises(self) -> None:


### PR DESCRIPTION
<!-- TODO(@FBumann): replace this line with your own intent/motivation, in your own words. -->

> [!NOTE]
> The following was generated by AI.

Found by working through `open-items.md` — the **transition-surface completeness audit** (Stage 1: every v1 behaviour-change must warn under legacy, the "no silent change" guarantee).

## Audit

Probed every convention §'s legacy→v1 divergence under legacy and checked a `LinopySemanticsWarning` fires: §5 user-NaN (`+`/`*`), §6 masked variable through every operator + comparison, §8 set-mismatch / reorder (const, merge, coeff, rhs `<=`/`>=`/`==`), §11 aux-coord conflict, §12 RHS NaN, #803 MultiIndex construction, unlabeled ambiguous pairing, multi-key groupby. **All warned except one.**

## The gap

`groupby([names]).sum(observed=True)` mints a stacked `group` **MultiIndex** under legacy (v1 returns a flat `group` dim + key aux coords) but emitted **no warning** — only the *DataFrame*-grouper spelling of the same operation warned:

| grouper | `observed` | legacy | warned? |
|---|---|---|---|
| `groupby(df)` | any | MultiIndex | ✅ |
| `groupby([names])` | `False` | flat (unstacked) | — (no MI) |
| **`groupby([names])`** | **`True`** | **MultiIndex** | **❌ → now ✅** |

So a legacy model doing `groupby(["country","carrier"]).sum(observed=True)` and consuming `.sel(group=(...))` would break under v1 with no deprecation notice — exactly the PyPSA-Eur CCL pattern.

## Fix

`_restore_multikey_index` gated the warning on `user_facing` (DataFrame groupers only). The correct condition is "legacy keeps a *surviving* `group` MultiIndex" — `stacked_survives and not is_v1()`, which the code already reaches only under legacy. Dropped the `user_facing` parameter; reworded the message ("multi-key groupby", not "frame grouper").

**The warning now hands the user a robust one-line migration.** `.reset_index("group")` on the legacy MI result yields *exactly* the v1 flat `group` dim + aux coords — verified by `assert_linequal(legacy_mi.reset_index("group"), v1_flat)` built from the same expression. The message includes it as a `Convert:` line.

Tests: namelist+`observed` warn/flat, the `reset_index → v1` migration equivalence, and scoped `test_observed_silences_blowup_warning` to the blowup warning specifically (it had used a blanket `simplefilter("error")`).

`open-items.md` records the audit and that no other silent fork site remains.

Full suite green; ruff/mypy clean.
