### PR TITLE
fix: Model.copy() silently drops the quadratic part of the objective

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -54,6 +54,7 @@ Upcoming Version
 **Bug fixes**
 
 * A multi-key ``groupby`` now returns its groups sorted by key tuple, like the single-key path. The key combinations were numbered by iterating a ``set``, so the group order was arbitrary and changed between processes with ``PYTHONHASHSEED``.
+* ``Model.copy`` (and the ``copy.copy``/``copy.deepcopy`` protocols) no longer downgrades a quadratic objective to a linear one. The objective was rebuilt as a ``LinearExpression`` regardless of its type, so the copy silently solved a different problem. ``linopy.testing.assert_model_equal`` now compares the objective by expression type as well, which it could not do before. (`#903 <https://github.com/PyPSA/linopy/issues/903>`__)
 
 
 Version 0.9.1

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -55,6 +55,7 @@ Upcoming Version
 
 * A multi-key ``groupby`` now returns its groups sorted by key tuple, like the single-key path. The key combinations were numbered by iterating a ``set``, so the group order was arbitrary and changed between processes with ``PYTHONHASHSEED``.
 * ``Model.copy`` (and the ``copy.copy``/``copy.deepcopy`` protocols) no longer downgrades a quadratic objective to a linear one. The objective was rebuilt as a ``LinearExpression`` regardless of its type, so the copy silently solved a different problem. ``linopy.testing.assert_model_equal`` now compares the objective by expression type as well, which it could not do before. (`#903 <https://github.com/PyPSA/linopy/issues/903>`__)
+* ``Model.to_netcdf``/``linopy.read_netcdf`` downgraded a quadratic objective the same way; the expression type is now stored alongside the objective and restored on read. Files written by earlier versions are read as before. (`#903 <https://github.com/PyPSA/linopy/issues/903>`__)
 
 
 Version 0.9.1

--- a/linopy/io.py
+++ b/linopy/io.py
@@ -1267,7 +1267,9 @@ def copy(m: Model, include_solution: bool = False, deep: bool = True) -> Model:
         new_model,
     )
 
-    obj_expr = LinearExpression(m.objective.expression.data.copy(deep=deep), new_model)
+    obj_expr = type(m.objective.expression)(
+        m.objective.expression.data.copy(deep=deep), new_model
+    )
     new_model._objective = Objective(obj_expr, new_model, m.objective.sense)
     new_model._objective._value = (
         float(m.objective.value)

--- a/linopy/io.py
+++ b/linopy/io.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 NETCDF_VERSION_ATTR = "_linopy_version"
+EXPR_TYPE_ATTR = "_linopy_expr_type"
 
 
 ufunc_kwargs = dict(vectorize=True)
@@ -986,14 +987,14 @@ def to_netcdf(m: Model, *args: Any, **kwargs: Any) -> None:
     ]
     exprs = [
         with_prefix(
-            expr.data.assign_attrs(name=name, _linopy_expr_type=expr.type),
+            expr.data.assign_attrs(name=name, **{EXPR_TYPE_ATTR: expr.type}),
             f"expressions-{name}",
         )
         for name, expr in m.expressions.items()
     ]
     objective = m.objective.data
     objective = objective.assign_attrs(
-        sense=m.objective.sense, _linopy_expr_type=m.objective.expression.type
+        sense=m.objective.sense, **{EXPR_TYPE_ATTR: m.objective.expression.type}
     )
     if m.objective.value is not None:
         objective = objective.assign_attrs(value=m.objective.value)
@@ -1116,7 +1117,7 @@ def read_netcdf(path: Path | str, **kwargs: Any) -> Model:
     for k in sorted(expr_names):
         name = remove_prefix(k, "expressions")
         expr_ds = get_prefix(ds, k)
-        expr_type = expr_ds.attrs.pop("_linopy_expr_type", None)
+        expr_type = expr_ds.attrs.pop(EXPR_TYPE_ATTR, None)
         expr_ds.attrs.pop("name", None)  # re-attached below, after construction
         expr: LinearExpression | QuadraticExpression
         if expr_type == "QuadraticExpression" or (
@@ -1143,7 +1144,7 @@ def read_netcdf(path: Path | str, **kwargs: Any) -> Model:
     m._constraints = Constraints(constraints, m)
 
     objective = get_prefix(ds, "objective")
-    obj_type = objective.attrs.pop("_linopy_expr_type", None)
+    obj_type = objective.attrs.pop(EXPR_TYPE_ATTR, None)
     obj_cls: type[LinearExpression] | type[QuadraticExpression] = (
         QuadraticExpression
         if obj_type == "QuadraticExpression"

--- a/linopy/io.py
+++ b/linopy/io.py
@@ -992,7 +992,9 @@ def to_netcdf(m: Model, *args: Any, **kwargs: Any) -> None:
         for name, expr in m.expressions.items()
     ]
     objective = m.objective.data
-    objective = objective.assign_attrs(sense=m.objective.sense)
+    objective = objective.assign_attrs(
+        sense=m.objective.sense, _linopy_expr_type=m.objective.expression.type
+    )
     if m.objective.value is not None:
         objective = objective.assign_attrs(value=m.objective.value)
     obj = [with_prefix(objective, "objective")]
@@ -1141,9 +1143,14 @@ def read_netcdf(path: Path | str, **kwargs: Any) -> Model:
     m._constraints = Constraints(constraints, m)
 
     objective = get_prefix(ds, "objective")
-    m.objective = Objective(
-        LinearExpression(objective, m), m, objective.attrs.pop("sense")
+    obj_type = objective.attrs.pop("_linopy_expr_type", None)
+    obj_cls: type[LinearExpression] | type[QuadraticExpression] = (
+        QuadraticExpression
+        if obj_type == "QuadraticExpression"
+        or (obj_type is None and FACTOR_DIM in objective.dims)
+        else LinearExpression
     )
+    m.objective = Objective(obj_cls(objective, m), m, objective.attrs.pop("sense"))
     m.objective._value = objective.attrs.pop("value", None)
 
     m.parameters = get_prefix(ds, "parameters")

--- a/linopy/testing.py
+++ b/linopy/testing.py
@@ -130,7 +130,7 @@ def assert_model_equal(a: Model, b: Model) -> None:
     for e in a.expressions:
         assert_exprequal(a.expressions[e], b.expressions[e])
 
-    assert_linequal(a.objective.expression, b.objective.expression)
+    assert_exprequal(a.objective.expression, b.objective.expression, check_name=False)
     assert a.objective.sense == b.objective.sense
     assert a.objective.value == b.objective.value
 

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -277,6 +277,20 @@ def test_model_to_netcdf_quadratic_expression(
     assert_exprequal(m.expressions["quad"], p.expressions["quad"])
 
 
+def test_model_to_netcdf_quadratic_objective(tmp_path: Path) -> None:
+    """A quadratic objective survives the round-trip as a QP, not an LP."""
+    m = Model()
+    x = m.add_variables(4, pd.Series([8, 10]), name="x")
+    m.add_objective((x * x + 2 * x).sum())
+
+    fn = tmp_path / "test.nc"
+    m.to_netcdf(fn)
+    p = read_netcdf(fn)
+
+    assert isinstance(p.objective.expression, QuadraticExpression)
+    assert_model_equal(m, p)
+
+
 def test_model_to_netcdf_expression_dash_name(
     model_with_expressions: Model, tmp_path: Path
 ) -> None:

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import copy as pycopy
 import weakref
+from collections.abc import Callable
 from pathlib import Path
 from tempfile import gettempdir
 
@@ -392,6 +393,29 @@ def test_copy_model_with_expressions(
     original_coeff = m.expressions["lin"].coeffs.values.flat[0].item()
     deep.expressions["lin"].coeffs.values.flat[0] = original_coeff + 42
     assert m.expressions["lin"].coeffs.values.flat[0] == original_coeff
+
+
+@pytest.mark.parametrize(
+    "copy_fn",
+    [lambda m: m.copy(), pycopy.copy, pycopy.deepcopy],
+    ids=["copy", "shallowcopy", "deepcopy"],
+)
+@pytest.mark.xfail(
+    strict=True, reason="issue #903: copy downgrades a quadratic objective to linear"
+)
+def test_model_copy_preserves_quadratic_objective(
+    copy_fn: Callable[[Model], Model],
+) -> None:
+    """Copying a model keeps its objective quadratic instead of linearizing it."""
+    m: Model = Model()
+    x = m.add_variables(lower=-5, upper=5, name="x")
+    m.add_objective(x * x + 2 * x)
+
+    c = copy_fn(m)
+
+    assert type(c.objective.expression) is type(m.objective.expression)
+    assert c.type == m.type == "QP"
+    assert_model_equal(m, c)
 
 
 @pytest.mark.skipif(not available_solvers, reason="No solver installed")

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -400,9 +400,6 @@ def test_copy_model_with_expressions(
     [lambda m: m.copy(), pycopy.copy, pycopy.deepcopy],
     ids=["copy", "shallowcopy", "deepcopy"],
 )
-@pytest.mark.xfail(
-    strict=True, reason="issue #903: copy downgrades a quadratic objective to linear"
-)
 def test_model_copy_preserves_quadratic_objective(
     copy_fn: Callable[[Model], Model],
 ) -> None:


### PR DESCRIPTION
<!-- Please replace this line with your own intent/motivation before marking ready. -->

Closes #903.

> [!NOTE]
> The following content was generated by AI.

`Model.copy()` wrapped the objective's `Dataset` in `LinearExpression` unconditionally, so
a `QuadraticExpression` objective was silently downgraded — `Model.type` flipped from `QP`
to `LP`, the quadratic term's second variable column was reinterpreted as a linear row, and
the copy solved a *different* problem without any warning (`-14.0` instead of `0.75` in the
issue's repro). `copy.copy`/`copy.deepcopy` route through the same function.

Three commits, the last one droppable on its own:

1. **test** — strict-xfail regression test over `Model.copy` / `copy.copy` / `copy.deepcopy`.
2. **fix (copy)** — dispatch on `type(m.objective.expression)`, as `_copy_expr` already does
   for named expressions. Also switches `assert_model_equal` from `assert_linequal` to
   `assert_exprequal` for the objective: `assert_linequal` rejects a `QuadraticExpression`
   outright, so `assert_model_equal` could not be used on a QP model at all, and it now
   catches a mismatch in expression type.
3. **fix (netcdf)** — *not part of the issue, drop this commit if you'd rather keep it
   separate.* `to_netcdf`/`read_netcdf` downgraded the objective exactly the same way, so a
   saved QP came back an LP. The expression type is now stored next to the objective and
   restored on read, falling back to the presence of the factor dimension for files written
   by earlier versions.

<details>
<summary>Issue repro, before and after</summary>

```
# before
QP True QuadraticExpression
LP False LinearExpression
copy.copy LP False
copy.deepcopy LP False
original objective: 0.75000000000001
copy objective    : -14.0

# after
QP True QuadraticExpression
QP True QuadraticExpression
copy.copy QP True
copy.deepcopy QP True
original: 0.75000000000001 copy: 0.75000000000001
Q is None on copy: False   c shape: (2,)
```

</details>
