### PR TITLE
docs(v1): cover the scalar-leftover-coord aux conflict (isel drop=True)

### DIFF
--- a/arithmetics-design/convention.md
+++ b/arithmetics-design/convention.md
@@ -202,6 +202,12 @@ conflict, which is the [#295] bug. The caller resolves it explicitly with
 `.drop_vars(name)` (remove the coord) or `.assign_coords(name=...)`
 (relabel one side).
 
+A common source is a *scalar* coordinate left behind by positional indexing:
+`x.isel(time=0)` drops `time` as a dimension but keeps it as a scalar coord
+(the first label), so a cyclic/boundary constraint like
+`x.isel(time=0) == x.isel(time=-1)` conflicts on `time` (first vs last). Drop
+it at the source with `.isel(..., drop=True)` / `.sel(..., drop=True)`.
+
 **Stacked MultiIndex dimensions.** A stacked MultiIndex dim (e.g. PyPSA's
 `(period, timestep)` `snapshot`) stores its *levels* as auxiliary
 coordinates — `period` and `timestep` are non-dimension coords on

--- a/doc/migrating-to-v1.rst
+++ b/doc/migrating-to-v1.rst
@@ -109,10 +109,14 @@ Every row is a legacy guess that becomes an explicit rule under v1. The
      - Absence propagates (the slot stays absent) instead of counting as ``0``.
      - Decide the intent: ``.fillna(0)`` to keep the old "treat as zero", or
        leave it to propagate and drop the term.
-   * - **Conflicting auxiliary coordinates** on a shared dim
+   * - **Conflicting auxiliary coordinates** on a shared dim — including a
+       leftover *scalar* coord from positional indexing (``x.isel(time=0)``
+       keeps ``time`` as a scalar coord, so a cyclic/boundary constraint like
+       ``x.isel(time=0) == x.isel(time=-1)`` sees ``time`` = first vs last)
      - Raises instead of silently dropping one.
-     - ``.drop_vars(name)`` to remove the coord, or ``.assign_coords(name=...)``
-       to relabel one side.
+     - ``.drop_vars(name)`` / ``.assign_coords(name=...)``; for a leftover index
+       coord, drop it at the source with ``.isel(..., drop=True)`` /
+       ``.sel(..., drop=True)``.
    * - A first-class ``pd.MultiIndex`` **dimension** — and a per-*level* input
        onto it (e.g. per-``period`` bounds onto a ``(period, timestep)``
        ``snapshot``)


### PR DESCRIPTION
Documents a v1 aux-coord conflict that's easy to hit and easy to miss. Part of the #717 migration-doc pass.

Same v1 rule as #791 (`x[0] + x[1]` / summing scalar selections), closed COMPLETED as *intended* (legacy warns about it). This PR documents the comparison form and the `drop=True` fix.

> [!NOTE]
> The following was generated by AI.

**The case.** Positional indexing leaves a *scalar* coordinate behind: `x.isel(time=0)` drops `time` as a dimension but keeps it as a scalar coord (the first label). So a **cyclic/boundary constraint** — very common in storage/energy models —

```python
x.isel(time=0) == x.isel(time=-1)
```

hits §11's auxiliary-coordinate conflict under v1 (`time` = first vs last) and **raises**, where legacy silently dropped it. Verified on the branch:

```
v1:     ValueError: Auxiliary coordinate 'time' has conflicting values across operands: left=0, right=3
legacy: builds silently
fix:    x.isel(time=0, drop=True) == x.isel(time=-1, drop=True)   # builds under v1
```

**Why a doc change.** The existing "Conflicting auxiliary coordinates" row *technically* covered it (the raise even says "Auxiliary coordinate"), but it listed only `.drop_vars` / `.assign_coords` and didn't name the scalar-leftover cause — so a user comparing two `.isel` endpoints wouldn't connect their error to that row, nor reach for the natural fix (`drop=True` at the indexing site).

- `doc/migrating-to-v1.rst` — broadened the aux-coord row (situation names the scalar-leftover case; fix adds `.isel/.sel(..., drop=True)`)
- `arithmetics-design/convention.md` §11 — same note

Independent of #855/#856 (different regions of both files); should merge cleanly alongside them.
