### PR TITLE
fix(v1): fill join-created positions per side; add fill_value= to add/sub/mul/div

### DIFF
--- a/doc/design/convention.rst
+++ b/doc/design/convention.rst
@@ -109,9 +109,10 @@ collapsing to ``0``, is what preserves the absent-vs-zero distinction of §1.
 Because §6 never fills, turning an absent slot into a value is the caller's
 explicit act, never linopy's. ``fillna(value)`` fills an expression's absent
 slots; ``.fillna(...)`` fills a constant before it enters the arithmetic;
-``fill_value=`` on a named method fills as part of the call. Filling at the call
-site documents the intent: ``x + y.shift(time=1).fillna(0)`` says "treat the
-missing earlier step as zero" exactly where it matters.
+``fill_value=`` on a named method fills the positions that method's join
+creates (§10). Filling at the call site documents the intent:
+``x + y.shift(time=1).fillna(0)`` says "treat the missing earlier step as zero"
+exactly where it matters.
 
 Coordinate alignment
 --------------------
@@ -193,6 +194,30 @@ A pure reorder (§8) is resolved the same way: a reindexing join
 (``.add(other, join="outer")`` / ``inner`` / ``left`` / ``right``) realigns both sides by
 label, or bring one side into the other's order first — ``other.sel(dim=…)``,
 ``other.reindex_like(self)``, or ``other.sortby(dim)`` on a plain-array operand.
+
+A reindexing join (``outer``, ``left``, ``right``) creates positions that
+neither operand held a value at. The join decides the *coordinates* — ``outer``
+returns the union, and every label it creates stays in the result whatever the
+values work out to. What the created positions are *worth* is decided
+separately. They were created by the caller's join rather than carried in by an
+operand, so §6 does not govern them and they are filled, each side with its own
+value.
+
+The linopy operand contributes the zero expression there: no terms, constant 0.
+The constant operand contributes ``fill_value=``, which defaults to "this
+operand does not apply here" — 0 for ``+`` and ``-``, 0 for ``*`` (a factor that
+was never given zeroes the term rather than scaling it by one), and the same
+zero row for ``/``. Pass the keyword to say otherwise:
+``expr.div(cost, join="outer", fill_value=1)`` keeps the term unscaled,
+``expr.add(price, join="outer", fill_value=10)`` treats an unpriced label as 10.
+It applies to constant operands only — an *expression* missing at a label always
+contributes the zero expression — and it requires an explicit ``join=``, since
+without one there are no created positions to fill.
+
+Absence an operand carries in — from ``mask=``, ``.where()``, ``.shift()``,
+``.reindex()`` — is untouched by the join and keeps propagating under §6. So
+``x.add(y.shift(time=1), join="outer")`` is absent at the shifted-in step and
+filled at the labels only ``y`` had.
 
 Because no operator silently drops coordinates, the associativity break
 (`#711 <https://github.com/PyPSA/linopy/issues/711>`__) cannot occur: the operation that used to drop coordinates now raises.

--- a/doc/migrating-to-v1.rst
+++ b/doc/migrating-to-v1.rst
@@ -99,6 +99,16 @@ Every row is a legacy guess that becomes an explicit rule under v1. The
      - Raises (``join="exact"`` — no silent reindex).
      - ``.sortby(dim)`` / ``.reindex`` one side to match, or a reindexing
        ``join=`` (``"outer"`` / ``"inner"`` / ``"left"`` / ``"right"``).
+   * - A reindexing ``join=`` that **creates labels** neither operand had
+     - The join still returns the union of the coordinates; the created rows
+       are filled per side — the linopy operand contributes the zero
+       expression, the constant operand ``fill_value=`` (0 by default). A
+       missing divisor now zeroes that row instead of leaving the term
+       unscaled, and a missing numerator no longer comes out as
+       ``1 / divisor``.
+     - Pass ``fill_value=`` on ``.add`` / ``.sub`` / ``.mul`` / ``.div`` to
+       choose the value, e.g. ``.div(other, join="outer", fill_value=1)`` to
+       keep the term unscaled.
    * - An **unlabeled** operand (numpy array, list, polars ``Series``)
      - Pairs with the linopy operand's dimensions by *size*; an ambiguous
        match (a square array, or two dimensions of equal length) or no size

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -16,6 +16,7 @@ Upcoming Version
   * a ``NaN`` in a user-supplied constant raises, rather than being silently filled (with a value that used to differ per operator).
   * *absence* — masked, reindexed, or shifted-in slots — is a first-class state that propagates through every operator, instead of collapsing to zero.
   * conflicting auxiliary coordinates raise, instead of being silently dropped.
+  * a reindexing ``join=`` fills the positions it creates per side: the linopy operand contributes the zero expression, the constant operand contributes ``fill_value=`` (new on ``.add`` / ``.sub`` / ``.mul`` / ``.div``), which defaults to "does not apply here" — so a missing divisor zeroes the term instead of leaving it unscaled, and a missing numerator no longer comes out as ``1 / divisor``. Absence carried in by an operand is untouched and still propagates.
   * a first-class ``pd.MultiIndex`` dimension is rejected in favour of a flat dimension with the levels as auxiliary coordinates.
   * a ``groupby`` grouper aligns to the grouped dimension by label — a grouper whose labels differ in set or order from the dimension raises instead of being matched positionally, and a multi-key grouper yields a flat ``group`` dimension (keys as aux coords) rather than a stacked ``group`` MultiIndex. (https://github.com/PyPSA/linopy/issues/827)
 

--- a/linopy/constraints.py
+++ b/linopy/constraints.py
@@ -316,7 +316,8 @@ class ConstraintBase(ABC):
 
     @property
     def coord_sizes(self) -> dict[Hashable, int]:
-        return {k: v for k, v in self.sizes.items() if k not in HELPER_DIMS}
+        sizes = self.sizes
+        return {k: sizes[k] for k in self.coord_dims}
 
     @property
     def coord_names(self) -> list[str]:

--- a/linopy/constraints.py
+++ b/linopy/constraints.py
@@ -316,8 +316,7 @@ class ConstraintBase(ABC):
 
     @property
     def coord_sizes(self) -> dict[Hashable, int]:
-        sizes = self.sizes
-        return {k: sizes[k] for k in self.coord_dims}
+        return {k: self.sizes[k] for k in self.coord_dims}
 
     @property
     def coord_names(self) -> list[str]:
@@ -358,7 +357,7 @@ class ConstraintBase(ABC):
     def __repr__(self) -> str:
         """Print the constraint arrays."""
         max_lines = options["display_max_rows"]
-        dims = list(self.coord_sizes.keys())
+        dims = list(self.coord_dims)
         ndim = len(dims)
         dim_names = self.coord_names
         dim_sizes = list(self.coord_sizes.values())

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -793,7 +793,7 @@ class BaseExpression(ABC):
         Print the expression arrays.
         """
         max_lines = options["display_max_rows"]
-        dims = list(self.coord_sizes)
+        dims = list(self.coord_dims)
         dim_names = self.coord_names
         ndim = len(dims)
         dim_sizes = list(self.coord_sizes.values())
@@ -1028,13 +1028,6 @@ class BaseExpression(ABC):
             if mismatch is not None:
                 raise ValueError(_shared_dim_mismatch_message(*mismatch))
             return self.const, other, False
-        # §10: the positions a join creates are filled per side. ``fill_value``
-        # belongs to the constant operand alone; the expression contributes the
-        # zero expression there (const 0, no terms), whatever the operator.
-        # Filling both sides from one value is what made a missing numerator
-        # come out as ``1 / divisor``. ``xr.align`` and ``reindex_like`` only
-        # touch the new positions, so absence carried in by an operand (§6)
-        # still propagates untouched.
         self_const, aligned = xr.align(
             self.const,
             other,
@@ -1221,11 +1214,6 @@ class BaseExpression(ABC):
         join: JoinOptions | None = None,
         fill_value: float | None = None,
     ) -> Self:
-        # §10: under v1 a missing divisor means the term does not apply, so the
-        # row is kept (the join's coords are unchanged) and evaluates to zero.
-        # Dividing by ``inf`` gets there without a division by zero;
-        # ``fill_value=1`` is how a caller keeps the term unscaled instead.
-        # Legacy keeps its own 1.
         if fill_value is None:
             fill_value = np.inf if is_v1() else 1
         return self._apply_constant_op(
@@ -1554,8 +1542,7 @@ class BaseExpression(ABC):
 
     @property
     def coord_sizes(self) -> dict[Hashable, int]:
-        sizes = self.sizes
-        return {k: sizes[k] for k in self.coord_dims}
+        return {k: self.sizes[k] for k in self.coord_dims}
 
     @property
     def coord_names(self) -> list[str]:

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -96,12 +96,14 @@ from linopy.semantics import (
     _legacy_nan_rhs_constraint_message,
     _shared_dim_mismatch_message,
     absorb_absence,
+    check_join_fill_value,
     check_user_nan,
     conform_merge_dims,
     enforce_aux_conflict,
     first_mismatched_dim,
     is_nan_scalar,
     is_v1,
+    reindex_like_if_needed,
     warn_legacy,
 )
 from linopy.types import (
@@ -1026,22 +1028,36 @@ class BaseExpression(ABC):
             if mismatch is not None:
                 raise ValueError(_shared_dim_mismatch_message(*mismatch))
             return self.const, other, False
+        # §10: the positions a join creates are filled per side. ``fill_value``
+        # belongs to the constant operand alone; the expression contributes the
+        # zero expression there (const 0, no terms), whatever the operator.
+        # Filling both sides from one value is what made a missing numerator
+        # come out as ``1 / divisor``. ``xr.align`` and ``reindex_like`` only
+        # touch the new positions, so absence carried in by an operand (§6)
+        # still propagates untouched.
         self_const, aligned = xr.align(
             self.const,
             other,
             join=join,
             fill_value=fill_value,
         )
+        self_const = reindex_like_if_needed(self.const, self_const, fill_value=0)
         return self_const, aligned, True
 
     def _add_constant(
-        self, other: ConstantLike, join: JoinOptions | None = None
+        self,
+        other: ConstantLike,
+        join: JoinOptions | None = None,
+        fill_value: float | None = None,
     ) -> Self:
+        fill_value = 0 if fill_value is None else fill_value
         if is_v1():
-            return self._add_constant_v1(other, join)
-        return self._add_constant_legacy(other, join)
+            return self._add_constant_v1(other, join, fill_value)
+        return self._add_constant_legacy(other, join, fill_value)
 
-    def _add_constant_v1(self, other: ConstantLike, join: JoinOptions | None) -> Self:
+    def _add_constant_v1(
+        self, other: ConstantLike, join: JoinOptions | None, fill_value: float = 0
+    ) -> Self:
         # §6: absence propagates — self.const NaN stays NaN, no fillna(0).
         # §5: user NaN raised in check_user_nan; never reaches the math here.
         if np.isscalar(other) and join is None:
@@ -1054,7 +1070,7 @@ class BaseExpression(ABC):
         if da.isnull().any():
             check_user_nan()
         self_const, da, needs_data_reindex = self._align_constant(
-            da, fill_value=0, join=join
+            da, fill_value=fill_value, join=join
         )
         if needs_data_reindex:
             return self.__class__(
@@ -1067,7 +1083,7 @@ class BaseExpression(ABC):
 
     # LEGACY: remove at 1.0 — see doc/design/legacy-removal.rst.
     def _add_constant_legacy(
-        self, other: ConstantLike, join: JoinOptions | None
+        self, other: ConstantLike, join: JoinOptions | None, fill_value: float = 0
     ) -> Self:
         # NaN values in self.const or other are silently filled with 0
         # (additive identity) so missing data does not propagate through
@@ -1082,7 +1098,7 @@ class BaseExpression(ABC):
         if da.isnull().any():
             check_user_nan()
         self_const, da, needs_data_reindex = self._align_constant(
-            da, fill_value=0, join=join
+            da, fill_value=fill_value, join=join
         )
         da = da.fillna(0)
         self_const = self_const.fillna(0)
@@ -1099,14 +1115,22 @@ class BaseExpression(ABC):
         self,
         other: ConstantLike,
         op: Callable[[DataArray, DataArray], DataArray],
-        fill_value: float,
+        nan_fill: float,
+        join_fill: float,
         op_kind: str,
         join: JoinOptions | None = None,
     ) -> Self:
-        """Apply a constant operation (mul, div) to this expression."""
+        """
+        Apply a constant operation (mul, div) to this expression.
+
+        ``join_fill`` is what the factor takes at join-created positions;
+        ``nan_fill`` is legacy's silent fill for a NaN the factor carried in.
+        """
         if is_v1():
-            return self._apply_constant_op_v1(other, op, fill_value, op_kind, join)
-        return self._apply_constant_op_legacy(other, op, fill_value, op_kind, join)
+            return self._apply_constant_op_v1(other, op, join_fill, op_kind, join)
+        return self._apply_constant_op_legacy(
+            other, op, nan_fill, join_fill, op_kind, join
+        )
 
     def _apply_constant_op_v1(
         self,
@@ -1145,12 +1169,13 @@ class BaseExpression(ABC):
         self,
         other: ConstantLike,
         op: Callable[[DataArray, DataArray], DataArray],
-        fill_value: float,
+        nan_fill: float,
+        join_fill: float,
         op_kind: str,
         join: JoinOptions | None,
     ) -> Self:
         # NaN values are silently filled with neutral elements before the op:
-        # factor → fill_value (0 for mul, 1 for div), coeffs/const → 0.
+        # factor → nan_fill (0 for mul, 1 for div), coeffs/const → 0.
         if is_nan_scalar(other):
             check_user_nan(op_kind=op_kind)
         factor = broadcast_to_coords(
@@ -1159,9 +1184,9 @@ class BaseExpression(ABC):
         if factor.isnull().any():
             check_user_nan(op_kind=op_kind)
         self_const, factor, needs_data_reindex = self._align_constant(
-            factor, fill_value=fill_value, join=join
+            factor, fill_value=join_fill, join=join
         )
-        factor = factor.fillna(fill_value)
+        factor = factor.fillna(nan_fill)
         self_const = self_const.fillna(0)
         if needs_data_reindex:
             data = self.data.reindex_like(self_const, fill_value=self._fill_value)
@@ -1176,17 +1201,40 @@ class BaseExpression(ABC):
         return self.assign(coeffs=op(coeffs, factor), const=op(self_const, factor))
 
     def _multiply_by_constant(
-        self, other: ConstantLike, join: JoinOptions | None = None
+        self,
+        other: ConstantLike,
+        join: JoinOptions | None = None,
+        fill_value: float | None = None,
     ) -> Self:
         return self._apply_constant_op(
-            other, operator.mul, fill_value=0, op_kind="mul", join=join
+            other,
+            operator.mul,
+            nan_fill=0,
+            join_fill=0 if fill_value is None else fill_value,
+            op_kind="mul",
+            join=join,
         )
 
     def _divide_by_constant(
-        self, other: ConstantLike, join: JoinOptions | None = None
+        self,
+        other: ConstantLike,
+        join: JoinOptions | None = None,
+        fill_value: float | None = None,
     ) -> Self:
+        # §10: under v1 a missing divisor means the term does not apply, so the
+        # row is kept (the join's coords are unchanged) and evaluates to zero.
+        # Dividing by ``inf`` gets there without a division by zero;
+        # ``fill_value=1`` is how a caller keeps the term unscaled instead.
+        # Legacy keeps its own 1.
+        if fill_value is None:
+            fill_value = np.inf if is_v1() else 1
         return self._apply_constant_op(
-            other, operator.truediv, fill_value=1, op_kind="div", join=join
+            other,
+            operator.truediv,
+            nan_fill=1,
+            join_fill=fill_value,
+            op_kind="div",
+            join=join,
         )
 
     def __div__(self, other: SideLike) -> Self:
@@ -1228,6 +1276,7 @@ class BaseExpression(ABC):
         self,
         other: SideLike,
         join: JoinOptions | None = None,
+        fill_value: float | None = None,
     ) -> Self | QuadraticExpression:
         """
         Add an expression to others.
@@ -1242,11 +1291,21 @@ class BaseExpression(ABC):
             semantics setting: under v1, shared dimensions must carry
             identical labels (same labels, same order) — a reorder or a
             differing set raises; under legacy, positional alignment.
+        fill_value : float, optional
+            Value the constant operand takes at the positions the join creates.
+            Defaults to 0, the additive identity. Requires an explicit ``join``
+            and a constant ``other``.
         """
+        check_join_fill_value(fill_value, join)
         if join is None:
             return self.__add__(other)
         if isinstance(other, CONSTANT_TYPES):
-            return self._add_constant(other, join=join)
+            return self._add_constant(other, join=join, fill_value=fill_value)
+        if fill_value is not None:
+            raise ValueError(
+                "fill_value= applies to constant operands only. An expression "
+                "that is missing at a label contributes the zero expression."
+            )
         other = as_expression(other, model=self.model, dims=self.coord_dims)
         if isinstance(other, LinearExpression) and isinstance(
             self, QuadraticExpression
@@ -1258,6 +1317,7 @@ class BaseExpression(ABC):
         self,
         other: SideLike,
         join: JoinOptions | None = None,
+        fill_value: float | None = None,
     ) -> Self | QuadraticExpression:
         """
         Subtract others from expression.
@@ -1272,13 +1332,19 @@ class BaseExpression(ABC):
             semantics setting: under v1, shared dimensions must carry
             identical labels (same labels, same order) — a reorder or a
             differing set raises; under legacy, positional alignment.
+        fill_value : float, optional
+            Value the subtrahend takes at the positions the join creates.
+            Defaults to 0. Requires an explicit ``join`` and a constant ``other``.
         """
-        return self.add(-other, join=join)
+        return self.add(
+            -other, join=join, fill_value=None if fill_value is None else -fill_value
+        )
 
     def mul(
         self,
         other: SideLike,
         join: JoinOptions | None = None,
+        fill_value: float | None = None,
     ) -> Self | QuadraticExpression:
         """
         Multiply the expr by a factor.
@@ -1293,19 +1359,25 @@ class BaseExpression(ABC):
             semantics setting: under v1, shared dimensions must carry
             identical labels (same labels, same order) — a reorder or a
             differing set raises; under legacy, positional alignment.
+        fill_value : float, optional
+            Value the factor takes at the positions the join creates. Defaults
+            to 0, so a term without a factor evaluates to zero. Requires an
+            explicit ``join``.
         """
+        check_join_fill_value(fill_value, join)
         if join is None:
             return self.__mul__(other)
         if isinstance(other, SUPPORTED_EXPRESSION_TYPES):
             raise TypeError(
                 "join parameter is not supported for expression-expression multiplication"
             )
-        return self._multiply_by_constant(other, join=join)
+        return self._multiply_by_constant(other, join=join, fill_value=fill_value)
 
     def div(
         self,
         other: VariableLike | ConstantLike,
         join: JoinOptions | None = None,
+        fill_value: float | None = None,
     ) -> Self | QuadraticExpression:
         """
         Divide the expr by a factor.
@@ -1320,7 +1392,12 @@ class BaseExpression(ABC):
             semantics setting: under v1, shared dimensions must carry
             identical labels (same labels, same order) — a reorder or a
             differing set raises; under legacy, positional alignment.
+        fill_value : float, optional
+            Value the divisor takes at the positions the join creates. By
+            default that term evaluates to zero; pass ``1`` to keep it unscaled.
+            Requires an explicit ``join``.
         """
+        check_join_fill_value(fill_value, join)
         if join is None:
             return self.__div__(other)
         if isinstance(other, SUPPORTED_EXPRESSION_TYPES):
@@ -1329,7 +1406,7 @@ class BaseExpression(ABC):
                 f"{type(self)} and {type(other)}. "
                 "Non-linear expressions are not yet supported."
             )
-        return self._divide_by_constant(other, join=join)
+        return self._divide_by_constant(other, join=join, fill_value=fill_value)
 
     def le(
         self,
@@ -1477,7 +1554,8 @@ class BaseExpression(ABC):
 
     @property
     def coord_sizes(self) -> dict[Hashable, int]:
-        return {k: v for k, v in self.sizes.items() if k not in HELPER_DIMS}
+        sizes = self.sizes
+        return {k: sizes[k] for k in self.coord_dims}
 
     @property
     def coord_names(self) -> list[str]:

--- a/linopy/semantics.py
+++ b/linopy/semantics.py
@@ -383,7 +383,7 @@ def check_user_nan(*, op_kind: str = "add") -> None:
 
 def check_join_fill_value(fill_value: float | None, join: str | None) -> None:
     """
-    §7/§10: ``fill_value=`` fills what a join creates, so it needs a join.
+    ``fill_value=`` fills what a join creates, so it requires an explicit join.
     """
     if fill_value is not None and join is None:
         raise ValueError(

--- a/linopy/semantics.py
+++ b/linopy/semantics.py
@@ -381,6 +381,18 @@ def check_user_nan(*, op_kind: str = "add") -> None:
     warn_legacy(_legacy_nan_constant_message(op_kind), stacklevel=5)
 
 
+def check_join_fill_value(fill_value: float | None, join: str | None) -> None:
+    """
+    §7/§10: ``fill_value=`` fills what a join creates, so it needs a join.
+    """
+    if fill_value is not None and join is None:
+        raise ValueError(
+            "fill_value= fills the positions a join creates, so it requires an "
+            "explicit join= (e.g. join='outer'). To fill absent slots of an "
+            "operand, call `.fillna(...)` on it before the operation."
+        )
+
+
 def enforce_aux_conflict(datasets: Sequence[Any], *, stacklevel: int = 5) -> None:
     """
     Enforce §11 across the given operands: v1 raises on aux-coord

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -617,7 +617,10 @@ class Variable:
         return self.data.__contains__(value)
 
     def add(
-        self, other: SideLike, join: JoinOptions | None = None
+        self,
+        other: SideLike,
+        join: JoinOptions | None = None,
+        fill_value: float | None = None,
     ) -> LinearExpression | QuadraticExpression:
         """
         Add variables to linear expressions or other variables.
@@ -632,11 +635,17 @@ class Variable:
             semantics setting: under v1, shared dimensions must carry
             identical labels (same labels, same order) — a reorder or a
             differing set raises; under legacy, positional alignment.
+        fill_value : float, optional
+            Value the constant operand takes at the positions the join
+            creates. Defaults to 0. Requires an explicit ``join``.
         """
-        return self.to_linexpr().add(other, join=join)
+        return self.to_linexpr().add(other, join=join, fill_value=fill_value)
 
     def sub(
-        self, other: SideLike, join: JoinOptions | None = None
+        self,
+        other: SideLike,
+        join: JoinOptions | None = None,
+        fill_value: float | None = None,
     ) -> LinearExpression | QuadraticExpression:
         """
         Subtract linear expressions or other variables from the variables.
@@ -651,11 +660,17 @@ class Variable:
             semantics setting: under v1, shared dimensions must carry
             identical labels (same labels, same order) — a reorder or a
             differing set raises; under legacy, positional alignment.
+        fill_value : float, optional
+            Value the subtrahend takes at the positions the join creates.
+            Defaults to 0. Requires an explicit ``join``.
         """
-        return self.to_linexpr().sub(other, join=join)
+        return self.to_linexpr().sub(other, join=join, fill_value=fill_value)
 
     def mul(
-        self, other: ConstantLike, join: JoinOptions | None = None
+        self,
+        other: ConstantLike,
+        join: JoinOptions | None = None,
+        fill_value: float | None = None,
     ) -> LinearExpression | QuadraticExpression:
         """
         Multiply variables with a coefficient.
@@ -670,11 +685,17 @@ class Variable:
             semantics setting: under v1, shared dimensions must carry
             identical labels (same labels, same order) — a reorder or a
             differing set raises; under legacy, positional alignment.
+        fill_value : float, optional
+            Value the factor takes at the positions the join creates.
+            Defaults to 0, so a term without a factor evaluates to zero.
         """
-        return self.to_linexpr().mul(other, join=join)
+        return self.to_linexpr().mul(other, join=join, fill_value=fill_value)
 
     def div(
-        self, other: ConstantLike, join: JoinOptions | None = None
+        self,
+        other: ConstantLike,
+        join: JoinOptions | None = None,
+        fill_value: float | None = None,
     ) -> LinearExpression | QuadraticExpression:
         """
         Divide variables with a coefficient.
@@ -689,8 +710,11 @@ class Variable:
             semantics setting: under v1, shared dimensions must carry
             identical labels (same labels, same order) — a reorder or a
             differing set raises; under legacy, positional alignment.
+        fill_value : float, optional
+            Value the divisor takes at the positions the join creates. By
+            default that term evaluates to zero; pass ``1`` to keep it unscaled.
         """
-        return self.to_linexpr().div(other, join=join)
+        return self.to_linexpr().div(other, join=join, fill_value=fill_value)
 
     def le(self, rhs: SideLike, join: JoinOptions | None = None) -> Constraint:
         """

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -945,7 +945,8 @@ class Variable:
         """
         Get the coordinate sizes of the variable.
         """
-        return {k: v for k, v in self.sizes.items() if k not in HELPER_DIMS}
+        sizes = self.sizes
+        return {k: sizes[k] for k in self.coord_dims}
 
     @property
     def coord_names(self) -> list[str]:

--- a/linopy/variables.py
+++ b/linopy/variables.py
@@ -399,9 +399,9 @@ class Variable:
         Print the variable arrays.
         """
         max_lines = options["display_max_rows"]
-        dims = list(self.sizes)
+        dims = list(self.coord_dims)
         dim_names = self.coord_names
-        dim_sizes = list(self.sizes.values())
+        dim_sizes = list(self.coord_sizes.values())
         masked_entries = (~self.mask).sum().values
         sos_type = self.attrs.get(SOS_TYPE_ATTR)
         sos_dim = self.attrs.get(SOS_DIM_ATTR)
@@ -945,8 +945,7 @@ class Variable:
         """
         Get the coordinate sizes of the variable.
         """
-        sizes = self.sizes
-        return {k: sizes[k] for k in self.coord_dims}
+        return {k: self.sizes[k] for k in self.coord_dims}
 
     @property
     def coord_names(self) -> list[str]:

--- a/test/test_linear_expression.py
+++ b/test/test_linear_expression.py
@@ -3301,14 +3301,6 @@ class TestJoinParameter:
 
 @pytest.mark.v1
 class TestOuterJoinFill:
-    """
-    §10: a join fills the positions it creates — the expression side with the
-    zero expression, the constant side with ``fill_value`` (0 by default, so a
-    factor-less term evaluates to zero). The join's coords are unaffected —
-    every created label stays in the result. Absence carried in is untouched
-    and still propagates (§6).
-    """
-
     @pytest.fixture
     def operands(self) -> dict[str, Any]:
         m = Model()

--- a/test/test_linear_expression.py
+++ b/test/test_linear_expression.py
@@ -8,6 +8,7 @@ Created on Wed Mar 17 17:06:36 2021.
 from __future__ import annotations
 
 import warnings
+from collections.abc import Callable
 from types import SimpleNamespace
 from typing import Any
 
@@ -3245,7 +3246,11 @@ class TestJoinParameter:
             assert list(result.coords["i"].values) == [0, 1, 2]
             np.testing.assert_array_equal(result.const.values, [5.0, 2.0, 1.0])
 
-        def test_div_constant_outer_fill_values(self, a: Variable) -> None:
+        @pytest.mark.legacy
+        def test_div_constant_outer_fill_values_legacy(self, a: Variable) -> None:
+            # Both semantics return the union of the coords. Legacy fills a
+            # missing divisor with 1, keeping the term unscaled; under v1 the
+            # row is there but zero (see TestOuterJoinFill).
             expr = 1 * a + 10
             other = xr.DataArray([2.0, 5.0], dims=["i"], coords={"i": [1, 3]})
             result = expr.div(other, join="outer")
@@ -3254,6 +3259,17 @@ class TestJoinParameter:
             assert result.coeffs.squeeze().sel(i=1).item() == pytest.approx(0.5)
             assert result.const.sel(i=0).item() == pytest.approx(10.0)
             assert result.coeffs.squeeze().sel(i=0).item() == pytest.approx(1.0)
+
+        @pytest.mark.v1
+        def test_div_constant_outer_fill_values_v1(self, a: Variable) -> None:
+            expr = 1 * a + 10
+            other = xr.DataArray([2.0, 5.0], dims=["i"], coords={"i": [1, 3]})
+            result = expr.div(other, join="outer")
+            assert set(result.coords["i"].values) == {0, 1, 2, 3}
+            assert result.const.sel(i=1).item() == pytest.approx(5.0)
+            assert result.coeffs.squeeze().sel(i=1).item() == pytest.approx(0.5)
+            assert result.const.sel(i=0).item() == 0
+            assert result.coeffs.squeeze().sel(i=0).item() == 0
 
     class TestQuadratic:
         @pytest.mark.legacy
@@ -3281,3 +3297,191 @@ class TestJoinParameter:
             const = xr.DataArray([2, 3, 4], dims=["i"], coords={"i": [1, 2, 3]})
             result = quad.mul(const, join="inner")
             assert list(result.indexes["i"]) == [1, 2, 3]
+
+
+@pytest.mark.v1
+class TestOuterJoinFill:
+    """
+    §10: a join fills the positions it creates — the expression side with the
+    zero expression, the constant side with ``fill_value`` (0 by default, so a
+    factor-less term evaluates to zero). The join's coords are unaffected —
+    every created label stays in the result. Absence carried in is untouched
+    and still propagates (§6).
+    """
+
+    @pytest.fixture
+    def operands(self) -> dict[str, Any]:
+        m = Model()
+        full = m.add_variables(coords=[pd.Index([0, 1], name="i")], name="full")
+        part = m.add_variables(coords=[pd.Index([1], name="i")], name="part")
+        return {
+            "expr_full": 1 * full + 2,
+            "expr_part": 1 * part + 2,
+            "const_full": xr.DataArray([2.0, 2.0], dims=["i"], coords={"i": [0, 1]}),
+            "const_part": xr.DataArray([2.0], dims=["i"], coords={"i": [1]}),
+        }
+
+    @pytest.mark.parametrize(
+        ("op", "const", "coeffs"),
+        [
+            pytest.param(
+                lambda o: o["expr_full"].add(o["expr_part"], join="outer"),
+                2.0,
+                [1.0, np.nan],
+                id="add-expr-missing-right",
+            ),
+            pytest.param(
+                lambda o: o["expr_part"].add(o["expr_full"], join="outer"),
+                2.0,
+                [np.nan, 1.0],
+                id="add-expr-missing-left",
+            ),
+            pytest.param(
+                lambda o: o["expr_full"].add(o["const_part"], join="outer"),
+                2.0,
+                [1.0],
+                id="add-const-missing",
+            ),
+            pytest.param(
+                lambda o: o["expr_part"].add(o["const_full"], join="outer"),
+                2.0,
+                [np.nan],
+                id="add-expr-missing",
+            ),
+            pytest.param(
+                lambda o: o["expr_full"].sub(o["expr_part"], join="outer"),
+                2.0,
+                [1.0, np.nan],
+                id="sub-expr-missing-right",
+            ),
+            pytest.param(
+                lambda o: o["expr_part"].sub(o["expr_full"], join="outer"),
+                -2.0,
+                [np.nan, -1.0],
+                id="sub-expr-missing-left",
+            ),
+            pytest.param(
+                lambda o: o["expr_full"].sub(o["const_part"], join="outer"),
+                2.0,
+                [1.0],
+                id="sub-const-missing",
+            ),
+            pytest.param(
+                lambda o: o["expr_part"].sub(o["const_full"], join="outer"),
+                -2.0,
+                [np.nan],
+                id="sub-expr-missing",
+            ),
+            pytest.param(
+                lambda o: o["expr_full"].mul(o["const_part"], join="outer"),
+                0.0,
+                [0.0],
+                id="mul-factor-missing",
+            ),
+            pytest.param(
+                lambda o: o["expr_part"].mul(o["const_full"], join="outer"),
+                0.0,
+                [np.nan],
+                id="mul-expr-missing",
+            ),
+            pytest.param(
+                lambda o: o["expr_full"].div(o["const_part"], join="outer"),
+                0.0,
+                [0.0],
+                id="div-divisor-missing",
+            ),
+            pytest.param(
+                lambda o: o["expr_part"].div(o["const_full"], join="outer"),
+                0.0,
+                [np.nan],
+                id="div-numerator-missing",
+            ),
+        ],
+    )
+    def test_value_at_created_position(
+        self,
+        operands: dict[str, Any],
+        op: Callable[[dict[str, Any]], LinearExpression],
+        const: float,
+        coeffs: list[float],
+    ) -> None:
+        result = op(operands)
+        assert list(result.indexes["i"]) == [0, 1]
+        assert result.const.sel(i=0).item() == const
+        np.testing.assert_array_equal(result.coeffs.sel(i=0).values, coeffs)
+
+    @pytest.mark.parametrize(
+        ("op", "const", "coeff"),
+        [
+            pytest.param(
+                lambda o: o["expr_full"].add(
+                    o["const_part"], join="outer", fill_value=10
+                ),
+                12.0,
+                1.0,
+                id="add",
+            ),
+            pytest.param(
+                lambda o: o["expr_full"].sub(
+                    o["const_part"], join="outer", fill_value=10
+                ),
+                -8.0,
+                1.0,
+                id="sub",
+            ),
+            pytest.param(
+                lambda o: o["expr_full"].mul(
+                    o["const_part"], join="outer", fill_value=1
+                ),
+                2.0,
+                1.0,
+                id="mul",
+            ),
+            pytest.param(
+                lambda o: o["expr_full"].div(
+                    o["const_part"], join="outer", fill_value=1
+                ),
+                2.0,
+                1.0,
+                id="div",
+            ),
+        ],
+    )
+    def test_fill_value_overrides_the_default(
+        self,
+        operands: dict[str, Any],
+        op: Callable[[dict[str, Any]], LinearExpression],
+        const: float,
+        coeff: float,
+    ) -> None:
+        result = op(operands)
+        assert result.const.sel(i=0).item() == const
+        assert result.coeffs.sel(i=0).item() == coeff
+
+    def test_fill_value_without_join_raises(self, operands: dict[str, Any]) -> None:
+        with pytest.raises(ValueError, match="requires an explicit join="):
+            operands["expr_full"].mul(operands["const_full"], fill_value=1)
+
+    def test_fill_value_with_expression_raises(self, operands: dict[str, Any]) -> None:
+        with pytest.raises(ValueError, match="constant operands only"):
+            operands["expr_full"].add(operands["expr_part"], join="outer", fill_value=1)
+
+    def test_carried_absence_still_propagates(self) -> None:
+        m = Model()
+        x = m.add_variables(coords=[pd.Index([0, 1], name="i")], name="x")
+        shifted = (1 * x).shift(i=1)
+        const = xr.DataArray([2.0, 2.0], dims=["i"], coords={"i": [1, 2]})
+        result = shifted.add(const, join="outer")
+        assert list(result.indexes["i"]) == [0, 1, 2]
+        assert np.isnan(result.const.sel(i=0).item())
+        assert result.const.sel(i=2).item() == 2.0
+
+
+@pytest.mark.legacy
+def test_join_fill_value_honoured_under_legacy() -> None:
+    m = Model()
+    x = m.add_variables(coords=[pd.Index([0, 1], name="i")], name="x")
+    const = xr.DataArray([2.0], dims=["i"], coords={"i": [1]})
+    result = (1 * x + 2).div(const, join="outer", fill_value=1)
+    assert result.coeffs.sel(i=0).item() == 1.0
+    assert result.const.sel(i=0).item() == 2.0

--- a/test/test_repr.py
+++ b/test/test_repr.py
@@ -202,21 +202,19 @@ def test_model_repr_empty() -> None:
 def test_repr_with_transposed_dataset_dim_order() -> None:
     # the dataset dim order may deviate from the array layout, e.g. when the
     # coordinate of a trailing dimension was inserted first
-    dim_1 = pd.Index([10, 20], name="dim_1")
+    dims = ("dim_1", "dim_0", "_term")
     labels = np.tile(x.labels.values, (2, 1))[..., None]
     ds = xr.Dataset(
         {
-            "coeffs": (("dim_1", "dim_0", "_term"), np.ones(labels.shape)),
-            "vars": (("dim_1", "dim_0", "_term"), labels),
-            "const": (("dim_1", "dim_0"), np.zeros(labels.shape[:2])),
+            "coeffs": (dims, np.ones(labels.shape)),
+            "vars": (dims, labels),
+            "const": (dims[:2], np.zeros(labels.shape[:2])),
         },
-        coords={"dim_0": lower.index, "dim_1": dim_1},
+        coords={"dim_0": lower.index, "dim_1": pd.Index([10, 20], name="dim_1")},
     )
     expr = LinearExpression(ds, m)
 
-    assert [d for d in expr.data.sizes if d != "_term"] == ["dim_0", "dim_1"]
-    assert expr.coord_dims == ("dim_1", "dim_0")
-    assert tuple(expr.coord_sizes) == expr.coord_dims
-    assert expr.coord_names == ["dim_1", "dim_0"]
-    repr(expr)
+    assert tuple(expr.data.sizes) != expr.vars.dims
+    assert expr.coord_sizes == {"dim_1": 2, "dim_0": 10}
+    assert repr(expr).startswith("LinearExpression [dim_1: 2, dim_0: 10]:")
     repr(expr >= 0)

--- a/test/test_repr.py
+++ b/test/test_repr.py
@@ -197,3 +197,26 @@ def test_label_position_too_high() -> None:
 
 def test_model_repr_empty() -> None:
     repr(Model())
+
+
+def test_repr_with_transposed_dataset_dim_order() -> None:
+    # the dataset dim order may deviate from the array layout, e.g. when the
+    # coordinate of a trailing dimension was inserted first
+    dim_1 = pd.Index([10, 20], name="dim_1")
+    labels = np.tile(x.labels.values, (2, 1))[..., None]
+    ds = xr.Dataset(
+        {
+            "coeffs": (("dim_1", "dim_0", "_term"), np.ones(labels.shape)),
+            "vars": (("dim_1", "dim_0", "_term"), labels),
+            "const": (("dim_1", "dim_0"), np.zeros(labels.shape[:2])),
+        },
+        coords={"dim_0": lower.index, "dim_1": dim_1},
+    )
+    expr = LinearExpression(ds, m)
+
+    assert [d for d in expr.data.sizes if d != "_term"] == ["dim_0", "dim_1"]
+    assert expr.coord_dims == ("dim_1", "dim_0")
+    assert tuple(expr.coord_sizes) == expr.coord_dims
+    assert expr.coord_names == ["dim_1", "dim_0"]
+    repr(expr)
+    repr(expr >= 0)


### PR DESCRIPTION
Closes # (if applicable).

<!-- human intent goes here -->

> [!NOTE]
> The following content was generated by AI.

## Changes proposed in this Pull Request

Under v1, a reindexing `join=` filled **both** operands from a single value.
That value is the constant operand's identity (`0` for `*`, `1` for `/`), so it
also landed on the expression's own `const`: dividing an expression that was
missing at a label produced `1 / divisor` there. The additive family was
unaffected only because `0` is both its identity and its "contributes nothing"
value.

Each side is now filled separately:

- the **linopy operand** contributes the zero expression at a created label
  (no terms, `const` 0), whatever the operator;
- the **constant operand** contributes `fill_value=`, new on `.add` / `.sub` /
  `.mul` / `.div` (and their `Variable` counterparts). It defaults to "this
  operand does not apply here" — `0` for `+`, `-` and `*`, and the same zero row
  for `/`.

The join keeps deciding the coordinates: `outer` still returns the union, and
every created label stays in the result. What changed is only what those rows
are worth.

`fill_value=` requires an explicit `join=` (without one there are no created
positions) and applies to constant operands only — an expression missing at a
label always contributes the zero expression. Both cases raise rather than
being ignored. `expr.div(cost, join="outer", fill_value=1)` restores the
unscaled term; `expr.add(price, join="outer", fill_value=10)` treats an
unpriced label as 10.

Absence an operand *carries in* — from `mask=`, `.where()`, `.shift()`,
`.reindex()` — is untouched and still propagates under §6. Only the positions
the join creates are filled.

**Behaviour change:** the two division cells only. A missing divisor zeroes its
row instead of leaving the term unscaled, and a missing numerator no longer
comes out as `1 / divisor`. Addition, subtraction and multiplication are
unchanged in both directions, and legacy semantics are untouched throughout.

<details>
<summary>Outer-join value table (v1), pinned as a parametrised test</summary>

Expression `1 * x + 2`, constant `2`, one label missing on one side,
`join="outer"`; values shown at the created label.

| operation | side missing the label | result there |
| --- | --- | --- |
| `expr + expr` | either | survivor kept, missing side contributes 0 |
| `expr ± const` | const | expression unchanged |
| `expr ± const` | expr | `const` = ±2 |
| `expr * const` | factor | `coeff` 0, `const` 0 |
| `expr * const` | expr | no terms, `const` 0 |
| `expr / const` | divisor | `coeff` 0, `const` 0 — **was** `coeff` 1, `const` 2 |
| `expr / const` | numerator | `const` 0 — **was** `const` 0.5 |

Verified by reverting `expressions.py` alone: exactly the two division cells
fail, the other ten pass.

</details>

Also: `check_join_fill_value` in `semantics.py` next to the other convention
checks; internally the previously shared fill parameter is split into
`nan_fill` (legacy's silent NaN fill) and `join_fill` (what the join creates).
§7 and §10 of the convention, the migration guide and the release notes are
updated.

Full suite green under both semantics (6347 passed), `ruff` clean.

## Checklist

- [x] AI-generated content is marked (see [`AGENTS.md`](../blob/master/AGENTS.md)).
- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
