### PR TITLE
fix: _as_index() calls to_index() for DataArrays

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -15,7 +15,7 @@ Upcoming Version
 
 * ``Model.remove_variables`` no longer removes constraints that never reference the removed variable. A masked variable carries ``-1`` label entries, which matched the ``-1`` that marks an empty term slot in a constraint, so any masked variable looked like it was used by any constraint with padded terms. Models built with ``mask=`` could silently lose constraints and solve to a wrong optimum. (`#883 <https://github.com/PyPSA/linopy/issues/883>`__)
 * ``Model.remove_variables`` now also works on a model with a quadratic objective, where it raised an ``IndexError`` because the term mask was built over the factor dimension as well. Quadratic terms are dropped when any of their factors references the removed variable. (`#883 <https://github.com/PyPSA/linopy/issues/883>`__)
-
+* Using timezone-aware ``DatetimeIndex`` coordinates in a model no longer raises a ``ValueError``. The index is now retrieved directly via ``DataArray.to_index()`` instead of rebuilding it with ``pd.Index()``, which dropped the timezone info and failed during alignment. (`#898 <https://github.com/PyPSA/linopy/issues/898>`__)
 
 Version v0.9.0
 --------------

--- a/linopy/alignment.py
+++ b/linopy/alignment.py
@@ -172,9 +172,11 @@ def _coords_to_dict(
 
 
 def _as_index(coord_values: Any) -> pd.Index:
-    return (
-        coord_values if isinstance(coord_values, pd.Index) else pd.Index(coord_values)
-    )
+    if isinstance(coord_values, DataArray):
+        return coord_values.to_index()
+    if isinstance(coord_values, pd.Index):
+        return coord_values
+    return pd.Index(coord_values)
 
 
 def _as_multiindex(coord_values: Any) -> pd.MultiIndex | None:

--- a/test/test_alignment.py
+++ b/test/test_alignment.py
@@ -572,6 +572,17 @@ class TestCoordsToDict:
 class TestAddVariablesCoords:
     """End-to-end: each coords / dims form sets the variable's dimensions."""
 
+    @staticmethod
+    def _datetime_coordinates(timezone: str | None) -> xr.Coordinates:
+        time = pd.date_range(
+            "2025-10-26 00:00",
+            periods=5,
+            freq="h",
+            tz=timezone,
+            name="time",
+        )
+        return xr.Coordinates({"time": time})
+
     @pytest.mark.parametrize(
         "coords, dims, expected_dims",
         [
@@ -586,6 +597,9 @@ class TestAddVariablesCoords:
             ([np.array([0, 1, 2])], None, ("dim_0",)),
             ([pd.Index([0, 1, 2])], None, ("dim_0",)),
             ([("origin", ["a", "b"]), ("dest", ["x", "y"])], None, ("origin", "dest")),
+            (_datetime_coordinates(None), None, ("time",)),
+            (_datetime_coordinates("UTC"), None, ("time",)),
+            (_datetime_coordinates("Europe/Berlin"), None, ("time",)),
         ],
         ids=[
             "tuple",
@@ -599,6 +613,9 @@ class TestAddVariablesCoords:
             "ndarray",
             "unnamed-index",
             "multiple-tuples",
+            "xarray-datetime-naive",
+            "xarray-datetime-utc",
+            "xarray-datetime-dst",
         ],
     )
     def test_coords_set_variable_dims(


### PR DESCRIPTION
Closes #898 (if applicable).

<!-- Using AI? Keep this description human: write your own intent by hand and
mark AI-generated content. See AGENTS.md for the rules. -->

## Changes proposed in this Pull Request
helper in alignment.py uses `DataArray.to_index()` to retrieve the actual pandas index object instead of re-building it via `pd.Index`. This fixes regression where timezone-aware indexes cannot be used to build a model.

Unit tests are added to validate that models can be built with timezone-aware coords.

## Checklist

- [ ] AI-generated content is marked (see [`AGENTS.md`](../blob/master/AGENTS.md)).
- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [ ] I consent to the release of this PR's code under the MIT license.
