### PR TITLE
fix(options): context manager restores values active on entry

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -54,6 +54,7 @@ Upcoming Version
 **Bug fixes**
 
 * A multi-key ``groupby`` now returns its groups sorted by key tuple, like the single-key path. The key combinations were numbered by iterating a ``set``, so the group order was arbitrary and changed between processes with ``PYTHONHASHSEED``.
+* The ``linopy.options`` context manager now restores the values that were active on entry instead of resetting all options to their defaults.
 
 
 Version 0.9.1

--- a/linopy/config.py
+++ b/linopy/config.py
@@ -25,11 +25,12 @@ class LinopySemanticsWarning(FutureWarning):
 
 
 class OptionSettings:
-    """Runtime configuration knobs (e.g. display widths). Use as a context manager or set values directly via ``options(key=value)``."""
+    """Runtime configuration knobs (e.g. display widths). Use as a context manager, which restores the values active on entry on exit, or set values directly via ``options(key=value)``."""
 
     def __init__(self, **kwargs: Any) -> None:
         self._defaults = kwargs
         self._current_values = kwargs.copy()
+        self._stack: list[dict[str, Any]] = []
 
     def __call__(self, **kwargs: Any) -> None:
         self.set_value(**kwargs)
@@ -61,6 +62,7 @@ class OptionSettings:
         self._current_values = self._defaults.copy()
 
     def __enter__(self) -> OptionSettings:
+        self._stack.append(self._current_values.copy())
         return self
 
     def __exit__(
@@ -69,7 +71,7 @@ class OptionSettings:
         exc_val: BaseException | None,
         exc_tb: Any | None,
     ) -> None:
-        self.reset()
+        self._current_values = self._stack.pop()
 
     def __repr__(self) -> str:
         settings = "\n ".join(

--- a/test/test_options.py
+++ b/test/test_options.py
@@ -64,3 +64,37 @@ def test_reset(options: OptionSettings) -> None:
     options(a=10)
     options.reset()
     assert options._current_values == {"a": 1, "b": 2, "c": 3}
+
+
+def test_context_restores_prior_value(options: OptionSettings) -> None:
+    options(a=5)
+    with options:
+        options(a=10)
+    assert options._current_values == {"a": 5, "b": 2, "c": 3}
+
+
+def test_context_undoes_inner_changes(options: OptionSettings) -> None:
+    with options as o:
+        o(b=20)
+        assert o.get_value("b") == 20
+    assert options.get_value("b") == 2
+
+
+def test_nested_context_restores_level_by_level(options: OptionSettings) -> None:
+    options(a=1)
+    with options:
+        options(a=2)
+        with options:
+            options(a=3)
+            assert options.get_value("a") == 3
+        assert options.get_value("a") == 2
+    assert options.get_value("a") == 1
+
+
+def test_context_restores_on_exception(options: OptionSettings) -> None:
+    options(a=1)
+    with pytest.raises(ValueError):
+        with options:
+            options(a=99)
+            raise ValueError("boom")
+    assert options.get_value("a") == 1


### PR DESCRIPTION
Groundwork for #919: a spec-built model must run under v1 semantics, and that needs `linopy.options` to be scopable without losing a globally set value.

> [!NOTE]
> The following content was generated by AI.

## Changes proposed in this Pull Request

`OptionSettings.__exit__` reset every option to its default, so this lost the outer setting:

```python
options["semantics"] = "v1"
with options as o:
    o(display_max_rows=3)
options["semantics"]  # "legacy"
```

- `__enter__` now pushes a copy of the current values onto a stack and `__exit__` pops it back, so nested blocks restore level by level and the restore also runs when an exception propagates.
- `reset()` and the existing `with options as opts:` call sites are unchanged.
- Four tests in `test/test_options.py` cover prior value surviving a block, inner changes undone, nesting, and exception.
- Release note added under Bug fixes.

## Checklist

- [x] AI-generated content is marked (see [`AGENTS.md`](../blob/master/AGENTS.md)).
- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.