### PR TITLE
bench(ops): add matmul micro-benchmarks (dense vs sparse operand)

### DIFF
--- a/benchmarks/ops.py
+++ b/benchmarks/ops.py
@@ -108,6 +108,37 @@ def cond(profile: Profile) -> xr.DataArray:
     return array(profile) > 0.0
 
 
+# the contraction dim for `expr @ M` — M spans (last profile dim × c), KVL-style
+CONTRACT_DIM = "c"
+CONTRACT_LEN = 100
+
+
+def contraction_matrix(profile: Profile, density: float = 1.0) -> xr.DataArray:
+    """
+    A matrix contracting the profile's last (large) dim, with the given
+    fraction of nonzero (±1) entries per column. The default is fully dense;
+    ``density=0.003`` matches a cycle-incidence matrix (~3 of 1000 branches
+    per cycle, #748).
+    """
+    last, n = profile.dims[-1], profile.shape[-1]
+    if density == 1.0:
+        values = np.linspace(-1.0, 1.0, n * CONTRACT_LEN).reshape(n, CONTRACT_LEN)
+    else:
+        per_column = max(1, round(density * n))
+        values = np.zeros((n, CONTRACT_LEN))
+        cols = np.repeat(np.arange(CONTRACT_LEN), per_column)
+        rows = np.arange(cols.size) * 37 % n
+        values[rows, cols] = np.where(np.arange(cols.size) % 2, 1.0, -1.0)
+    return xr.DataArray(
+        values,
+        dims=[last, CONTRACT_DIM],
+        coords={
+            last: pd.RangeIndex(n, name=last),
+            CONTRACT_DIM: pd.RangeIndex(CONTRACT_LEN, name=CONTRACT_DIM),
+        },
+    )
+
+
 def masked_expr(profile: Profile) -> linopy.LinearExpression:
     """An expression carrying absence (§4) — masked in place."""
     return expr(profile).where(cond(profile))
@@ -260,6 +291,21 @@ register_op(
     "expr_arith",
     lambda p: (expr(p), extra_array(p)),
     lambda e, a: a * e,
+)
+
+# matmul / contraction (#748) — `dense` measures the full-`_term` kernel;
+# `sparse` (0.3% nonzero, incidence-shaped) is what a sparse-aware kernel collapses
+register_op(
+    "expr_matmul_dense",
+    "matmul",
+    lambda p: (expr(p), contraction_matrix(p)),
+    lambda e, mat: e @ mat,
+)
+register_op(
+    "expr_matmul_sparse",
+    "matmul",
+    lambda p: (expr(p), contraction_matrix(p, density=0.003)),
+    lambda e, mat: e @ mat,
 )
 
 # reductions


### PR DESCRIPTION
We are not yet tracking sparse matmul in the ops. To optimize it, im adding a baseline benchmark here.

Sorry for the churn. I wanted to keep it in the kvl benchmark, but It regressed with matmul, so decided to keep the existing one.

> [!NOTE]
> The following content was generated by AI (Claude Code), prompted and reviewed by @FBumann.

The suite has no benchmark exercising `@`/`dot`: the `kvl_cycles` pattern — written to show what a sparse-aware matmul would win (#748) — builds its constraint via the expanded `(flow * C).sum("branch")`, which bypasses `__matmul__` entirely, and `ops.py` has no contraction op. A sparse-aware kernel (#867) would land invisible to CI.

An earlier revision of this PR switched `kvl_cycles` itself to the `@` operator, but that surfaced as a flat +31% memory "regression" across all severities: on the current kernel, `Variable.__matmul__` goes through `to_linexpr()` (ones coefficients) plus a full-size multiply, allocating an extra `(time × branch × cycle)` float64 temporary that the expansion avoids. Real information about the `@` idiom's current cost, but the wrong place to change measurement history — so instead this adds a dedicated **matmul op group** to `ops.py`, following the suite's own op-vs-pattern philosophy ("an op benchmark says *which path* got heavier"):

- `expr_matmul_dense` — fully nonzero (1000 × 100) operand; stays on the dense kernel, guards it.
- `expr_matmul_sparse` — incidence-shaped operand at 0.3% density (the #748 KVL case, ~3 of 1000 entries per column); flat today, collapses under a sparse-aware kernel.

New ops carry no CodSpeed history, so no existing baseline moves and nothing is flagged. `kvl_cycles` is untouched. Landing this **before** #867 gives that PR a proper baseline: its CodSpeed run should show `expr_matmul_sparse` dropping sharply while `expr_matmul_dense` stays put.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
