### PR TITLE
docs: changelog entry for opt-in v1 arithmetic semantics

### DIFF
--- a/arithmetics-design/open-items.md
+++ b/arithmetics-design/open-items.md
@@ -37,13 +37,12 @@ here ([`goals.md`] step 1: *warn on legacy, raise on v1*).
   found one remaining silent site: `groupby([names]).sum(observed=True)` minted
   the `group` MultiIndex without warning (only DataFrame groupers warned) — now
   fixed. No other silent fork site found.
-- [ ] **Land grouper strict alignment on the branch** — [#827]'s fix ([#830],
-  check-and-raise on a reordered/mismatched grouper) is on `master`; it reaches
-  #717 when master merges in. The **Groupers** rule in [`convention.md`] §13
-  documents the target; until #830 lands here the fast path still matches a
-  reordered grouper positionally.
-- [ ] Changelog note — v1 available via `options['semantics'] = 'v1'`; legacy
-  remains the default; link [`convention.md`].
+- [x] **Land grouper strict alignment on the branch** — [#830]'s
+  check-and-raise on a reordered/mismatched grouper is merged in. The
+  **Groupers** rule in [`convention.md`] §13 documents the behaviour.
+- [x] Changelog note — v1 opt-in via `options['semantics'] = 'v1'` (legacy
+  remains the default), with the strict-alignment / absence / user-NaN /
+  aux-coord / MultiIndex summary and a link to [`convention.md`].
 
 ## Stage 2 — make v1 the default (legacy opt-out)
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -7,6 +7,18 @@ Upcoming Version
 **Features**
 
 
+*Strict "v1" arithmetic semantics (opt-in)*
+
+* A new, stricter convention for how linopy arithmetic aligns coordinates and treats missing data is available behind ``linopy.options["semantics"] = "v1"``. Legacy behaviour remains the **default** in this release; v1 is opt-in. In short, under v1:
+
+  * shared dimensions align by label with ``join="exact"`` — a differing label set *or* a pure reorder (same labels, different order) raises instead of silently filling, dropping, or pairing by position. Resolve explicitly with ``.sel`` / ``.reindex`` / ``.assign_coords``, or pass an explicit ``join=`` to the named ``.add`` / ``.sub`` / ``.mul`` / ``.div`` / ``.le`` / ``.ge`` / ``.eq`` methods.
+  * a ``NaN`` in a user-supplied constant raises, rather than being silently filled (with a value that used to differ per operator).
+  * *absence* — masked, reindexed, or shifted-in slots — is a first-class state that propagates through every operator, instead of collapsing to zero.
+  * conflicting auxiliary coordinates raise, instead of being silently dropped.
+  * a first-class ``pd.MultiIndex`` dimension is rejected in favour of a flat dimension with the levels as auxiliary coordinates.
+
+* Every operation whose result changes under v1 emits a ``LinopySemanticsWarning`` under legacy, naming the fix — so a model can be migrated incrementally before opting in. The full rules are specified in `the arithmetic convention <https://github.com/PyPSA/linopy/blob/master/arithmetics-design/convention.md>`_.
+
 *In-place solver updates (persistent re-solve)*
 
 * A built solver can now be re-solved against a mutated ``Model`` without a full rebuild. Construct with ``Solver.from_name(..., track_updates=True)`` and re-call ``solver.solve(model)`` after edits — the diff against the previous build is applied in place when the backend supports it, falling back to a rebuild otherwise. Supported on HiGHS, Gurobi, Xpress, and Mosek (``io_api="direct"``).


### PR DESCRIPTION
<!-- TODO(@FBumann): your intent in your own words. -->

> [!NOTE]
> Generated by AI.

Open-items.md item **"Changelog note"**. Adds a **Features** entry announcing the opt-in v1 arithmetic semantics — `linopy.options["semantics"] = "v1"`, legacy stays the default — summarising what changes (exact label alignment / reorder raises, user-NaN raises, absence as a first-class state, aux-coord conflicts raise, MultiIndex rejected) and noting the legacy `LinopySemanticsWarning` migration path. Links the convention doc.

Also ticks off the changelog and grouper-landing (#830 merged) items in `open-items.md`.

Docs-only; rST validated with docutils (no structural warnings).