### PR TITLE
fix(deps): drop stale numpy<2 pin from the docs extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,6 @@ docs = [
     "nbsphinx==0.9.4",
     "nbsphinx-link==1.4.1",
     "docutils<0.24",
-    "numpy<2",
     "gurobipy>=13.0.0",
     "ipykernel==7.3.0",
     "matplotlib==3.11.0",


### PR DESCRIPTION
> [!NOTE]
> This PR was generated by AI (Claude Code), reviewed by @FBumann.

Installing `linopy[docs,benchmarks]` is currently unresolvable:

```
× No solution found when resolving dependencies:
╰─▶ Because linopy[benchmarks] depends on numpy==2.4.6 and linopy[docs]
    depends on numpy<2, we can conclude that linopy[benchmarks] and
    linopy[docs] are incompatible.
```

The `numpy<2` pin in the `docs` extra dates from the numpy 2.0 transition (e2f95f3, June 2024) and is obsolete: the core dependency is unpinned, the benchmarks extra pins numpy 2.4.6, and the docs stack (matplotlib 3.11, sphinx 9) supports numpy 2. This drops the pin; `uv pip compile` with both extras now resolves (numpy 2.4.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)