### PR TITLE
perf: make fill_missing_coords copy lazily (skip the no-op deep copy)

### DIFF
--- a/linopy/alignment.py
+++ b/linopy/alignment.py
@@ -354,16 +354,17 @@ def fill_missing_coords(
         Whether to fill in integer coordinates for helper dimensions, by default False.
 
     """
-    ds = ds.copy()
     if not isinstance(ds, Dataset | DataArray):
         raise TypeError(f"Expected xarray.DataArray or xarray.Dataset, got {type(ds)}.")
 
     skip_dims = [] if fill_helper_dims else HELPER_DIMS
+    missing = [d for d in ds.dims if d not in ds.coords and d not in skip_dims]
+    if not missing:
+        return ds
 
-    # Fill in missing integer coordinates
-    for dim in ds.dims:
-        if dim not in ds.coords and dim not in skip_dims:
-            ds.coords[dim] = arange(ds.sizes[dim])
+    ds = ds.copy()
+    for dim in missing:
+        ds.coords[dim] = arange(ds.sizes[dim])
 
     return ds
 


### PR DESCRIPTION
_TODO: your own intent/motivation here._

> [!NOTE]
> The following content was generated by AI.

Follow-up to #838. On that PR @coroa asked whether it's smarter to preserve
index object identity than to re-implement an xarray perf short-circuit. That
prompt was right to push on the approach — chasing it down, the reindex was
never the real cost.

## What's actually going on

Two facts settle it:

- xarray's `reindex_like` copies **regardless** of index object identity — a
  same-object index and an equal-but-distinct one cost the same. So preserving
  identity would not have helped.
- Old master pays that same reindex copy on `var_mul_array_match` and is still
  cheaper than the branch. The reindex is not the regression.

Bisecting the op, the extra full-size copy comes from `as_dataarray`, which
ends in `fill_missing_coords`:

```python
ds = ds.copy()                         # unconditional
for dim in ds.dims:
    if dim not in ds.coords ...:
        ds.coords[dim] = arange(...)   # the only mutation
```

The `.copy()` exists to protect that one `coords[dim] = ...` mutation. But it
runs on **every** call, so when all coords are already present (every
`var * array`, and most real inputs) it deep-copies the array and throws the
copy away. In `Variable.to_linexpr`, the §8 check `as_dataarray(coefficient)`
therefore copied the whole coefficient and held it live through reindex+fillna
— the remaining half of the `test_op[var_mul_array_match]` regression.

## Fix

Copy lazily: compute the missing dims first, copy (and mutate) only when there
is something to fill, otherwise return `ds` untouched. The copy still guards
the one mutation it ever performs; it just no longer fires when it changes
nothing. More general than a `to_linexpr`-local guard — every `as_dataarray` /
`fill_missing_coords` caller benefits.

## Measurements (memray, legacy default, GRID 3×4×1000)

| op | before (with #838) | after |
|---|---|---|
| var_mul_array_match | 217 | **123** |
| var_mul_array_bcast | 998 | **593** |

## Safety

The one behavioral change: `fill_missing_coords` / `as_dataarray` may now
return the input object (not a fresh copy) when nothing needs filling. Full
suite passes under both semantics — **7840 passed, 610 skipped** — so no
caller relied on the always-copy contract.
