### PR TITLE
fix(v1): sparse merge keeps absent cells absent instead of zero-filling (#928)

### DIFF
--- a/linopy/sparse_expression.py
+++ b/linopy/sparse_expression.py
@@ -90,7 +90,9 @@ class CSRPayload:
             if d != member_dim
         }
         indexes[group_dim] = pd.Index(uniques, name=group_dim)
-        return cls._from_scatter(expr, grid_dims, indexes, group_dim, member_dim, codes)
+        return cls._from_scatter(
+            expr, grid_dims, indexes, group_dim, member_dim, codes, True
+        )
 
     @classmethod
     def from_expression(
@@ -105,7 +107,7 @@ class CSRPayload:
         first = template.grid_dims[0]
         codes = np.arange(len(template.indexes[first]))
         return cls._from_scatter(
-            expr, template.grid_dims, template.indexes, first, first, codes
+            expr, template.grid_dims, template.indexes, first, first, codes, False
         )
 
     @classmethod
@@ -117,13 +119,16 @@ class CSRPayload:
         scatter_dim: str,
         member_dim: str,
         codes: np.ndarray,
+        skipna: bool,
     ) -> CSRPayload:
         """
         Scatter an expression's terms into grid rows (conceptually ``G @ A``):
         ``member_dim`` lands in the grid dim ``scatter_dim`` at row positions
         ``codes``, every other grid dim maps one-to-one, and the COO→CSR
-        conversion sums duplicates — which is the group sum. The constant is
-        reduced with the dense kernel's skipna semantics.
+        conversion sums duplicates — which is the group sum. With ``skipna``
+        the constant is reduced as by the dense group kernel (NaN members
+        count as 0); without it an absent cell (NaN const) stays absent, as
+        on the dense v1 merge path.
         """
         ds = expr.data
         shape = tuple(len(indexes[d]) for d in grid_dims)
@@ -153,8 +158,10 @@ class CSRPayload:
         )
 
         const_vals = ds.const.transpose(*transposed).to_numpy().reshape(-1)
+        if skipna:
+            const_vals = np.where(np.isnan(const_vals), 0.0, const_vals)
         const = np.zeros(full_size)
-        np.add.at(const, cell_rows, np.where(np.isnan(const_vals), 0.0, const_vals))
+        np.add.at(const, cell_rows, const_vals)
 
         return cls(scipy.sparse.csr_array(coo), const, grid_dims, indexes, expr.model)
 
@@ -187,8 +194,10 @@ class CSRPayload:
         """
         Expand to the dense rectangle in canonical form: terms label-ordered,
         duplicates summed, padded to the widest cell with the usual fill.
+        Absent cells (NaN const) carry no terms, per the v1 dead-term invariant.
         """
         from linopy.expressions import LinearExpression
+        from linopy.semantics import absorb_absence
 
         csr = self.csr.copy()
         csr.sort_indices()
@@ -213,7 +222,7 @@ class CSRPayload:
             },
             coords={d: self.indexes[d] for d in self.grid_dims},
         )
-        return LinearExpression(ds, self.model)
+        return LinearExpression(absorb_absence(ds), self.model)
 
 
 def try_csr_merge(

--- a/test/test_sparse_groupby.py
+++ b/test/test_sparse_groupby.py
@@ -132,6 +132,24 @@ def test_zero_coefficient_rows_stay_active(sparse: bool) -> None:
     assert len(con.active_labels()) == c.load.size
 
 
+def test_merge_keeps_absent_cell_absent() -> None:
+    require_v1()
+    c = base_model()
+    dense = (c.eff * c.gen_p).groupby(c.gbus).sum()
+    flow = (1.0 * c.flow).groupby(c.bus0).sum()
+    mask = xr.DataArray(np.arange(len(c.load.bus)) % 2 == 0, coords=[c.load.bus])
+    flow = flow.where(mask)
+
+    sparse = (c.eff * c.gen_p).groupby(c.gbus).sum(sparse=True)
+    tot = linopy.merge([sparse, flow], join="outer")
+    assert tot._payload is not None
+    assert_linequal(tot, linopy.merge([dense, flow], join="outer"))
+
+    con = c.m.add_constraints(tot >= c.load, name="bal", freeze=True)
+    assert isinstance(con, CSRConstraint)
+    assert con.ncons == int(mask.sum()) * c.load.sizes["snapshot"]
+
+
 @pytest.mark.parametrize(
     "grouper, kwargs",
     [


### PR DESCRIPTION
Part of layer 0 in https://github.com/PyPSA/linopy/issues/756#issuecomment-5558889654. Rather a small but needed fix.

Closes #928.

> [!NOTE]
> The following content was generated by AI (Claude Code).

**Root cause.** `CSRPayload._from_scatter` zero-filled a NaN constant for every caller. That matches the dense group kernel in `from_grouper` (a NaN member counts as 0), but it is wrong in `from_expression`, which converts a dense summand during `try_csr_merge`: there a NaN const means the cell is absent and must propagate, as the dense v1 merge does via `skipna=False` and `absorb_absence`.

**Fix.**
- `_from_scatter` takes a `skipna` flag: `from_grouper` passes `True`, `from_expression` passes `False`, so an absent cell keeps its NaN const in the payload.
- `materialize` applies `absorb_absence`, so the dense expansion carries no terms in absent cells (the CSR rows still hold the other summand's terms).
- `CSRConstraint.from_payload` needed no change: it moves the const into the rhs and already drops NaN-rhs rows.

**Test.** `test_merge_keeps_absent_cell_absent` merges a sparse group sum with a `.where`-masked dense one, asserts equality with the all-dense merge, and asserts the frozen `CSRConstraint` drops the masked rows.

<details>
<summary>Repro from the issue, after the fix</summary>

```
sparse=False: const=[ 0. nan] rows=1
sparse=True:  const=[ 0. nan] rows=1
```

</details>
