### PR TITLE
fix(sos): order a set by its declaration, not by its coordinate labels

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -11,6 +11,14 @@ Upcoming Version
 * ``Model.add_expressions`` registers a ``LinearExpression`` or ``QuadraticExpression`` under a name (auto-generated as ``expr0``, ``expr1``, ... if omitted), accessible afterwards via ``Model.expressions`` (an ``Expressions`` container mirroring ``Model.variables``/``Model.constraints``) and removable via ``Model.remove_expressions``.
   Named expressions are persisted by ``Model.to_netcdf``/``linopy.read_netcdf`` and preserved by ``Model.copy``, ``copy.copy``, ``copy.deepcopy``, and pickling.
 
+*SOS constraints*
+
+* ``Model.add_sos_constraints`` no longer requires the SOS dimension to have numeric coordinates.
+
+**Breaking Changes**
+
+* An SOS set is ordered by the positions its members are declared in, rather than by the values of its coordinates. Ascending coordinates state the same order, so a model whose SOS dimension is sorted is unaffected, every piecewise formulation among them; descending ones reverse it, which leaves an SOS set's meaning intact. Only a ``sos_type=2`` set whose numeric coordinates neither ascend nor descend changes meaning, and it now emits a ``UserWarning``; sorting the index restores the previous behaviour. (`#892 <https://github.com/PyPSA/linopy/issues/892>`__)
+
 
 Version v0.9.0
 --------------

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -17,7 +17,7 @@ Upcoming Version
 
 **Breaking Changes**
 
-* An SOS set is ordered by the positions its members are declared in, rather than by the values of its coordinates. Ascending coordinates state the same order, so a model whose SOS dimension is sorted is unaffected, every piecewise formulation among them; descending ones reverse it, which leaves an SOS set's meaning intact. Only a ``sos_type=2`` set whose numeric coordinates neither ascend nor descend changes meaning, and it now emits a ``UserWarning``; sorting the index restores the previous behaviour. (`#892 <https://github.com/PyPSA/linopy/issues/892>`__)
+* An SOS set is now ordered by the positions its members are declared in, rather than by the values of its coordinates. Ascending coordinates give the same order as before, so a model whose SOS dimension is sorted is unaffected, including every piecewise formulation. Descending coordinates now run in reverse, which does not change which members of a ``sos_type=2`` set are adjacent. Only a ``sos_type=2`` set whose numeric coordinates neither ascend nor descend changes meaning; it now emits a ``UserWarning``, and sorting the index restores the previous behaviour. (`#892 <https://github.com/PyPSA/linopy/issues/892>`__)
 
 **Bug fixes**
 

--- a/doc/sos-constraints.rst
+++ b/doc/sos-constraints.rst
@@ -105,8 +105,12 @@ unordered, so it does not apply.
 The coordinates need not be numeric. Where they are numeric but neither
 ascend nor descend, linopy warns: such a set was previously ordered by
 coordinate value, so its meaning changes. Sort the index to keep that
-ordering. Descending coordinates are left alone, reversing a set being
-the one reordering that leaves its adjacencies intact.
+ordering. Descending coordinates are not warned about, because reversing a
+set does not change which of its members are adjacent.
+
+The weights written to an LP file, or passed to a solver that supports SOS
+sets natively, are the coordinates themselves where they ascend, and member
+positions otherwise.
 
 Examples
 --------

--- a/doc/sos-constraints.rst
+++ b/doc/sos-constraints.rst
@@ -34,7 +34,7 @@ In an SOS1 constraint, **at most one** variable in the ordered set can be non-ze
 SOS Type 2 (SOS2)
 ~~~~~~~~~~~~~~~~~~
 
-In an SOS2 constraint, **at most two adjacent** variables in the ordered set can be non-zero. The adjacency is determined by the ordering weights (coordinates) of the variables.
+In an SOS2 constraint, **at most two adjacent** variables in the ordered set can be non-zero. Adjacency follows the order the members are declared in (see :ref:`sos-ordering`).
 
 **Example use cases:**
 - Piecewise linear approximation of nonlinear functions
@@ -91,8 +91,22 @@ Method Signature
 **Requirements:**
 
 - The specified dimension must exist in the variable
-- The coordinates for the SOS dimension must be numeric (used as weights for ordering)
 - Only one SOS constraint can be applied per variable
+
+.. _sos-ordering:
+
+Ordering
+~~~~~~~~
+
+A set runs in the order its members are declared along ``sos_dim``. For
+``sos_type=2`` that decides which members are adjacent; an SOS1 set is
+unordered, so it does not apply.
+
+The coordinates need not be numeric. Where they are numeric but neither
+ascend nor descend, linopy warns: such a set was previously ordered by
+coordinate value, so its meaning changes. Sort the index to keep that
+ordering. Descending coordinates are left alone, reversing a set being
+the one reordering that leaves its adjacencies intact.
 
 Examples
 --------

--- a/linopy/common.py
+++ b/linopy/common.py
@@ -1257,3 +1257,24 @@ def values_to_lookup_array(
     arr = np.full(size, nan, dtype=float)
     arr[labels[mask]] = values[mask]
     return arr
+
+
+def labels_state_order(labels: np.ndarray) -> bool:
+    """Whether ``labels`` are numeric and strictly increasing."""
+    return bool(
+        pd.api.types.is_numeric_dtype(labels.dtype)
+        and (labels.size < 2 or np.all(np.diff(labels) > 0))
+    )
+
+
+def sos_weights(labels: np.ndarray) -> np.ndarray:
+    """
+    SOS member weights spelling out the declared order of ``labels``.
+
+    Ascending labels already spell it and are passed through, which keeps the
+    LP file unchanged; anything else is weighted by position.
+    """
+    labels = np.asarray(labels)
+    if labels_state_order(labels):
+        return labels
+    return np.arange(labels.size)

--- a/linopy/common.py
+++ b/linopy/common.py
@@ -1293,22 +1293,31 @@ def values_to_lookup_array(
     return arr
 
 
-def labels_state_order(labels: np.ndarray) -> bool:
-    """Whether ``labels`` are numeric and strictly increasing."""
-    return bool(
-        pd.api.types.is_numeric_dtype(labels.dtype)
-        and (labels.size < 2 or np.all(np.diff(labels) > 0))
-    )
+def coords_ascend(coords: np.ndarray) -> bool:
+    """Whether ``coords`` are real numbers in strictly ascending order."""
+    return bool(coords.dtype.kind in "iuf" and np.all(coords[1:] > coords[:-1]))
 
 
-def sos_weights(labels: np.ndarray) -> np.ndarray:
+def coords_reorder_set(coords: np.ndarray) -> bool:
     """
-    SOS member weights spelling out the declared order of ``labels``.
+    Whether ``coords`` order a set differently than the order it is declared in.
 
-    Ascending labels already spell it and are passed through, which keeps the
-    LP file unchanged; anything else is weighted by position.
+    Ascending coords state the declared order and descending ones reverse it,
+    which leaves which members are adjacent unchanged. Non-numeric coords state
+    no order at all.
     """
-    labels = np.asarray(labels)
-    if labels_state_order(labels):
-        return labels
-    return np.arange(labels.size)
+    if coords.dtype.kind not in "iuf":
+        return False
+    return not (coords_ascend(coords) or coords_ascend(coords[::-1]))
+
+
+def sos_weights(coords: np.ndarray) -> np.ndarray:
+    """
+    SOS member weights stating the order ``coords`` is declared in.
+
+    Ascending coords already state it and are passed through, which keeps the LP
+    file unchanged. Anything else is weighted by position.
+    """
+    if coords_ascend(coords):
+        return coords
+    return np.arange(coords.size)

--- a/linopy/io.py
+++ b/linopy/io.py
@@ -25,7 +25,7 @@ import xarray as xr
 from tqdm import tqdm
 
 from linopy import solvers
-from linopy.common import to_polars
+from linopy.common import sos_weights, to_polars
 from linopy.constants import CONCAT_DIM, FACTOR_DIM, SOS_DIM_ATTR, SOS_TYPE_ATTR
 from linopy.objective import Objective
 
@@ -448,12 +448,13 @@ def sos_to_file(
         sos_dim = str(var.attrs[SOS_DIM_ATTR])
 
         other_dims = [dim for dim in var.labels.dims if dim != sos_dim]
+        weights = sos_weights(var.coords[sos_dim].values)
         for var_slice in var.iterate_slices(slice_size, other_dims):
             ds = var_slice.labels.to_dataset()
             # Per-set id = max member label: unique per set (labels are globally
             # unique); a fully-masked set reduces to -1 and is dropped below.
             ds["sos_labels"] = ds["labels"].max(sos_dim)
-            ds["weights"] = ds.coords[sos_dim]
+            ds["weights"] = ((sos_dim,), weights)
             df = to_polars(ds)
 
             # Drop masked members

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -32,6 +32,7 @@ from linopy.alignment import as_dataarray, broadcast_to_coords
 from linopy.common import (
     assign_multiindex_safe,
     best_int,
+    labels_state_order,
     maybe_replace_signs,
     replace_by_map,
     to_path,
@@ -1017,7 +1018,8 @@ class Model:
         """
         Add an sos1 or sos2 constraint for one dimension of a variable
 
-        The dimension values are used as SOS.
+        The set runs in the order its members are declared along ``sos_dim``,
+        which for ``sos_type=2`` decides which members are adjacent.
 
         Parameters
         ----------
@@ -1050,11 +1052,22 @@ class Model:
                 f"variable already has an sos{existing_sos_type} constraint on {existing_sos_dim}"
             )
 
-        # Validate that sos_dim coordinates are numeric (needed for weights)
-        if not pd.api.types.is_numeric_dtype(variable.coords[sos_dim]):
-            raise ValueError(
-                f"SOS constraint requires numeric coordinates for dimension '{sos_dim}', "
-                f"but got {variable.coords[sos_dim].dtype}"
+        # Only sos_type=2 can change meaning, and only where the labels group
+        # the members differently: an sos1 set is unordered, and reversing an
+        # ordered one leaves which of its members are adjacent unchanged.
+        labels = np.asarray(variable.coords[sos_dim].values)
+        if (
+            sos_type == 2
+            and pd.api.types.is_numeric_dtype(labels.dtype)
+            and not (labels_state_order(labels) or labels_state_order(labels[::-1]))
+        ):
+            warn(
+                f"The coordinates of SOS dimension '{sos_dim}' neither ascend "
+                "nor descend. This set is ordered by the positions its members "
+                "are declared in, which decides which of them are adjacent. "
+                "Sort the index to order it by coordinate value instead.",
+                UserWarning,
+                stacklevel=2,
             )
 
         attrs_update: dict[str, Any] = {SOS_TYPE_ATTR: sos_type, SOS_DIM_ATTR: sos_dim}

--- a/linopy/model.py
+++ b/linopy/model.py
@@ -33,7 +33,7 @@ from linopy.common import (
     assign_multiindex_safe,
     assigned_labels,
     best_int,
-    labels_state_order,
+    coords_reorder_set,
     maybe_replace_signs,
     replace_by_map,
     to_path,
@@ -1054,15 +1054,7 @@ class Model:
                 f"variable already has an sos{existing_sos_type} constraint on {existing_sos_dim}"
             )
 
-        # Only sos_type=2 can change meaning, and only where the labels group
-        # the members differently: an sos1 set is unordered, and reversing an
-        # ordered one leaves which of its members are adjacent unchanged.
-        labels = np.asarray(variable.coords[sos_dim].values)
-        if (
-            sos_type == 2
-            and pd.api.types.is_numeric_dtype(labels.dtype)
-            and not (labels_state_order(labels) or labels_state_order(labels[::-1]))
-        ):
+        if sos_type == 2 and coords_reorder_set(variable.coords[sos_dim].values):
             warn(
                 f"The coordinates of SOS dimension '{sos_dim}' neither ascend "
                 "nor descend. This set is ordered by the positions its members "

--- a/linopy/solvers.py
+++ b/linopy/solvers.py
@@ -34,7 +34,7 @@ from packaging.version import parse as parse_version
 from scipy.sparse import tril, triu
 
 import linopy.io
-from linopy.common import count_initial_letters, values_to_lookup_array
+from linopy.common import count_initial_letters, sos_weights, values_to_lookup_array
 from linopy.constants import (
     EQUAL,
     SOS_DIM_ATTR,
@@ -135,7 +135,7 @@ def _iter_sos_sets(model: Model) -> Iterator[tuple[int, np.ndarray, np.ndarray]]
         sos_dim = str(var.attrs[SOS_DIM_ATTR])
 
         labels = var.labels.transpose(sos_dim, ...)
-        weights = labels.coords[sos_dim].values
+        weights = sos_weights(labels.coords[sos_dim].values)
         arr = labels.values.reshape(labels.shape[0], -1)
 
         for i in range(arr.shape[1]):

--- a/linopy/sos_reformulation.py
+++ b/linopy/sos_reformulation.py
@@ -194,11 +194,8 @@ def reformulate_sos2(
         x_mid = x_expr.isel({sos_dim: mid_slice})
         M_mid = M.isel({sos_dim: mid_slice})
 
-        z_left_coords = var.coords[sos_dim].values[: n - 2]
-        z_right_coords = var.coords[sos_dim].values[1 : n - 1]
-
-        z_left = z_expr.sel({sos_dim: z_left_coords})
-        z_right = z_expr.sel({sos_dim: z_right_coords})
+        z_left = z_expr.isel({sos_dim: slice(0, n - 2)})
+        z_right = z_expr.isel({sos_dim: slice(1, n - 1)})
 
         z_left_aligned = z_left.assign_coords({sos_dim: M_mid.coords[sos_dim].values})
         z_right_aligned = z_right.assign_coords({sos_dim: M_mid.coords[sos_dim].values})
@@ -276,17 +273,11 @@ def reformulate_sos_constraints(
 
             result.saved_attrs[var_name] = dict(var.attrs)
 
-            sort_idx = np.argsort(var.coords[sos_dim].values)
-            if not np.all(sort_idx[:-1] <= sort_idx[1:]):
-                sorted_var = var.isel({sos_dim: sort_idx})
-                M = M.isel({sos_dim: sort_idx})
-            else:
-                sorted_var = var
-
+            # The array order is already the order to reformulate along.
             if sos_type == 1:
-                added_vars, added_cons = reformulate_sos1(model, sorted_var, prefix, M)
+                added_vars, added_cons = reformulate_sos1(model, var, prefix, M)
             elif sos_type == 2:
-                added_vars, added_cons = reformulate_sos2(model, sorted_var, prefix, M)
+                added_vars, added_cons = reformulate_sos2(model, var, prefix, M)
             else:
                 raise ValueError(
                     f"Unknown sos_type={sos_type} on variable '{var_name}'"

--- a/linopy/sos_reformulation.py
+++ b/linopy/sos_reformulation.py
@@ -273,7 +273,6 @@ def reformulate_sos_constraints(
 
             result.saved_attrs[var_name] = dict(var.attrs)
 
-            # The array order is already the order to reformulate along.
             if sos_type == 1:
                 added_vars, added_cons = reformulate_sos1(model, var, prefix, M)
             elif sos_type == 2:

--- a/test/test_sos_constraints.py
+++ b/test/test_sos_constraints.py
@@ -37,7 +37,6 @@ def test_add_sos_constraints_validation() -> None:
     with pytest.raises(ValueError, match="dimension"):
         m.add_sos_constraints(variable, sos_type=1, sos_dim="missing")
 
-    # A set is ordered by declaration, so a string label is no obstacle.
     m.add_sos_constraints(variable, sos_type=1, sos_dim="strings")
     assert "string_var" in list(m.variables.sos)
 

--- a/test/test_sos_constraints.py
+++ b/test/test_sos_constraints.py
@@ -37,8 +37,9 @@ def test_add_sos_constraints_validation() -> None:
     with pytest.raises(ValueError, match="dimension"):
         m.add_sos_constraints(variable, sos_type=1, sos_dim="missing")
 
-    with pytest.raises(ValueError, match="numeric"):
-        m.add_sos_constraints(variable, sos_type=1, sos_dim="strings")
+    # A set is ordered by declaration, so a string label is no obstacle.
+    m.add_sos_constraints(variable, sos_type=1, sos_dim="strings")
+    assert "string_var" in list(m.variables.sos)
 
     numeric = m.add_variables(coords=[pd.Index([0, 1], name="dim")], name="num")
     m.add_sos_constraints(numeric, sos_type=1, sos_dim="dim")

--- a/test/test_sos_weights.py
+++ b/test/test_sos_weights.py
@@ -1,8 +1,8 @@
 """
 Which order an SOS set runs in: the declared one, or the one its labels imply.
 
-Where the labels ascend the two coincide — the common case, and every piecewise
-model. Where they do not, the declared order wins.
+Where the labels ascend the two are the same, which covers the common case and
+every piecewise model. Where they do not, the declared order wins.
 """
 
 from __future__ import annotations
@@ -11,10 +11,12 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Literal
 
+import numpy as np
 import pandas as pd
 import pytest
 
 from linopy import Model, available_solvers
+from linopy.common import sos_weights
 
 #: Gains that separate the two orders: the first two members declared are worth
 #: 1.0 each, the last 0.1. Declaration order can take the first two and scores
@@ -64,15 +66,6 @@ def lp_sos_section(tmp_path: Path) -> Callable[[Model], str]:
         return fn.read_text().split("\nsos\n")[1]
 
     return read
-
-
-def test_ascending_labels_are_written_as_weights_verbatim(
-    sos_model: Callable[..., Model], lp_sos_section: Callable[[Model], str]
-) -> None:
-    section = lp_sos_section(sos_model([0.0, 1.5, 3.5]))
-
-    assert "1.5" in section
-    assert "3.5" in section
 
 
 @needs_highs
@@ -164,3 +157,27 @@ def test_weights_are_positions_where_labels_do_not_ascend(
 def test_labels_that_regroup_the_set_warn(sos_model: Callable[..., Model]) -> None:
     with pytest.warns(UserWarning, match="order"):
         sos_model([30, 10, 20])
+
+
+@pytest.mark.parametrize(
+    "labels",
+    [
+        pytest.param([False, True], id="ascending"),
+        pytest.param([True, False], id="descending"),
+    ],
+)
+def test_boolean_labels_are_weighted_by_position(labels: list) -> None:
+    """A bool passes ``is_numeric_dtype``, but is no weight an LP file can hold."""
+    assert list(sos_weights(np.array(labels))) == [0, 1]
+
+
+@pytest.mark.parametrize("dtype", ["uint8", "uint32", "uint64", "int64"])
+def test_unsigned_labels_that_do_not_ascend_are_weighted_by_position(
+    sos_model: Callable[..., Model],
+    lp_sos_section: Callable[[Model], str],
+    dtype: str,
+) -> None:
+    with pytest.warns(UserWarning, match="order"):
+        m = sos_model(pd.Index(np.array([30, 10, 20], dtype=dtype)))
+
+    assert lp_sos_section(m).split()[:6] == ["s2:", "S2", "::", "x0:0", "x1:1", "x2:2"]

--- a/test/test_sos_weights.py
+++ b/test/test_sos_weights.py
@@ -2,8 +2,7 @@
 Which order an SOS set runs in: the declared one, or the one its labels imply.
 
 Where the labels ascend the two coincide — the common case, and every piecewise
-model. Where they do not, the labels still win; those tests are ``xfail``
-until the following commit makes the declaration authoritative.
+model. Where they do not, the declared order wins.
 """
 
 from __future__ import annotations
@@ -118,7 +117,6 @@ def test_monotonic_labels_do_not_warn(
     assert not [w for w in recwarn if issubclass(w.category, UserWarning)]
 
 
-@pytest.mark.xfail(strict=True, reason="labels still order the set")
 @pytest.mark.parametrize(
     "sos_type", [pytest.param(1, id="sos1"), pytest.param(2, id="sos2")]
 )
@@ -131,7 +129,6 @@ def test_string_labels_are_accepted(
 
 
 @needs_highs
-@pytest.mark.xfail(strict=True, reason="labels still order the set")
 @pytest.mark.parametrize(
     "labels",
     [
@@ -145,7 +142,6 @@ def test_declaration_order_governs_adjacency(
     assert optimum(labels) == pytest.approx(2.0)
 
 
-@pytest.mark.xfail(strict=True, reason="labels still order the set")
 @pytest.mark.parametrize(
     "labels",
     [
@@ -165,7 +161,6 @@ def test_weights_are_positions_where_labels_do_not_ascend(
     assert "x2:2" in section
 
 
-@pytest.mark.xfail(strict=True, reason="the reinterpretation is silent")
 def test_labels_that_regroup_the_set_warn(sos_model: Callable[..., Model]) -> None:
     with pytest.warns(UserWarning, match="order"):
         sos_model([30, 10, 20])

--- a/test/test_sos_weights.py
+++ b/test/test_sos_weights.py
@@ -1,0 +1,171 @@
+"""
+Which order an SOS set runs in: the declared one, or the one its labels imply.
+
+Where the labels ascend the two coincide — the common case, and every piecewise
+model. Where they do not, the labels still win; those tests are ``xfail``
+until the following commit makes the declaration authoritative.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, Literal
+
+import pandas as pd
+import pytest
+
+from linopy import Model, available_solvers
+
+#: Gains that separate the two orders: the first two members declared are worth
+#: 1.0 each, the last 0.1. Declaration order can take the first two and scores
+#: 2.0; label order cannot, and settles for 1.1.
+GAINS = [1.0, 1.0, 0.1]
+
+needs_highs = pytest.mark.skipif(
+    "highs" not in available_solvers, reason="HiGHS not installed"
+)
+
+
+@pytest.fixture
+def sos_model() -> Callable[..., Model]:
+    """A three-member SOS set over ``labels``, maximising ``GAINS``."""
+
+    def build(labels: list, sos_type: Literal[1, 2] = 2, **kwargs: Any) -> Model:
+        m = Model()
+        index = pd.Index(labels, name="size")
+        x = m.add_variables(lower=0, upper=1, coords=[index], name="x")
+        m.add_sos_constraints(x, sos_type=sos_type, sos_dim="size", **kwargs)
+        m.add_objective((x * pd.Series(GAINS, index=index)).sum(), sense="max")
+        return m
+
+    return build
+
+
+@pytest.fixture
+def optimum(sos_model: Callable[..., Model]) -> Callable[..., float]:
+    """The objective such a set reaches."""
+
+    def solve(labels: list, sos_type: Literal[1, 2] = 2, **kwargs: Any) -> float:
+        m = sos_model(labels, sos_type=sos_type, **kwargs)
+        m.solve(solver_name="highs", reformulate_sos=True, output_flag=False)
+        assert m.objective.value is not None
+        return float(m.objective.value)
+
+    return solve
+
+
+@pytest.fixture
+def lp_sos_section(tmp_path: Path) -> Callable[[Model], str]:
+    """The ``sos`` section a model writes into an LP file."""
+
+    def read(m: Model) -> str:
+        fn = tmp_path / "sos.lp"
+        m.to_file(fn, io_api="lp")
+        return fn.read_text().split("\nsos\n")[1]
+
+    return read
+
+
+def test_ascending_labels_are_written_as_weights_verbatim(
+    sos_model: Callable[..., Model], lp_sos_section: Callable[[Model], str]
+) -> None:
+    section = lp_sos_section(sos_model([0.0, 1.5, 3.5]))
+
+    assert "1.5" in section
+    assert "3.5" in section
+
+
+@needs_highs
+def test_ascending_labels_make_the_first_two_members_adjacent(
+    optimum: Callable[..., float],
+) -> None:
+    assert optimum([0, 1, 2]) == pytest.approx(2.0)
+
+
+@needs_highs
+@pytest.mark.parametrize(
+    "labels",
+    [
+        pytest.param([0, 1, 2], id="ascending"),
+        pytest.param([30, 10, 20], id="unordered"),
+        pytest.param([2, 1, 0], id="descending"),
+    ],
+)
+def test_sos1_optimum_is_independent_of_label_order(
+    optimum: Callable[..., float], labels: list
+) -> None:
+    assert optimum(labels, sos_type=1) == pytest.approx(1.0)
+
+
+@needs_highs
+def test_descending_labels_reach_the_same_optimum(
+    optimum: Callable[..., float],
+) -> None:
+    """Reversing a set leaves which of its members are adjacent unchanged."""
+    assert optimum([2, 1, 0]) == pytest.approx(optimum([0, 1, 2]))
+
+
+@pytest.mark.parametrize(
+    "labels",
+    [pytest.param([0, 1, 2], id="ascending"), pytest.param([2, 1, 0], id="descending")],
+)
+def test_monotonic_labels_do_not_warn(
+    sos_model: Callable[..., Model], recwarn: pytest.WarningsRecorder, labels: list
+) -> None:
+    sos_model(labels)
+
+    assert not [w for w in recwarn if issubclass(w.category, UserWarning)]
+
+
+@pytest.mark.xfail(strict=True, reason="labels still order the set")
+@pytest.mark.parametrize(
+    "sos_type", [pytest.param(1, id="sos1"), pytest.param(2, id="sos2")]
+)
+def test_string_labels_are_accepted(
+    sos_model: Callable[..., Model], sos_type: Literal[1, 2]
+) -> None:
+    m = sos_model(["s1", "s2", "s3"], sos_type=sos_type)
+
+    assert list(m.variables.sos) == ["x"]
+
+
+@needs_highs
+@pytest.mark.xfail(strict=True, reason="labels still order the set")
+@pytest.mark.parametrize(
+    "labels",
+    [
+        pytest.param([30, 10, 20], id="numeric-out-of-order"),
+        pytest.param(["s1", "s2", "s3"], id="string"),
+    ],
+)
+def test_declaration_order_governs_adjacency(
+    optimum: Callable[..., float], labels: list
+) -> None:
+    assert optimum(labels) == pytest.approx(2.0)
+
+
+@pytest.mark.xfail(strict=True, reason="labels still order the set")
+@pytest.mark.parametrize(
+    "labels",
+    [
+        pytest.param([30, 10, 20], id="numeric-out-of-order"),
+        pytest.param(["s1", "s2", "s3"], id="string"),
+    ],
+)
+def test_weights_are_positions_where_labels_do_not_ascend(
+    sos_model: Callable[..., Model],
+    lp_sos_section: Callable[[Model], str],
+    labels: list,
+) -> None:
+    section = lp_sos_section(sos_model(labels))
+
+    assert "x0:0" in section
+    assert "x1:1" in section
+    assert "x2:2" in section
+
+
+@pytest.mark.xfail(strict=True, reason="the reinterpretation is silent")
+def test_labels_that_regroup_the_set_warn(sos_model: Callable[..., Model]) -> None:
+    with pytest.warns(UserWarning, match="order"):
+        sos_model([30, 10, 20])


### PR DESCRIPTION
*(your intent here, handwritten)*

> [!NOTE]
> The following content was generated by AI.

Closes #892.

An SOS set now runs in the order its members are declared along `sos_dim`, rather than the order its coordinate labels sort into — the array order linopy reads everywhere else (`isel`, `shift`, `roll`, `diff`).

## Why

Making the labels the SOS weights had two consequences:

- a string-labelled dimension could carry no set at all (`ValueError: SOS constraint requires numeric coordinates`), reaching `piecewise` the day its breakpoints are labelled `[low, mid, high]`;
- numeric labels declared out of order silently redefined which members are adjacent. Two models identical member-for-member reached different optima depending only on what the coordinates were named, both reported optimal.

## What does not change

Ascending numeric coordinates state the same order and are still passed through as the member weights, so a model whose SOS dimension is sorted is unaffected down to the bytes of its LP file — every piecewise formulation among them, since `_validate_numeric_breakpoint_coords` already requires strictly increasing breakpoints.

Descending coordinates are also meaning-preserving: reversing a set maps its consecutive pairs `{i, i+1}` to `{n-i, n+1-i}`, which are consecutive too, so SOS2's feasible set is unchanged. Only a `sos_type=2` set whose numeric coordinates *neither* ascend *nor* descend genuinely regroups; it now warns, and sorting the index restores the previous behaviour. An `sos_type=1` set cannot change meaning at all — its feasible region never depended on the order, `reformulate_sos1` being `x <= M * y` and `sum(y) <= 1` — so it stays silent.

## Notes for review

- The numeric-coordinate requirement is dropped for both SOS types.
- `reformulate_sos_constraints` loses its `argsort`: that permutation is now always the identity, so it is deleted rather than rewritten. `reformulate_sos2` selects the neighbouring segment indicators with `isel` instead of `sel`.
- `test_sos2_unsorted_coords_matches_sorted` passes both before and after, its best pair happening to coincide either way. That is why this was never caught, and why the new tests pick coefficients that separate the two orders.

## Commits

1. `test(sos)` — five tests pinning the overlap where labels and declaration agree, plus seven strict `xfail`s marking where they part. Self-verifying at that commit.
2. `fix(sos)` — the rule, with the `xfail` markers removed.
