### PR TITLE
fix(v1): don't warn on exactly-aligned @/dot under legacy (#849)

### DIFF
--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -860,22 +860,15 @@ class BaseExpression(ABC):
                 # LEGACY: remove at 1.0 — see arithmetics-design/legacy-removal.md.
                 # Legacy default: positional when sizes match, else left-join.
                 mismatch = first_mismatched_dim(self.const, other)
+                if mismatch is not None:
+                    warn_legacy(
+                        _legacy_coord_mismatch_message(
+                            "this operator's constant operand", *mismatch
+                        ),
+                        stacklevel=4,
+                    )
                 if other.sizes == self.const.sizes:
-                    if mismatch is not None:
-                        warn_legacy(
-                            _legacy_coord_mismatch_message(
-                                "this operator's constant operand", *mismatch
-                            ),
-                            stacklevel=4,
-                        )
                     return self.const, other.assign_coords(coords=self.coords), False
-                warn_legacy(
-                    _legacy_coord_mismatch_message(
-                        "this operator's constant operand",
-                        *(mismatch or (None, None, None)),
-                    ),
-                    stacklevel=4,
-                )
                 return (
                     self.const,
                     other.reindex_like(self.const, fill_value=fill_value),

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -858,7 +858,6 @@ class BaseExpression(ABC):
                 join = "exact"
             else:
                 # LEGACY: remove at 1.0 — see arithmetics-design/legacy-removal.md.
-                # Legacy default: positional when sizes match, else left-join.
                 mismatch = first_mismatched_dim(self.const, other)
                 if mismatch is not None:
                     warn_legacy(
@@ -867,13 +866,12 @@ class BaseExpression(ABC):
                         ),
                         stacklevel=4,
                     )
+                # Legacy default: positional when sizes match, else left-join.
                 if other.sizes == self.const.sizes:
-                    return self.const, other.assign_coords(coords=self.coords), False
-                return (
-                    self.const,
-                    other.reindex_like(self.const, fill_value=fill_value),
-                    False,
-                )
+                    aligned = other.assign_coords(coords=self.coords)
+                else:
+                    aligned = other.reindex_like(self.const, fill_value=fill_value)
+                return self.const, aligned, False
 
         if join == "override":
             # §10: ``override`` is the *explicit* form of the legacy

--- a/test/test_legacy_violations.py
+++ b/test/test_legacy_violations.py
@@ -173,6 +173,23 @@ class TestBroadcastNonSharedDim:
         result = x * bcast
         assert set(result.coeffs.dims) == {"time", "scenario", "_term"}
 
+    @pytest.mark.legacy
+    def test_matmul_exactly_aligned_shared_dim_is_silent(
+        self, x: Variable, unsilenced: None
+    ) -> None:
+        # #849 — the contracted "time" dim is identically aligned; the size
+        # difference is only the constant's own "cyc" dim, which broadcasts.
+        # v1 accepts this, so legacy must not warn about a coordinate mismatch.
+        c = xr.DataArray(
+            np.ones((5, 2)),
+            dims=["time", "cyc"],
+            coords={"time": x.coords["time"]},
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", LinopySemanticsWarning)
+            result = x @ c
+        assert set(result.const.dims) == {"cyc"}
+
 
 # =====================================================================
 # Coordinate-alignment intro — unlabeled operands pair by size (#736)


### PR DESCRIPTION
<!-- TODO(@FBumann): replace this line with your own intent/motivation. -->

Closes #849. Stacked on `feat/arithmetic-convention` (#717).

> [!NOTE]
> The following content was generated by AI.

## Problem

Under legacy semantics, the alignment path warned on `@` / `dot` **even when the operands are already exactly aligned** on the contracted dimension — a false positive, since v1 accepts the same expression and both produce identical results.

## Cause

`LinearExpression._align_constant` warned whenever the constant operand's size dict differed from the expression's. But a size difference can come purely from *disjoint* dims (in `x @ C`, the constant `C` carries its own contracted-out dim), which is ordinary broadcasting — not a shared-dim misalignment. `first_mismatched_dim` correctly returned `None`, yet the warn still fired.

## Fix

Warn only when `first_mismatched_dim` reports an actual shared-dim disagreement, mirroring the sizes-equal branch, and collapse the duplicated warn/branch into one.

Genuine divergences are unaffected: a same-size shared dim with different labels, or a reordered shared dim, still warn under legacy and raise under v1.

## Test

`TestBroadcastNonSharedDim::test_matmul_exactly_aligned_shared_dim_is_silent` — `x @ C` with an identically-aligned contracted dim raises no `LinopySemanticsWarning` under legacy.