### PR TITLE
feat(sparse): payload-preserving reindex via CSRPayload.reindexed

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -67,7 +67,7 @@ Version 0.9.1
 
 * ``Model.remove_variables`` is 2-5x faster. The masked labels are filtered once per removal instead of once per constraint group, membership is tested against the contiguous label range rather than by a sort-based ``isin``, and CSR-backed constraints are matched on term positions instead of gathering their labels. (`#895 <https://github.com/PyPSA/linopy/pull/895>`__)
 
-* ``LinearExpression.reindex`` keeps a sparse (CSR-backed) expression sparse for plain label changes — reorder, add, or drop coordinates — instead of expanding to the dense ``_term`` rectangle. New coordinates become absent cells; the result matches the dense reindex. A ``groupby(sparse=True) → reindex → merge`` chain therefore stays sparse, cutting the transient build peak on ragged constraints (v1 only; other reindex arguments fall back to the dense path). (`#932 <https://github.com/PyPSA/linopy/issues/932>`__)
+* ``LinearExpression.reindex`` keeps a sparse (CSR-backed) expression sparse for plain label changes — reorder, add, or drop coordinates — instead of expanding to the dense rectangle. New coordinates become absent cells and the result matches the dense reindex, so a ``groupby(sparse=True) → reindex → merge`` chain stays sparse and the build peak stays low (v1 only; other arguments fall back to dense). (`#932 <https://github.com/PyPSA/linopy/issues/932>`__)
 
 **Bug fixes**
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -67,6 +67,8 @@ Version 0.9.1
 
 * ``Model.remove_variables`` is 2-5x faster. The masked labels are filtered once per removal instead of once per constraint group, membership is tested against the contiguous label range rather than by a sort-based ``isin``, and CSR-backed constraints are matched on term positions instead of gathering their labels. (`#895 <https://github.com/PyPSA/linopy/pull/895>`__)
 
+* ``LinearExpression.reindex`` keeps a sparse (CSR-backed) expression sparse for plain label changes — reorder, add, or drop coordinates — instead of expanding to the dense ``_term`` rectangle. New coordinates become absent cells; the result matches the dense reindex. A ``groupby(sparse=True) → reindex → merge`` chain therefore stays sparse, cutting the transient build peak on ragged constraints (v1 only; other reindex arguments fall back to the dense path). (`#932 <https://github.com/PyPSA/linopy/issues/932>`__)
+
 **Bug fixes**
 
 * An SOS set is now ordered by declaration, not by the values of its coordinates. Labels are names, but they were handed to the solver as SOS weights, so element-for-element identical models could reach different optima — silently changing who is adjacent in a ``sos_type=2`` set — just because their coordinates were named differently. **Behaviour change:** ascending coordinates are unaffected (this covers every piecewise formulation), descending ones now run in reverse with the same adjacency, and only a ``sos_type=2`` set whose numeric coordinates neither ascend nor descend changes meaning — that case now warns, and sorting the index restores the old order. (`#892 <https://github.com/PyPSA/linopy/issues/892>`__, `#893 <https://github.com/PyPSA/linopy/pull/893>`__)

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -47,7 +47,7 @@ from xarray import Coordinates, DataArray, Dataset, IndexVariable
 from xarray.core.coordinates import DataArrayCoordinates, DatasetCoordinates
 from xarray.core.indexes import Indexes
 from xarray.core.types import JoinOptions
-from xarray.core.utils import Frozen
+from xarray.core.utils import Frozen, either_dict_or_kwargs
 
 try:
     # resolve breaking change in xarray 2025.03.0
@@ -2487,6 +2487,43 @@ class LinearExpression(BaseExpression):
         df = df.groupby("vars", as_index=False).sum()
         check_has_nulls(df, name=self.type)
         return df
+
+    def reindex(
+        self,
+        indexers: Mapping[Any, Any] | None = None,
+        *,
+        method: str | None = None,
+        tolerance: Any = None,
+        copy: bool = True,
+        fill_value: Any = FILL_VALUE,
+        **indexers_kwargs: Any,
+    ) -> LinearExpression:
+        """
+        Conform to new coordinates as ``Dataset.reindex``; a CSR-backed
+        expression stays sparse when only labels change.
+        """
+        indexers = either_dict_or_kwargs(indexers, indexers_kwargs, "reindex")
+        payload = self._payload
+        if (
+            payload is not None
+            and set(indexers) <= set(payload.grid_dims)
+            and method is None
+            and tolerance is None
+            and copy
+            and fill_value is self._fill_value
+        ):
+            indexes = {
+                d: pd.Index(indexers.get(d, payload.indexes[d]), name=d)
+                for d in payload.grid_dims
+            }
+            return type(self)._from_payload(payload.reindexed(indexes), self._model)
+        return super().reindex(
+            indexers,
+            method=method,
+            tolerance=tolerance,
+            copy=copy,
+            fill_value=fill_value,
+        )
 
     def to_quadexpr(self) -> QuadraticExpression:
         """Convert LinearExpression to QuadraticExpression."""

--- a/linopy/expressions.py
+++ b/linopy/expressions.py
@@ -1966,6 +1966,13 @@ class BaseExpression(ABC):
         ``to_linexpr``), which still holds the absence labels.
         """
         value = _expr_unwrap(value)
+        payload = self._payload
+        if (
+            payload is not None
+            and isinstance(value, np.floating | np.integer | int | float)
+            and not isinstance(value, bool)
+        ):
+            return type(self)._from_payload(payload.filled(float(value)), self._model)
         if isinstance(value, DataArray | np.floating | np.integer | int | float):
             value = {"const": value}
         return self.__class__(self.data.fillna(value), self.model)
@@ -2524,6 +2531,22 @@ class LinearExpression(BaseExpression):
             copy=copy,
             fill_value=fill_value,
         )
+
+    def rename(
+        self,
+        name_dict: Mapping[Any, Any] | None = None,
+        **names: Any,
+    ) -> LinearExpression:
+        """
+        Rename dimensions as ``Dataset.rename``; a CSR-backed expression
+        stays sparse when only grid dims are relabelled.
+        """
+        name_dict = either_dict_or_kwargs(name_dict, names, "rename")
+        payload = self._payload
+        if payload is not None and set(name_dict) <= set(payload.grid_dims):
+            relabel = {str(k): str(v) for k, v in name_dict.items()}
+            return type(self)._from_payload(payload.renamed(relabel), self._model)
+        return super().rename(name_dict)
 
     def to_quadexpr(self) -> QuadraticExpression:
         """Convert LinearExpression to QuadraticExpression."""

--- a/linopy/sparse_expression.py
+++ b/linopy/sparse_expression.py
@@ -187,6 +187,20 @@ class CSRPayload:
             self, csr=scipy.sparse.csr_array(coo), const=const, indexes=indexes
         )
 
+    def filled(self, value: float) -> CSRPayload:
+        """Resolve absent cells (NaN const) to a constant; terms untouched."""
+        const = np.where(np.isnan(self.const), value, self.const)
+        return replace(self, const=const)
+
+    def renamed(self, names: dict[str, str]) -> CSRPayload:
+        """Relabel grid dims; the CSR row layout is unchanged."""
+        grid_dims = tuple(names.get(d, d) for d in self.grid_dims)
+        indexes = {
+            names.get(d, d): self.indexes[d].rename(names.get(d, d))
+            for d in self.grid_dims
+        }
+        return replace(self, grid_dims=grid_dims, indexes=indexes)
+
     def same_grid(self, other: CSRPayload) -> bool:
         return self.grid_dims == other.grid_dims and all(
             self.indexes[d].equals(other.indexes[d]) for d in self.grid_dims

--- a/linopy/sparse_expression.py
+++ b/linopy/sparse_expression.py
@@ -131,20 +131,15 @@ class CSRPayload:
         on the dense v1 merge path.
         """
         ds = expr.data
-        shape = tuple(len(indexes[d]) for d in grid_dims)
-        strides = [
-            int(np.prod(shape[i + 1 :], dtype=np.int64)) for i in range(len(shape))
-        ]
+        shape, strides = _grid_layout(grid_dims, indexes)
 
         transposed = [member_dim if d == scatter_dim else d for d in grid_dims]
-        axis_positions = [
-            codes * stride if d == scatter_dim else np.arange(n) * stride
-            for d, n, stride in zip(grid_dims, shape, strides)
-        ]
-        cell_rows = axis_positions[0]
-        for pos in axis_positions[1:]:
-            cell_rows = cell_rows[..., None] + pos
-        cell_rows = cell_rows.reshape(-1)
+        cell_rows = _flat_cells(
+            [
+                codes * stride if d == scatter_dim else np.arange(n) * stride
+                for d, n, stride in zip(grid_dims, shape, strides)
+            ]
+        )
 
         coeffs = ds.coeffs.transpose(*transposed, TERM_DIM).to_numpy().reshape(-1)
         vars_ = ds.vars.transpose(*transposed, TERM_DIM).to_numpy().reshape(-1)
@@ -167,6 +162,30 @@ class CSRPayload:
 
     def scaled(self, factor: float) -> CSRPayload:
         return replace(self, csr=self.csr * factor, const=self.const * factor)
+
+    def reindexed(self, indexes: dict[str, pd.Index]) -> CSRPayload:
+        """
+        Remap rows onto new per-dim indexes without the dense rectangle:
+        dropped labels vanish, new labels are absent cells (NaN const).
+        """
+        shape, strides = _grid_layout(self.grid_dims, indexes)
+        positions = [indexes[d].get_indexer(self.indexes[d]) for d in self.grid_dims]
+        valid = _flat_cells([pos == -1 for pos in positions]) == 0
+        row_map = _flat_cells([pos * s for pos, s in zip(positions, strides)])
+
+        coo = self.csr.tocoo()
+        keep = valid[coo.coords[0]]
+        rows = row_map[coo.coords[0][keep]]
+        cols = coo.coords[1][keep]
+        n_cells = int(np.prod(shape, dtype=np.int64))
+        coo = scipy.sparse.coo_array(
+            (coo.data[keep], (rows, cols)), shape=(n_cells, self.csr.shape[1])
+        )
+        const = np.full(n_cells, np.nan)
+        const[row_map[valid]] = self.const[valid]
+        return replace(
+            self, csr=scipy.sparse.csr_array(coo), const=const, indexes=indexes
+        )
 
     def same_grid(self, other: CSRPayload) -> bool:
         return self.grid_dims == other.grid_dims and all(
@@ -223,6 +242,23 @@ class CSRPayload:
             coords={d: self.indexes[d] for d in self.grid_dims},
         )
         return LinearExpression(absorb_absence(ds), self.model)
+
+
+def _grid_layout(
+    grid_dims: tuple[str, ...], indexes: dict[str, pd.Index]
+) -> tuple[tuple[int, ...], list[int]]:
+    """C-order shape and row strides of the grid."""
+    shape = tuple(len(indexes[d]) for d in grid_dims)
+    strides = [int(np.prod(shape[i + 1 :], dtype=np.int64)) for i in range(len(shape))]
+    return shape, strides
+
+
+def _flat_cells(axis_positions: list[np.ndarray]) -> np.ndarray:
+    """Outer sum of per-axis offsets, flattened in C order."""
+    cells = np.zeros((), dtype=np.int64)
+    for pos in axis_positions:
+        cells = cells[..., None] + pos
+    return cells.reshape(-1)
 
 
 def try_csr_merge(

--- a/test/test_sparse_groupby.py
+++ b/test/test_sparse_groupby.py
@@ -345,3 +345,36 @@ def test_reindex_merge_chain_peak_memory() -> None:
     finally:
         tracemalloc.stop()
     assert peak < dense_rectangle_bytes / 4
+
+
+@pytest.mark.parametrize("value", [0.0, 3.5])
+def test_fillna_stays_csr_and_matches_dense(value: float) -> None:
+    require_v1()
+    c = base_model()
+    wide = {"bus": [f"bus{i}" for i in range(7)]}
+    sparse = (c.eff * c.gen_p).groupby(c.gbus).sum(sparse=True).reindex(wide)
+    filled = sparse.fillna(value)
+    assert filled._payload is not None
+    dense = (c.eff * c.gen_p).groupby(c.gbus).sum(sparse=False).reindex(wide)
+    assert_linequal(filled, dense.fillna(value))
+
+
+def test_fillna_with_array_falls_back_to_dense() -> None:
+    require_v1()
+    c = base_model()
+    fill = xr.zeros_like(c.load)
+    sparse = (c.eff * c.gen_p).groupby(c.gbus).sum(sparse=True)
+    res = sparse.fillna(fill)
+    assert res._payload is None
+    dense = (c.eff * c.gen_p).groupby(c.gbus).sum(sparse=False)
+    assert_linequal(res, dense.fillna(fill))
+
+
+def test_rename_stays_csr_and_matches_dense() -> None:
+    require_v1()
+    c = base_model()
+    sparse = (c.eff * c.gen_p).groupby(c.gbus).sum(sparse=True).rename(bus="node")
+    assert sparse._payload is not None
+    dense = (c.eff * c.gen_p).groupby(c.gbus).sum(sparse=False).rename(bus="node")
+    assert sparse.coord_dims == ("node", "snapshot")
+    assert_linequal(sparse, dense)

--- a/test/test_sparse_groupby.py
+++ b/test/test_sparse_groupby.py
@@ -99,7 +99,7 @@ def reindexed_balance(c: Case, sparse: bool) -> LinearExpression:
     gen = (c.eff * c.gen_p).groupby(c.gbus).sum(sparse=sparse)
     flow = (1.0 * c.flow.loc[lines]).groupby(c.bus0.loc[lines]).sum(sparse=sparse)
     parts = [gen.reindex(bus=c.load.bus), flow.reindex(bus=c.load.bus)]
-    return linopy.merge(parts, join="outer")
+    return linopy.merge(parts, join="outer", cls=LinearExpression)
 
 
 def test_csr_requires_v1() -> None:

--- a/test/test_sparse_groupby.py
+++ b/test/test_sparse_groupby.py
@@ -6,6 +6,7 @@ materialization, and direct CSR realization under freeze. v1-only feature.
 from __future__ import annotations
 
 import re
+import tracemalloc
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -79,6 +80,26 @@ def canon(df: pl.DataFrame) -> pl.DataFrame:
         .agg(pl.col("coeffs").sum(), pl.col("sign").first(), pl.col("rhs").first())
         .sort(["labels", "vars"])
     )
+
+
+def assert_frozen_equal(con1: Constraint, con2: CSRConstraint) -> None:
+    d1, d2 = canon(con1.to_polars()), canon(con2.to_polars())
+    assert d1["labels"].equals(d2["labels"])
+    assert d1["vars"].equals(d2["vars"])
+    assert np.allclose(d1["coeffs"], d2["coeffs"])
+    assert (d1["sign"] == d2["sign"]).all()
+    assert np.allclose(d1["rhs"], d2["rhs"])
+    labels = con1.labels.values.ravel()
+    assert np.array_equal(np.sort(labels[labels != -1]), np.sort(con2.active_labels()))
+
+
+def reindexed_balance(c: Case, sparse: bool) -> LinearExpression:
+    """Generation on all buses plus flow on two lines, both reindexed onto the load grid."""
+    lines = ["line0", "line1"]
+    gen = (c.eff * c.gen_p).groupby(c.gbus).sum(sparse=sparse)
+    flow = (1.0 * c.flow.loc[lines]).groupby(c.bus0.loc[lines]).sum(sparse=sparse)
+    parts = [gen.reindex(bus=c.load.bus), flow.reindex(bus=c.load.bus)]
+    return linopy.merge(parts, join="outer")
 
 
 def test_csr_requires_v1() -> None:
@@ -176,15 +197,7 @@ def test_freeze_realizes_csr_without_dense_rectangle() -> None:
     )
 
     assert isinstance(con2, CSRConstraint)
-    d1, d2 = canon(con1.to_polars()), canon(con2.to_polars())
-    assert d1["labels"].equals(d2["labels"])
-    assert d1["vars"].equals(d2["vars"])
-    assert np.allclose(d1["coeffs"], d2["coeffs"])
-    assert (d1["sign"] == d2["sign"]).all()
-    assert np.allclose(d1["rhs"], d2["rhs"])
-    assert np.array_equal(
-        np.sort(con1.labels.values.ravel()), np.sort(con2.active_labels())
-    )
+    assert_frozen_equal(con1, con2)
 
 
 def test_freeze_false_falls_back_to_identical_dense_constraint() -> None:
@@ -275,3 +288,60 @@ def test_lp_files_identical(tmp_path: Path) -> None:
     c1.m.to_file(f1)
     c2.m.to_file(f2)
     assert canon_lp(f1.read_text()) == canon_lp(f2.read_text())
+
+
+@pytest.mark.parametrize(
+    "indexers",
+    [
+        {"bus": ["bus3", "bus0", "bus1", "bus2", "bus4"]},
+        {"bus": ["bus0", "bus1", "bus2", "bus3", "bus4", "bus9"]},
+        {"bus": ["bus3", "bus0"]},
+        {"bus": ["bus4", "bus0", "bus7"], "snapshot": [2, 0, 5]},
+    ],
+    ids=["reorder", "add", "drop", "multi_dim"],
+)
+def test_reindex_stays_csr_and_matches_dense(indexers: dict) -> None:
+    require_v1()
+    c = base_model()
+    sparse = (c.eff * c.gen_p).groupby(c.gbus).sum(sparse=True).reindex(indexers)
+    assert sparse._payload is not None
+    dense = (c.eff * c.gen_p).groupby(c.gbus).sum(sparse=False).reindex(indexers)
+    assert_linequal(sparse, dense)
+
+
+def test_reindex_falls_back_to_dense_for_unsupported_kwargs() -> None:
+    require_v1()
+    c = base_model()
+    sparse = (c.eff * c.gen_p).groupby(c.gbus).sum(sparse=True)
+    res = sparse.reindex(bus=["bus3", "bus0"], copy=False)
+    assert res._payload is None
+    dense = (c.eff * c.gen_p).groupby(c.gbus).sum(sparse=False)
+    assert_linequal(res, dense.reindex(bus=["bus3", "bus0"]))
+
+
+def test_reindex_merge_chain_freezes_csr() -> None:
+    require_v1()
+    c1, c2 = base_model(), base_model()
+    con1 = c1.m.add_constraints(reindexed_balance(c1, False) == c1.load, name="bal")
+    tot = reindexed_balance(c2, True)
+    assert tot._payload is not None
+    con2 = c2.m.add_constraints(tot == c2.load, name="bal", freeze=True)
+    assert isinstance(con2, CSRConstraint)
+    assert_frozen_equal(con1, con2)
+
+
+def test_reindex_merge_chain_peak_memory() -> None:
+    require_v1()
+    sizes = (200,) + (1,) * 299
+    n_snap = 50
+    dense_rectangle_bytes = len(sizes) * n_snap * max(sizes) * 16
+    c = base_model(gens_per_bus=sizes, n_snap=n_snap)
+    tracemalloc.start()
+    try:
+        c.m.add_constraints(
+            reindexed_balance(c, True) == c.load, name="bal", freeze=True
+        )
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+    assert peak < dense_rectangle_bytes / 4


### PR DESCRIPTION
Closes #932.

_Replace this line with your own intent in your own words (AGENTS.md rule 2)._

> [!NOTE]
> The following content was generated by AI (Claude Code).

## Changes proposed in this Pull Request

Implements the payload-preserving reindex primitive proposed in #932, the shared
unblock for keeping expressions sparse through a `groupby → reindex → merge`
chain.

- **`CSRPayload.reindexed(indexes)`** (`linopy/sparse_expression.py`) — remaps
  CSR rows onto new per-dim indexes without building the dense `_term`
  rectangle. Dropped labels vanish, new labels become absent cells (NaN const),
  existing cells keep their const. Grid stride/flatten logic is factored into
  `_grid_layout` / `_flat_cells`, shared with `_from_scatter` (no behavior
  change there).
- **`LinearExpression.reindex`** (`linopy/expressions.py`) — stays sparse when a
  payload is present and only labels change (plain label indexers on grid dims,
  default `fill_value`, `copy=True`, no `method`/`tolerance`); otherwise falls
  back to the dense path. `QuadraticExpression` is unchanged.
- **`materialize`** now runs the existing `absorb_absence` helper so
  reindex-created absent cells carry no terms. It is a no-op for the existing
  groupby output.

### Behavior note

Reindexing a partial sum onto a common grid creates absent cells, and
`merge(join="outer")` keeps them absent under v1 (`skipna=False`) on both the
dense and sparse paths — so the chain does **not** gap-fill with the zero
expression. Dense and sparse agree; filling gaps needs `fillna`/`ABSENT`
upstream. This is the follow-up tracked for the `fillna` payload branch.

### Verification

- `test/test_sparse_groupby.py`: parity (reorder/add/drop/multi-dim),
  dense fallback, the `groupby → reindex → merge → freeze` chain, and a
  `tracemalloc` peak guard (48 MB dense rectangle → measured 4 MB sparse peak,
  threshold 12 MB).
- Full sparse suite + `test_linear_expression.py` + `test_quadratic_expression.py`
  pass; `ruff` and `mypy` (on the two changed modules) clean.

## Checklist

- [x] AI-generated content is marked (see [`AGENTS.md`](../blob/master/AGENTS.md)).
- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [ ] I consent to the release of this PR's code under the MIT license.
