### PR TITLE
test(alignment): assert coord values, not just dims

### DIFF
--- a/test/test_alignment.py
+++ b/test/test_alignment.py
@@ -565,41 +565,49 @@ class TestCoordsToDict:
 
 
 # ---------------------------------------------------------------------------
-# add_variables — coords / dims map to the variable's dimensions
+# add_variables — coords / dims map to the variable's dimensions and values
 # ---------------------------------------------------------------------------
 
 
-class TestAddVariablesCoords:
-    """End-to-end: each coords / dims form sets the variable's dimensions."""
+def _hourly_index(timezone: str | None) -> pd.DatetimeIndex:
+    """Five hourly stamps spanning the Europe/Berlin DST fallback."""
+    return pd.date_range(
+        "2025-10-26 00:00", periods=5, freq="h", tz=timezone, name="time"
+    )
 
-    @staticmethod
-    def _datetime_coordinates(timezone: str | None) -> xr.Coordinates:
-        time = pd.date_range(
-            "2025-10-26 00:00",
-            periods=5,
-            freq="h",
-            tz=timezone,
-            name="time",
-        )
-        return xr.Coordinates({"time": time})
+
+def _datetime_coordinates(timezone: str | None) -> xr.Coordinates:
+    return xr.Coordinates({"time": _hourly_index(timezone)})
+
+
+class TestAddVariablesCoords:
+    """End-to-end: each coords / dims form sets the variable's dims and values."""
 
     @pytest.mark.parametrize(
-        "coords, dims, expected_dims",
+        "coords, dims, expected_coords",
         [
-            ([("x", [0, 1, 2])], None, ("x",)),
-            ([pd.Index([0, 1, 2], name="x")], None, ("x",)),
-            ([pd.Index([0, 1, 2])], ["x"], ("x",)),
-            ([[0, 1, 2]], ["x"], ("x",)),
-            ([range(3)], ["x"], ("x",)),
-            ([np.array([0, 1, 2])], ["x"], ("x",)),
-            ([[0, 1, 2]], None, ("dim_0",)),
-            ([range(3)], None, ("dim_0",)),
-            ([np.array([0, 1, 2])], None, ("dim_0",)),
-            ([pd.Index([0, 1, 2])], None, ("dim_0",)),
-            ([("origin", ["a", "b"]), ("dest", ["x", "y"])], None, ("origin", "dest")),
-            (_datetime_coordinates(None), None, ("time",)),
-            (_datetime_coordinates("UTC"), None, ("time",)),
-            (_datetime_coordinates("Europe/Berlin"), None, ("time",)),
+            ([("x", [0, 1, 2])], None, {"x": [0, 1, 2]}),
+            ([pd.Index([0, 1, 2], name="x")], None, {"x": [0, 1, 2]}),
+            ([pd.Index([0, 1, 2])], ["x"], {"x": [0, 1, 2]}),
+            ([[0, 1, 2]], ["x"], {"x": [0, 1, 2]}),
+            ([range(3)], ["x"], {"x": [0, 1, 2]}),
+            ([np.array([0, 1, 2])], ["x"], {"x": [0, 1, 2]}),
+            ([[0, 1, 2]], None, {"dim_0": [0, 1, 2]}),
+            ([range(3)], None, {"dim_0": [0, 1, 2]}),
+            ([np.array([0, 1, 2])], None, {"dim_0": [0, 1, 2]}),
+            ([pd.Index([0, 1, 2])], None, {"dim_0": [0, 1, 2]}),
+            (
+                [("origin", ["a", "b"]), ("dest", ["x", "y"])],
+                None,
+                {"origin": ["a", "b"], "dest": ["x", "y"]},
+            ),
+            (_datetime_coordinates(None), None, {"time": _hourly_index(None)}),
+            (_datetime_coordinates("UTC"), None, {"time": _hourly_index("UTC")}),
+            (
+                _datetime_coordinates("Europe/Berlin"),
+                None,
+                {"time": _hourly_index("Europe/Berlin")},
+            ),
         ],
         ids=[
             "tuple",
@@ -618,12 +626,14 @@ class TestAddVariablesCoords:
             "xarray-datetime-dst",
         ],
     )
-    def test_coords_set_variable_dims(
-        self, coords: Any, dims: Any, expected_dims: tuple
+    def test_coords_set_variable_dims_and_values(
+        self, coords: Any, dims: Any, expected_coords: dict
     ) -> None:
         m = Model()
         v = m.add_variables(lower=0, coords=coords, dims=dims)
-        assert v.dims == expected_dims
+        assert v.dims == tuple(expected_coords)
+        for dim, values in expected_coords.items():
+            assert v.indexes[dim].equals(pd.Index(values))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The test also compares the coord values, on top of the existing dim names now

> [!NOTE]
> The following content was generated by AI.

Follow-up to #897, now rebased onto master since that merged — the diff here
is one commit touching only `test/test_alignment.py`.

`TestAddVariablesCoords.test_coords_set_variable_dims` asserted which
dimensions each coords form produces, but never the values behind them. A
coords form that silently reordered, re-typed or truncated its entries passed.

Each case now carries a `dim -> values` mapping instead of a dims tuple, and
the test asserts the resulting index against it, so both halves of the
contract are pinned for all 14 forms — including the three timezone-aware
ones from #897, where the value assertion is what actually catches #898.
Reverting #897's `_as_index` change fails the `xarray-datetime-utc` and
`xarray-datetime-dst` cases under both the legacy and v1 conventions; with it,
the file is 228 passed / 14 skipped and the suite 5253 passed / 493 skipped.

The DST-spanning hourly range is @peterhron's from #897, kept as-is and
lifted into a module-level `_hourly_index` so the expected column can reuse it.

## Checklist

- [x] AI-generated content is marked (see [`AGENTS.md`](../blob/master/AGENTS.md)).
- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included. — n/a, test-only; the note for the fix landed with #897.
- [x] I consent to the release of this PR's code under the MIT license.
