### PR TITLE
fix(packaging): ship linopy.remote and linopy.persistent in the wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ solvers = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["linopy"]
+include = ["linopy", "linopy.*"]
 
 [tool.setuptools.package-data]
 "linopy" = ["py.typed"]


### PR DESCRIPTION
Closes #864.

> [!NOTE]
> The following content was generated by AI and verified locally.

`[tool.setuptools.packages.find]` include patterns are exact per level, so `include = ["linopy"]` matched only the top-level package and dropped `linopy.remote` and `linopy.persistent` from built wheels.

This is worse than latent: `linopy/__init__.py` does an unconditional `from linopy.remote import RemoteHandler`, so `import linopy` fails outright on a clean wheel install. It doesn't surface in development because editable/source installs expose the whole tree regardless.

**Fix:** add `"linopy.*"` so subpackages are discovered.

```diff
 [tool.setuptools.packages.find]
-include = ["linopy"]
+include = ["linopy", "linopy.*"]
```

<details>
<summary>Verification (uv build wheel contents)</summary>

Before (`include = ["linopy"]`):
```
find_packages(where=".", include=["linopy"]) -> ['linopy']
```

After, the built wheel ships both subpackages:
```
linopy/persistent/__init__.py
linopy/persistent/diff.py
linopy/persistent/errors.py
linopy/persistent/snapshot.py
linopy/remote/__init__.py
linopy/remote/oetc.py
linopy/remote/ssh.py
```
</details>