### PR TITLE
docs: add v1 migration guide

### DIFF
--- a/arithmetics-design/docs-plan.md
+++ b/arithmetics-design/docs-plan.md
@@ -1,5 +1,8 @@
 # Docs plan — user-facing migration guide
 
+**Done:** the guide now lives at `doc/migrating-to-v1.rst`. This file is kept
+as the outline it was written from.
+
 Early-stage outline for the v1 migration docs. Not the guide itself —
 the three pieces it needs to cover, written when someone picks it up.
 

--- a/arithmetics-design/open-items.md
+++ b/arithmetics-design/open-items.md
@@ -47,7 +47,9 @@ here ([`goals.md`] step 1: *warn on legacy, raise on v1*).
 
 ## Stage 2 — make v1 the default (legacy opt-out)
 
-- [ ] Write the **migration guide** ([`docs-plan.md`] is only an outline).
+- [x] Write the **migration guide** — `doc/migrating-to-v1.rst` (why v1, the
+  opt-in→default→1.0 rollout, the three audiences, the surface-warnings-then-fix
+  recipe, and a situation→v1→fix table). [`docs-plan.md`] was the outline.
 - [ ] Flip the `options['semantics']` default to v1.
 - [ ] Close [#714] once v1 ships as default.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -113,6 +113,7 @@ This package is published under MIT license.
    creating-expressions
    creating-constraints
    coordinate-alignment
+   migrating-to-v1
    manipulating-models
 
 .. toctree::

--- a/doc/migrating-to-v1.rst
+++ b/doc/migrating-to-v1.rst
@@ -1,0 +1,138 @@
+Migrating to the v1 arithmetic convention
+=========================================
+
+.. note::
+
+   v1 is **opt-in** in this release and legacy remains the default. Nothing
+   changes until you set ``linopy.options["semantics"] = "v1"``. This guide is
+   for deciding *when* to opt in and *what* to change when you do.
+
+Why v1 exists
+-------------
+
+Legacy linopy silently guessed in three situations where a guess can quietly
+change a model:
+
+- a ``NaN`` in user-supplied data was filled — with a value that differed by
+  operator (``0`` for ``+``/``*``, ``1`` for ``/``);
+- a coordinate mismatch on a shared dimension was resolved by position or an
+  inner join, which can drop terms and constraints without notice;
+- an absent (masked, reindexed, or shifted-in) variable was treated as a
+  variable fixed to zero.
+
+The v1 convention replaces every silent guess with an explicit rule: it aligns
+strictly by label and *raises* where legacy would have guessed, so a wrong model
+surfaces as an error at build time instead of a wrong number at solve time. The
+per-case bug catalogue is in `issue #714 <https://github.com/PyPSA/linopy/issues/714>`_.
+
+The rollout
+-----------
+
+The transition happens over three steps so that no model changes behaviour
+without warning first:
+
+#. **Now — opt-in.** v1 is available via ``linopy.options["semantics"] = "v1"``.
+   Legacy is the default. Under legacy, every operation whose result *would*
+   change under v1 emits a :class:`linopy.LinopySemanticsWarning` that names the
+   rule and the fix.
+#. **A later minor release — default.** v1 becomes the default; legacy stays
+   reachable via ``options["semantics"] = "legacy"`` for one more cycle.
+#. **linopy 1.0 — legacy removed.** Only v1 remains.
+
+Who this affects
+----------------
+
+- **Downstream library maintainers** (PyPSA, PyPSA-Eur, Calliope, …) carry most
+  of the work: opt the library into v1, fix the raises, and release so it no
+  longer warns under legacy.
+- **Direct linopy users** do the same for their own call sites.
+- **End users of a downstream library** never touch linopy directly. A
+  ``LinopySemanticsWarning`` in your logs is an upstream item your maintainer
+  will handle; you can :ref:`silence it <silencing-v1>` in the meantime.
+
+How to migrate
+--------------
+
+The legacy warning already names the rule and the fix at every site, so the
+recipe is short:
+
+#. **Surface every site.** Run your existing test suite under legacy and turn
+   the warning into an error so nothing is missed:
+
+   .. code-block:: python
+
+       import warnings
+       from linopy import LinopySemanticsWarning
+
+       warnings.filterwarnings("error", category=LinopySemanticsWarning)
+
+#. **Fix each site** using the table below (the warning text points at the same
+   fix in context).
+#. **Opt in and run the suite** with ``linopy.options["semantics"] = "v1"``. The
+   v1 raises catch anything the warnings missed.
+#. **Release.** Set the option in your library's entry point, or simply drop it
+   once the default flips to v1.
+
+What changes, and how to fix it
+-------------------------------
+
+Every row is a legacy guess that becomes an explicit rule under v1. The
+``LinopySemanticsWarning`` you see under legacy names the same fix.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 40 38
+
+   * - Situation
+     - Under v1
+     - Fix
+   * - ``NaN`` in a user-supplied constant
+     - Raises (linopy will not guess a fill).
+     - ``.fillna(value)`` for a data error; ``mask=`` / ``.where(cond)`` /
+       ``.reindex(...)`` on the *variable* for intended absence.
+   * - Shared dimension with a **different label set**
+     - Raises instead of an inner/positional join.
+     - ``.sel`` / ``.reindex`` to a common index, ``.assign_coords`` to relabel,
+       or an explicit ``join=`` on ``.add`` / ``.sub`` / ``.mul`` / ``.div`` /
+       ``.le`` / ``.ge`` / ``.eq``.
+   * - Shared dimension with the **same labels in a different order**
+     - Raises (``join="exact"`` — no silent reindex).
+     - ``.sortby(dim)`` / ``.reindex`` one side to match, or a reindexing
+       ``join=`` (``"outer"`` / ``"inner"`` / ``"left"`` / ``"right"``).
+   * - A **masked / absent** variable in arithmetic
+     - Absence propagates (the slot stays absent) instead of counting as ``0``.
+     - Decide the intent: ``.fillna(0)`` to keep the old "treat as zero", or
+       leave it to propagate and drop the term.
+   * - **Conflicting auxiliary coordinates** on a shared dim
+     - Raises instead of silently dropping one.
+     - ``.drop_vars(name)`` to remove the coord, or ``.assign_coords(name=...)``
+       to relabel one side.
+   * - A first-class ``pd.MultiIndex`` **dimension**
+     - Rejected; v1 uses a flat dimension with the levels as aux coords.
+     - ``.reset_index(dim)`` to flatten before building the model.
+   * - A multi-key ``groupby(...).sum()`` result
+     - A flat ``group`` dimension with the keys as aux coords (not a stacked
+       ``group`` MultiIndex).
+     - Select on the key aux coords; convert an existing result with
+       ``.reset_index("group")``.
+
+The full, normative rule list lives in the
+`arithmetic convention <https://github.com/PyPSA/linopy/blob/master/arithmetics-design/convention.md>`_.
+
+.. _silencing-v1:
+
+Silencing the warning
+---------------------
+
+If the warning comes from a library you do not maintain, silence it until the
+upstream release lands:
+
+.. code-block:: python
+
+    import warnings
+    import linopy
+
+    warnings.filterwarnings("ignore", category=linopy.LinopySemanticsWarning)
+
+Do this only when the warning is upstream — for your own call sites, fix it
+instead, since the underlying result changes under v1.


### PR DESCRIPTION
<!-- TODO(@FBumann): your intent / framing in your own words. -->

> [!NOTE]
> Generated by AI.

Open-items.md item **"Write the migration guide"** (was only an outline in `docs-plan.md`).

Adds `doc/migrating-to-v1.rst` (User Guide toctree):

- **Why v1** — the three silent legacy guesses (user-NaN fill, positional/inner coord alignment, absent-as-zero) and how v1 replaces each with a raise.
- **Rollout** — opt-in now → default later → legacy removed at 1.0, with the legacy `LinopySemanticsWarning` as the migration signal.
- **Three audiences** — downstream maintainers, direct users, end users.
- **Recipe** — turn `LinopySemanticsWarning` into an error to surface every site, fix per the table, opt in, release.
- **Situation → v1 → fix table** — user-NaN, label-set / reorder mismatch, masked-variable absence, aux-coord conflicts, MultiIndex dims, multi-key groupby (incl. the `.reset_index("group")` conversion).

Links the convention for the normative rules. Docs-only; rST validated with docutils (no structural warnings), blackdoc clean.

Since it's user-facing prose, the framing/voice is yours to adjust — I've left a handwritten-intent placeholder.