### PR TITLE
fix(v1): make Variable.fillna(scalar) resolve absence under both conventions (#847, #848)

### DIFF
--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -1735,6 +1735,16 @@ class BaseExpression(ABC):
         -------
         linopy.LinearExpression or linopy.QuadraticExpression
             A new object with missing values filled with the given value.
+
+        Notes
+        -----
+        This fills ``NaN`` entries only. Under legacy semantics an absent slot
+        of a variable is already materialised as ``const = 0`` by the time it
+        reaches an expression, so there is no ``NaN`` here to fill and the value
+        is a no-op (under v1 absence is carried as ``NaN`` and is filled). To
+        resolve a variable's absent slots to a constant on both conventions, use
+        :meth:`Variable.fillna` (or resolve on the variable before
+        ``to_linexpr``), which still holds the absence labels.
         """
         value = _expr_unwrap(value)
         if isinstance(value, DataArray | np.floating | np.integer | int | float):

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -325,6 +325,8 @@ class Variable:
     def to_linexpr(
         self,
         coefficient: ConstantLike = 1,
+        *,
+        _warn_absence: bool = True,  # LEGACY: remove at 1.0 — gates the legacy absence warning
     ) -> expressions.LinearExpression:
         """
         Create a linear expression from the variables.
@@ -380,7 +382,7 @@ class Variable:
             # the origin of the most common legacy↔v1 divergence (masked
             # variables in arithmetic) that no other warn-site catches.
             has_absence = bool((self.labels == -1).any())
-            if has_absence:
+            if has_absence and _warn_absence:
                 warn_legacy(_legacy_masked_variable_message(self.name))
             coefficient = reindex_like_if_needed(coefficient, self.labels, 0)
             coefficient = coefficient.fillna(0)
@@ -1319,7 +1321,14 @@ class Variable:
             Value to fill the absent slots with.
         """
         if isinstance(fill_value, int | float | np.integer | np.floating):
-            return self.to_linexpr().fillna(fill_value)
+            if is_v1():
+                return self.to_linexpr().fillna(fill_value)
+            # LEGACY: remove at 1.0 — legacy to_linexpr marks absent const as 0
+            # (not NaN), so LinearExpression.fillna can't fill it and the fill is
+            # silently dropped. Place fill_value directly to match v1, and skip
+            # the absence warning fillna is itself the documented resolution for.
+            lin = self.to_linexpr(_warn_absence=False)
+            return lin.assign(const=lin.const.where(self.labels != -1, fill_value))
         return self.where(~self.isnull(), fill_value)
 
     def ffill(self, dim: str, limit: None = None) -> Variable:

--- a/test/test_legacy_violations.py
+++ b/test/test_legacy_violations.py
@@ -1359,13 +1359,27 @@ class TestFillnaResolves:
         assert not bool(result.isnull().values.any())
 
     @pytest.mark.legacy
-    def test_legacy_variable_fillna_numeric_is_noop(self, xs: Variable) -> None:
-        """Same no-op on the Variable path: the fill value is ignored."""
+    def test_legacy_variable_fillna_numeric_fills_like_v1(self, xs: Variable) -> None:
+        """
+        #848 — unlike the raw ``to_linexpr().fillna`` two-step above,
+        ``Variable.fillna`` still holds the absent (-1) labels, so it places
+        the fill value directly and honours it under legacy too, matching v1.
+        This is the single cross-convention form the migration relies on.
+        """
         from linopy import LinearExpression
 
         result = xs.fillna(42)
         assert isinstance(result, LinearExpression)
-        assert result.const.values[0] == 0.0
+        assert result.const.values[0] == 42.0
+
+    @pytest.mark.legacy
+    def test_legacy_variable_fillna_does_not_warn(
+        self, xs: Variable, unsilenced: None
+    ) -> None:
+        """#847 — the documented absence resolution must not itself warn."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", LinopySemanticsWarning)
+            xs.fillna(0)
 
     @pytest.mark.legacy
     def test_legacy_outer_fillna_then_add_double_counts(


### PR DESCRIPTION
<!-- TODO(@FBumann): replace this line with your own intent/motivation. -->

Closes #847, closes #848. Stacked on `feat/arithmetic-convention` (#717).

> [!NOTE]
> The following content was generated by AI.

## Problem

`Variable.fillna(<scalar>)` is the documented resolution for absent slots (from `shift`/`where`/`reindex`/`mask`), but under **legacy** it misbehaved two ways, so there was no single form valid under both conventions:

- **#847** — it *warned*. `fillna` calls `to_linexpr()`, whose legacy path emits the masked-variable `LinopySemanticsWarning`, even though `fillna` is the resolution that warning points to.
- **#848** — it silently *dropped the fill value*. Legacy `to_linexpr` marks absent `const` as `0` (not `NaN`), so the subsequent `LinearExpression.fillna` had nothing to fill: `fillna(5)` left `0` at absent slots while v1 put `5`.

## Fix

The v1 path already behaved correctly, so this is a pure **legacy workaround** (marked `LEGACY: remove at 1.0`):

- v1 stays the clean one-liner `self.to_linexpr().fillna(fill_value)`.
- under legacy, place the value at the `-1` labels directly and skip the absence warning (via a private `_warn_absence` flag on `to_linexpr`).

`var.shift(1).fillna(v)` is now a single form, **identical under both conventions** — same `vars`/`const`; only the immaterial phantom coefficient at `vars == -1` slots differs (dropped at solve time).

Note: the raw two-step `var.to_linexpr().fillna(v)` remains a legacy no-op — that low-level path has already overwritten absence with `0`. `Variable.fillna` is correct because it still holds the `-1` labels.

Cross-*release* (0.8.0) is intentionally out of scope: downstream requires the v1 release rather than a 0.8.x backport (a naive backport would be silently wrong for non-zero fills).

## Tests

- `test_legacy_variable_fillna_numeric_fills_like_v1` — legacy fill now lands (was pinned as a no-op).
- `test_legacy_variable_fillna_does_not_warn` — the documented resolution no longer warns.
- v1 counterparts unchanged.