### PR TITLE
fix(deps): resolve gpu/benchmarks extras conflict for uv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,11 @@ gpu = [
     # "cupdlpx>=0.1.2", pip package currently unstable, install manually
 ]
 
+[tool.uv]
+# cuopt-cu12 pulls cudf-cu12, which pins pandas<3.0.4, while benchmarks pins
+# pandas==3.0.5. Resolve the two extras in separate forks instead of together.
+conflicts = [[{ extra = "gpu" }, { extra = "benchmarks" }]]
+
 [tool.setuptools.packages.find]
 include = ["linopy", "linopy.*"]
 


### PR DESCRIPTION
Since #909, `uv lock`/`uv sync` fail for everyone on master. This unblocks the dev environment again.

> [!NOTE]
> The following content was generated by AI.

## Problem
`#909` added `cuopt-cu12>=26.8` to the `gpu` extra. It pulls `cudf-cu12`, which pins `pandas>=3.0.0,<3.0.4a0`. The `benchmarks` extra pins `pandas==3.0.5`. The two are mutually incompatible, and the dev resolution requires both, so `uv` resolution is unsatisfiable:

```
Because cudf-cu12>=26.8.0 depends on pandas>=3.0.0,<3.0.4a0 ...
And because linopy[benchmarks] depends on pandas==3.0.5, we can
conclude that linopy[benchmarks] and linopy[gpu] are incompatible.
And because your project requires linopy[benchmarks] and linopy[gpu], we
can conclude that your project's requirements are unsatisfiable.
```

## Fix
Declare the two extras as conflicting so `uv` resolves them in separate forks instead of unifying them:

```toml
[tool.uv]
conflicts = [[{ extra = "gpu" }, { extra = "benchmarks" }]]
```

After this, `uv lock` resolves (263 packages), `uv lock --check` passes, and `uv sync --extra dev` works. `gpu` and `benchmarks` remain individually installable but not together, which reflects the underlying pandas incompatibility.

## Checklist
- [x] AI-generated content is marked.
- [ ] Unit tests for new features were added (not applicable; dependency metadata).
- [ ] A release note is included (can add if wanted).
- [x] I consent to the release of this PR's code under the MIT license.
