### PR TITLE
Switch numpy pin to lower bound in docs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ docs = [
     "nbsphinx==0.9.4",
     "nbsphinx-link==1.4.1",
     "docutils<0.24",
-    "numpy<2",
+    "numpy>=2",
     "gurobipy>=13.0.0",
     "ipykernel==7.3.0",
     "matplotlib==3.11.0",


### PR DESCRIPTION
Closes #872 

Docs build locally so I assume this upper bound was a legacy that's no longer required.

## Checklist

- [ ] AI-generated content is marked (see [`AGENTS.md`](../blob/master/AGENTS.md)).
- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [ ] I consent to the release of this PR's code under the MIT license.
