### PR TITLE
docs(v1): fix §11 MultiIndex-level projection example

### DIFF
--- a/arithmetics-design/convention.md
+++ b/arithmetics-design/convention.md
@@ -210,10 +210,17 @@ position). An operand whose *dimension* names one of those levels — a
 per-`period` weighting meeting a `snapshot`-indexed expression — is a
 same-name conflict between a dimension and an auxiliary coordinate, and it
 raises like any other conflict of this section. There is no implicit
-projection; write it explicitly by selecting with the dimension's level
-values:
+projection. `snapshot` is a flat dimension carrying `period` and `timestep`
+as auxiliary coordinates (v1 rejects a first-class `pd.MultiIndex` dimension,
+so `expr.indexes["snapshot"]` is a flat index, not a `MultiIndex`). Map the
+per-`period` input onto `snapshot` through that coordinate — a plain array
+of one weight per position — then use it in the operation:
 
-    weights.sel(period=expr.indexes["snapshot"].get_level_values("period"))
+    # weights: pd.Series indexed by `period`; expr: indexed by `snapshot`
+    w = xr.DataArray(
+        weights.loc[expr.coords["period"].values].to_numpy(), dims="snapshot"
+    )
+    weighted = expr * w   # one constraint/term per snapshot, weighted by period
 
 An input that reconstructs the *entire* MultiIndex (all levels, every
 combination) is not a conflict — it is the same coordinate spelled

--- a/arithmetics-design/open-items.md
+++ b/arithmetics-design/open-items.md
@@ -61,7 +61,12 @@ here ([`goals.md`] step 1: *warn on legacy, raise on v1*).
   `grep "LEGACY: remove at 1.0"` marker. Dependency-ordered checklist in
   [`legacy-removal.md`].
 - [ ] Reframe [`convention.md`] / [`goals.md`] — drop the "v1"/legacy framing
-  once there is only one convention.
+  once there is only one convention. At this point [`convention.md`] also
+  **graduates into the rendered Sphinx docs** (add `myst-parser`, into the
+  toctree, internal `:doc:` cross-refs replacing the GitHub blob links in
+  `doc/migrating-to-v1.rst` and `doc/release_notes.rst`). Until then it stays a
+  design-record linked by URL — the rules are permanent but the transitional
+  framing would only be re-done, so rendering now is wasted effort.
 
 ## Not blocking (follow-ups)
 


### PR DESCRIPTION
Fixes a broken example in the v1 spec, found while polishing the migration guide (companion to #855). Part of the #717 spec-cleanup.

> [!NOTE]
> The following was generated by AI.

**§11 example can't run under v1.** The MultiIndex-level projection fix read:

```python
weights.sel(period=expr.indexes["snapshot"].get_level_values("period"))
```

Verified on the branch: v1 rejects a first-class `pd.MultiIndex` *dimension* at construction (`add_variables` raises `ValueError: ... does not support ... reset_index('snapshot')`), so `snapshot` is a flat dim with `period`/`timestep` as **aux coords** and `.indexes["snapshot"]` is a flat index — `.get_level_values(...)` fails. Replaced with the working aux-coord mapping (tested, coeffs `[1,1,1,10,10,10]`):

```python
# weights: Series indexed by `period`; expr: indexed by `snapshot`
w = xr.DataArray(weights.loc[expr.coords["period"].values].to_numpy(), dims="snapshot")
weighted = expr * w   # one term per snapshot, weighted by its period
```
The example now shows the full flow (map onto `snapshot`, then multiply) rather than dangling an unused intermediate.

**Placement note.** Also recorded in `open-items.md` that `convention.md` graduates into the rendered Sphinx docs at the 1.0 reframe (add `myst-parser`, toctree, internal cross-refs). Until then it stays a design-record linked by URL: the §1–§13 rules are permanent, but the transitional "v1-vs-legacy" framing would only be re-done, so rendering now is wasted effort. This reflects the repo's own Stage-3 plan (`goals.md` splits permanent *design* goals from temporary *transitioning* goals).
