### PR TITLE
fix(v1): NaN scalars of any float dtype, non-unique merge dims, dead-code cleanup

### DIFF
--- a/arithmetics-design/legacy-removal.md
+++ b/arithmetics-design/legacy-removal.md
@@ -11,7 +11,6 @@ source tree.
 ### `linopy/config.py`
 
 - Drop `LEGACY_SEMANTICS`, `V1_SEMANTICS`, `VALID_SEMANTICS` constants.
-- Drop `LEGACY_SEMANTICS_MESSAGE`.
 - Drop the `LinopySemanticsWarning` class.
 - Remove the `semantics` key from `options`. The option no longer exists;
   callers don't need to opt in.
@@ -53,8 +52,7 @@ source tree.
     propagation rule).
   - The trailing `if is_v1(): ds = absorb_absence(ds)` becomes
     unconditional.
-- Drop the `LinopySemanticsWarning` / `LEGACY_SEMANTICS_MESSAGE` imports
-  from `expressions.py`.
+- Drop the legacy `warn_legacy` message imports from `expressions.py`.
 
 ### `linopy/variables.py`
 

--- a/examples/piecewise-inequality-bounds.ipynb
+++ b/examples/piecewise-inequality-bounds.ipynb
@@ -36,17 +36,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import warnings\n",
-    "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "\n",
     "import linopy\n",
     "\n",
-    "linopy.options[\"semantics\"] = \"v1\"\n",
-    "\n",
-    "# Silence the evolving-API warning for cleaner tutorial output.\n",
-    "warnings.filterwarnings(\"ignore\", category=linopy.EvolvingAPIWarning)"
+    "linopy.options[\"semantics\"] = \"v1\""
    ]
   },
   {

--- a/examples/piecewise-linear-constraints.ipynb
+++ b/examples/piecewise-linear-constraints.ipynb
@@ -35,8 +35,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import warnings\n",
-    "\n",
     "import matplotlib.pyplot as plt\n",
     "import pandas as pd\n",
     "import xarray as xr\n",
@@ -44,9 +42,6 @@
     "import linopy\n",
     "\n",
     "linopy.options[\"semantics\"] = \"v1\"\n",
-    "\n",
-    "# Silence the evolving-API warning for cleaner tutorial output.\n",
-    "warnings.filterwarnings(\"ignore\", category=linopy.EvolvingAPIWarning)\n",
     "\n",
     "time = pd.Index([1, 2, 3], name=\"time\")\n",
     "\n",

--- a/linopy/config.py
+++ b/linopy/config.py
@@ -13,14 +13,6 @@ LEGACY_SEMANTICS = "legacy"
 V1_SEMANTICS = "v1"
 VALID_SEMANTICS = {LEGACY_SEMANTICS, V1_SEMANTICS}
 
-LEGACY_SEMANTICS_MESSAGE = (
-    "The 'legacy' semantics are deprecated and will be removed in "
-    "linopy 1.0. Set linopy.options['semantics'] = 'v1' to opt in "
-    "to the new behaviour, or silence this warning with:\n"
-    "  import warnings; warnings.filterwarnings("
-    "'ignore', category=LinopySemanticsWarning)"
-)
-
 
 class LinopySemanticsWarning(FutureWarning):
     """

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -100,6 +100,7 @@ from linopy.semantics import (
     conform_merge_dims,
     enforce_aux_conflict,
     first_mismatched_dim,
+    is_nan_scalar,
     is_v1,
     warn_legacy,
 )
@@ -936,7 +937,7 @@ class BaseExpression(ABC):
         # §6: absence propagates — self.const NaN stays NaN, no fillna(0).
         # §5: user NaN raised in check_user_nan; never reaches the math here.
         if np.isscalar(other) and join is None:
-            if isinstance(other, float) and np.isnan(other):
+            if is_nan_scalar(other):
                 check_user_nan()
             return self.assign(const=self.const + other)
         da = broadcast_to_coords(
@@ -964,7 +965,7 @@ class BaseExpression(ABC):
         # (additive identity) so missing data does not propagate through
         # arithmetic. ``check_user_nan`` only warns under legacy.
         if np.isscalar(other) and join is None:
-            if isinstance(other, float) and np.isnan(other):
+            if is_nan_scalar(other):
                 check_user_nan()
             return self.assign(const=self.const.fillna(0) + other)
         da = broadcast_to_coords(
@@ -1009,7 +1010,7 @@ class BaseExpression(ABC):
     ) -> Self:
         # §6: NaN in coeffs/const propagates through op (NaN * x = NaN).
         # §5: user NaN raised before we get here.
-        if isinstance(other, float) and np.isnan(other):
+        if is_nan_scalar(other):
             check_user_nan(op_kind=op_kind)
         factor = broadcast_to_coords(
             other, coords=self.coords, strict=False, warn_reorder=True
@@ -1042,7 +1043,7 @@ class BaseExpression(ABC):
     ) -> Self:
         # NaN values are silently filled with neutral elements before the op:
         # factor → fill_value (0 for mul, 1 for div), coeffs/const → 0.
-        if isinstance(other, float) and np.isnan(other):
+        if is_nan_scalar(other):
             check_user_nan(op_kind=op_kind)
         factor = broadcast_to_coords(
             other, coords=self.coords, strict=False, warn_reorder=True

--- a/linopy/semantics.py
+++ b/linopy/semantics.py
@@ -309,6 +309,19 @@ def is_v1() -> bool:
     return options["semantics"] == V1_SEMANTICS
 
 
+def is_nan_scalar(value: Any) -> bool:
+    """
+    True for a scalar float NaN of any dtype — Python ``float`` or any
+    ``np.floating`` (``np.float32`` / ``np.float16`` included).
+
+    ``np.float64`` subclasses ``float``, but ``np.float32`` does not, so an
+    ``isinstance(value, float)`` guard alone lets a ``np.float32('nan')`` slip
+    past the §5 user-NaN check on a scalar fast path. The float-type guard is
+    still required to keep ``np.isnan`` from raising on non-numeric scalars.
+    """
+    return isinstance(value, (float, np.floating)) and bool(np.isnan(value))
+
+
 def check_user_nan(*, op_kind: str = "add") -> None:
     """
     Enforce §5 for a user-supplied constant (scalar or array).
@@ -412,6 +425,10 @@ def conform_merge_dims(
     either under v1, and warns on either under legacy. Helper dims (``_term``,
     ``_factor``) and the concat dim are excluded; bare dimension indexes are
     compared, so auxiliary coords stay §11's job.
+
+    A non-unique shared index can't be resolved to a permutation (``get_indexer``
+    requires uniqueness), so it is classified as a *mismatch* rather than a
+    reorder — harmless, since both raise under v1 and warn under legacy.
     """
     datasets = list(datasets)
     if len(datasets) < 2:
@@ -433,7 +450,10 @@ def conform_merge_dims(
             ref, idx = indexed[0][d], indexed[i][d]
             if ref.equals(idx):
                 continue
-            positions = idx.get_indexer(ref) if len(idx) == len(ref) else None
+            # Non-unique index → mismatch (see docstring).
+            positions = (
+                idx.get_indexer(ref) if len(idx) == len(ref) and idx.is_unique else None
+            )
             if positions is not None and (positions >= 0).all():
                 if reorder is None:
                     reorder = (str(d), ref.values, idx.values)

--- a/test/test_legacy_violations.py
+++ b/test/test_legacy_violations.py
@@ -435,6 +435,19 @@ class TestUserNaNRaises:
             _OPS[op](x, float("nan"))
 
     @pytest.mark.v1
+    @pytest.mark.parametrize("op", ["add", "sub", "mul", "div"])
+    @pytest.mark.parametrize("dtype", [np.float64, np.float32, np.float16])
+    def test_nan_numpy_scalar_raises(self, x: Variable, op: str, dtype: type) -> None:
+        """
+        A numpy-scalar NaN must raise regardless of dtype. ``np.float32`` /
+        ``np.float16`` do not subclass Python ``float``, so the scalar
+        fast-path §5 check (``isinstance(other, float)``) used to miss them
+        and silently add/multiply NaN into the expression.
+        """
+        with pytest.raises(ValueError, match="NaN"):
+            _OPS[op](1 * x, dtype("nan"))
+
+    @pytest.mark.v1
     def test_pypsa_1683_inf_times_zero_raises(
         self, x: Variable, time: pd.RangeIndex
     ) -> None:
@@ -827,6 +840,35 @@ class TestExactAlignmentMerge:
         b = m.add_variables(coords=[pd.Index(["penalty", "costs"], name="e")], name="b")
         with pytest.raises(ValueError, match="Coordinate mismatch"):
             (1 * a) + (1 * b)
+
+    @pytest.mark.v1
+    def test_var_plus_var_duplicate_differing_labels_raises_cleanly(
+        self, m: Model
+    ) -> None:
+        """
+        A shared dim with non-unique labels can't be resolved to a
+        permutation, so ``conform_merge_dims`` must report a §8 mismatch
+        (clean ``Coordinate mismatch`` ValueError) rather than letting
+        ``Index.get_indexer`` surface an opaque ``InvalidIndexError``.
+        """
+        a = m.add_variables(coords=[pd.Index(["a", "a", "b"], name="d")], name="a")
+        b = m.add_variables(coords=[pd.Index(["a", "b", "b"], name="d")], name="b")
+        with pytest.raises(ValueError, match="Coordinate mismatch"):
+            a + b
+
+    @pytest.mark.legacy
+    def test_var_plus_var_duplicate_differing_labels_legacy_positional(
+        self, m: Model
+    ) -> None:
+        """
+        Legacy aligns duplicate-labelled shared dims positionally (as it did
+        before the merge check existed). The reorder-detection must not crash
+        it with an ``InvalidIndexError`` on the non-unique index.
+        """
+        a = m.add_variables(coords=[pd.Index(["a", "a", "b"], name="d")], name="a")
+        b = m.add_variables(coords=[pd.Index(["a", "b", "b"], name="d")], name="b")
+        result = a + b
+        assert result.sizes["d"] == 3
 
     @pytest.mark.v1
     def test_reordered_constants_raise(self, m: Model) -> None:


### PR DESCRIPTION
Follow-ups from reviewing #717.

<!-- Replace this line with your own intent before merging. -->

> [!NOTE]
> The following was generated by AI (Claude Opus 4.8), from a review of #717.

Three fixes, targeting the `feat/arithmetic-convention` branch:

**1. §5 user-NaN check missed non-`float64` numpy scalars.** The scalar fast paths in `_add_constant_*` / `_apply_constant_op_*` guarded with `isinstance(other, float)`. `np.float64` subclasses Python `float`, but `np.float32` / `np.float16` do not — so a `np.float32('nan')` scalar slipped past the check and was silently added/multiplied into the expression instead of raising (v1) / warning (legacy). Added `semantics.is_nan_scalar` (`float | np.floating`) and applied it at all four sites.

**2. `conform_merge_dims` crashed on a non-unique shared dim.** The reorder-vs-mismatch detection called `Index.get_indexer(ref)`, which raises `InvalidIndexError` on a non-unique index. This is a regression vs. `master`, where duplicate labels aligned positionally and succeeded. Guarded on `idx.is_unique`, so a non-unique differing index is reported as a §8 mismatch — legacy aligns positionally + warns (no crash), v1 raises the canonical `Coordinate mismatch` `ValueError` instead of the opaque one.

**3. Dead-code / stale-doc cleanup.** Removed the unused `LEGACY_SEMANTICS_MESSAGE` constant (config.py) and the obsolete `EvolvingAPIWarning` filter cells in the two piecewise example notebooks — those cells set `semantics="v1"` yet still filtered a warning that was renamed to `LinopySemanticsWarning` and no longer fires there.

**Tests:** added regression coverage for the NaN-scalar dtypes (`float64`/`float32`/`float16` × add/sub/mul/div) and the duplicate-label merge on both conventions.

Full suite passes under both semantics (7856 passed, 626 skipped); `ruff` and pre-commit clean.