### PR TITLE
docs(scaling): note that scaling shifts solver tolerance meaning

### DIFF
--- a/examples/numerical-scaling.ipynb
+++ b/examples/numerical-scaling.ipynb
@@ -300,22 +300,7 @@
    "cell_type": "markdown",
    "id": "15",
    "metadata": {},
-   "source": [
-    "## Notes and caveats\n",
-    "\n",
-    "- **Scaling never changes the answer.** It is a pure change of units. Solutions,\n",
-    "  duals and the objective are always reported in your original units.\n",
-    "- **Discrete columns stay discrete.** For binary and integer variables the\n",
-    "  scaling factor is stored and round-tripped, but the solver column is left as an\n",
-    "  ordinary integer column — scaling a discrete variable would break integrality.\n",
-    "- **Choosing factors.** Aim to bring each variable's magnitude and each row's\n",
-    "  coefficients near 1. A good rule of thumb is to divide by the typical absolute\n",
-    "  value you expect. There is no single correct choice; different solvers and\n",
-    "  algorithms react differently (barrier methods care least; simplex and crossover\n",
-    "  benefit most).\n",
-    "- **This is manual scaling.** You provide the factors. An automatic strategy that\n",
-    "  picks them for you is a natural follow-up built on top of this mechanism."
-   ]
+   "source": "## Notes and caveats\n\n- **Scaling never changes the answer.** It is a pure change of units. Solutions,\n  duals and the objective are always reported in your original units.\n- **Scaling shifts what solver tolerances mean.** A solver applies its\n  feasibility and optimality tolerances to the numbers it sees — the scaled\n  problem — not to your original units. A fixed tolerance therefore maps to a\n  different absolute tolerance per row and column once you scale. That is usually\n  the point (it spreads the tolerances more evenly across the model), but it\n  means a scaled and an unscaled run agree only up to solver tolerance, not\n  bit-for-bit. Rescale if a solver reports numerical trouble, and re-check the\n  tolerances if you rely on tight ones.\n- **Discrete columns stay discrete.** For binary and integer variables the\n  scaling factor is stored and round-tripped, but the solver column is left as an\n  ordinary integer column — scaling a discrete variable would break integrality.\n- **Choosing factors.** Aim to bring each variable's magnitude and each row's\n  coefficients near 1. A good rule of thumb is to divide by the typical absolute\n  value you expect. There is no single correct choice; different solvers and\n  algorithms react differently (barrier methods care least; simplex and crossover\n  benefit most).\n- **This is manual scaling.** You provide the factors. An automatic strategy that\n  picks them for you is a natural follow-up built on top of this mechanism."
   }
  ],
  "metadata": {


### PR DESCRIPTION
The scaling feature is nice, but scaling changes the numbers the solver
actually works on. That also changes what the solver's tolerances mean, and I
think a short note of caution about this in the docs would help users avoid
surprises.

> [!NOTE]
> The following content was generated by AI.

## Changes proposed in this Pull Request

- Add a caveat to the **Notes and caveats** section of the numerical-scaling
  tutorial (`examples/numerical-scaling.ipynb`, rendered at
  `numerical-scaling.html`).
- The new bullet explains that a solver applies its feasibility and optimality
  tolerances to the scaled problem, not to the original units. So a fixed
  tolerance maps to different absolute tolerances per row and column once you
  scale, and a scaled run matches an unscaled run only up to solver tolerance,
  not bit-for-bit.
- It closes with two practical hints: rescale if a solver reports numerical
  trouble, and re-check the tolerances if you rely on tight ones.

Docs-only change. Built locally with the `docs` extra; the page renders and the
new bullet appears.

## Checklist

- [x] AI-generated content is marked (see [`AGENTS.md`](../blob/master/AGENTS.md)).
- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
